### PR TITLE
Reduce amount of trace logging

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -92,10 +92,13 @@ bool StreamElementsApiMessageHandler::OnProcessMessageReceived(
 			context->cefClientId = cefClientId;
 			context->source = source;
 			context->complete = [context]() {
-				blog(LOG_INFO,
-				     "obs-streamelements-core[%s]: API: completed call to '%s', callback id %d",
-				     context->target.c_str(), context->id.c_str(),
-				     context->cef_app_callback_id);
+				if (IsTraceLogLevel()) {
+					blog(LOG_INFO,
+					     "obs-streamelements-core[%s]: API: completed call to '%s', callback id %d",
+					     context->target.c_str(),
+					     context->id.c_str(),
+					     context->cef_app_callback_id);
+				}
 
 				if (context->cef_app_callback_id != -1) {
 					// Invoke result callback
@@ -130,23 +133,28 @@ bool StreamElementsApiMessageHandler::OnProcessMessageReceived(
 				CefRefPtr<CefValue> callArgsValue =
 					CefValue::Create();
 				callArgsValue->SetList(context->callArgs);
-				blog(LOG_INFO,
-				     "obs-streamelements-core[%s]: API: posting call to '%s', callback id %d, args: %s",
-				     context->target.c_str(), context->id.c_str(),
-				     context->cef_app_callback_id,
-				     CefWriteJSON(callArgsValue,
-						  JSON_WRITER_DEFAULT)
-					     .ToString()
-					     .c_str());
+				if (IsTraceLogLevel()) {
+					blog(LOG_INFO,
+					     "obs-streamelements-core[%s]: API: posting call to '%s', callback id %d, args: %s",
+					     context->target.c_str(),
+					     context->id.c_str(),
+					     context->cef_app_callback_id,
+					     CefWriteJSON(callArgsValue,
+							  JSON_WRITER_DEFAULT)
+						     .ToString()
+						     .c_str());
+				}
 			}
 
 			QtPostTask (
 				[context]() -> void {
-					blog(LOG_INFO,
-					     "obs-streamelements-core[%s]: API: performing call to '%s', callback id %d",
-					     context->target.c_str(),
-					     context->id.c_str(),
-					     context->cef_app_callback_id);
+					if (IsTraceLogLevel()) {
+						blog(LOG_INFO,
+						     "obs-streamelements-core[%s]: API: performing call to '%s', callback id %d",
+						     context->target.c_str(),
+						     context->id.c_str(),
+						     context->cef_app_callback_id);
+					}
 
 					context->self
 						->m_apiCallHandlers[context->id](
@@ -484,7 +492,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 						context->process();
 					},
 					context->cefClientId,
-					false /* enable_logging */);
+					IsTraceLogLevel() /* enable_logging */);
 			};
 
 			obs_frontend_defer_save_begin();
@@ -2190,9 +2198,11 @@ bool StreamElementsApiMessageHandler::InvokeHandler::InvokeApiCallAsync(
 	if (!m_apiCallHandlers.count(invoke))
 		return false;
 
-	blog(LOG_INFO,
-	     "obs-streamelements-core: StreamElementsApiMessageHandler::InvokeHandler::InvokeApiCallAsync: '%s', [%d]",
-	     invoke.c_str(), args->GetSize());
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO,
+		     "obs-streamelements-core: StreamElementsApiMessageHandler::InvokeHandler::InvokeApiCallAsync: '%s', [%d]",
+		     invoke.c_str(), args->GetSize());
+	}
 
 	incoming_call_handler_t handler = m_apiCallHandlers[invoke];
 

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -120,7 +120,7 @@ static void InitAppActiveTracker()
 	if (!g_AppActiveTrackerHook) {
 		blog(LOG_ERROR,
 		     "InitAppActiveTracker: SetWindowsHookExA call failed");
-	} else {
+	} else if (IsTraceLogLevel()) {
 		blog(LOG_INFO,
 		     "InitAppActiveTracker: SetWindowsHookExA succeeded");
 	}
@@ -139,8 +139,10 @@ static void ShutdownAppActiveTracker()
 	if (UnhookWindowsHookEx(g_AppActiveTrackerHook)) {
 		g_AppActiveTrackerHook = NULL;
 
-		blog(LOG_INFO,
-		     "ShutdownAppActiveTracker: UnhookWindowsHookEx succeeded");
+		if (IsTraceLogLevel()) {
+			blog(LOG_INFO,
+			     "ShutdownAppActiveTracker: UnhookWindowsHookEx succeeded");
+		}
 	} else {
 		blog(LOG_ERROR,
 		     "ShutdownAppActiveTracker: UnhookWindowsHookEx call failed");
@@ -481,8 +483,10 @@ void StreamElementsBrowserWidget::focusInEvent(QFocusEvent *event)
 {
 	QWidget::focusInEvent(event);
 
-	blog(LOG_INFO, "QWidget::focusInEvent: reason %d: %s", event->reason(),
-	     m_url.c_str());
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO, "QWidget::focusInEvent: reason %d: %s",
+		     event->reason(), m_url.c_str());
+	}
 
 	m_cefWidget->setFocus();
 }
@@ -491,7 +495,9 @@ void StreamElementsBrowserWidget::focusOutEvent(QFocusEvent *event)
 {
 	QWidget::focusOutEvent(event);
 
-	blog(LOG_INFO, "QWidget::focusOutEvent: %s", m_url.c_str());
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO, "QWidget::focusOutEvent: %s", m_url.c_str());
+	}
 
 	if (event->reason() != Qt::MenuBarFocusReason && event->reason() != Qt::PopupFocusReason) {
 		m_cefWidget->clearFocus();

--- a/streamelements/StreamElementsCrashHandler.cpp
+++ b/streamelements/StreamElementsCrashHandler.cpp
@@ -139,9 +139,11 @@ public:
 				std::string module =
 					modulesList->GetString(index).ToString();
 
-				blog(LOG_INFO,
-				     "StreamElementsCrashHandler: added module of interest: %s",
-				     module.c_str());
+				if (IsTraceLogLevel()) {
+					blog(LOG_INFO,
+					     "StreamElementsCrashHandler: added module of interest: %s",
+					     module.c_str());
+				}
 
 				modulesOfInterest.push_back(module);
 			}

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -97,7 +97,9 @@ void StreamElementsGlobalStateManager::ApplicationStateListener::
 
 static void SetMainWindowStyle()
 {
-	blog(LOG_INFO, "SetMainWindowStyle");
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO, "SetMainWindowStyle");
+	}
 
 	QMainWindow* main = (QMainWindow*)obs_frontend_get_main_window();
 
@@ -778,9 +780,11 @@ bool StreamElementsGlobalStateManager::DeserializeUserInterfaceState(
 		auto geometry = d->GetValue("geometry");
 
 		if (geometry.get() && geometry->GetType() == VTYPE_STRING) {
-			blog(LOG_INFO,
-			     "obs-streamelements-core: state: restoring geometry: %s",
-			     geometry->GetString().ToString().c_str());
+			if (IsTraceLogLevel()) {
+				blog(LOG_INFO,
+				     "obs-streamelements-core: state: restoring geometry: %s",
+				     geometry->GetString().ToString().c_str());
+			}
 
 			if (mainWindow()->restoreGeometry(
 				    QByteArray::fromStdString(base64_decode(
@@ -816,9 +820,13 @@ bool StreamElementsGlobalStateManager::DeserializeUserInterfaceState(
 
 		if (windowState.get() &&
 		    windowState->GetType() == VTYPE_STRING) {
-			blog(LOG_INFO,
-			     "obs-streamelements-core: state: restoring windowState: %s",
-			     windowState->GetString().ToString().c_str());
+			if (IsTraceLogLevel()) {
+				blog(LOG_INFO,
+				     "obs-streamelements-core: state: restoring windowState: %s",
+				     windowState->GetString()
+					     .ToString()
+					     .c_str());
+			}
 
 			if (mainWindow()->restoreState(QByteArray::fromStdString(
 				    base64_decode(windowState->GetString()
@@ -899,8 +907,11 @@ void StreamElementsGlobalStateManager::RestoreState()
 		return;
 	}
 
-	blog(LOG_INFO, "obs-streamelements-core: state: restoring state from base64: %s",
-	     base64EncodedJSON.c_str());
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO,
+		     "obs-streamelements-core: state: restoring state from base64: %s",
+		     base64EncodedJSON.c_str());
+	}
 
 	CefString json = base64_decode(base64EncodedJSON);
 
@@ -908,8 +919,11 @@ void StreamElementsGlobalStateManager::RestoreState()
 		return;
 	}
 
-	blog(LOG_INFO, "obs-streamelements-core: state: restoring state from json: %s",
-	     json.ToString().c_str());
+	if (IsTraceLogLevel()) {
+		blog(LOG_INFO,
+		     "obs-streamelements-core: state: restoring state from json: %s",
+		     json.ToString().c_str());
+	}
 
 	CefRefPtr<CefValue> root =
 		CefParseJSON(json, JSON_PARSER_ALLOW_TRAILING_COMMAS);
@@ -933,39 +947,54 @@ void StreamElementsGlobalStateManager::RestoreState()
 
 
 	if (workersState.get()) {
-		blog(LOG_INFO, "obs-streamelements-core: state: restoring workers: %s",
-		     CefWriteJSON(workersState, JSON_WRITER_DEFAULT)
-			     .ToString()
-			     .c_str());
+		if (IsTraceLogLevel()) {
+			blog(LOG_INFO,
+			     "obs-streamelements-core: state: restoring workers: %s",
+			     CefWriteJSON(workersState, JSON_WRITER_DEFAULT)
+				     .ToString()
+				     .c_str());
+		}
+
 		GetWorkerManager()->Deserialize(workersState);
 	}
 
 	if (dockingWidgetsState.get()) {
-		blog(LOG_INFO,
-		     "obs-streamelements-core: state: restoring docking widgets: %s",
-		     CefWriteJSON(dockingWidgetsState, JSON_WRITER_DEFAULT)
-			     .ToString()
-			     .c_str());
+		if (IsTraceLogLevel()) {
+			blog(LOG_INFO,
+			     "obs-streamelements-core: state: restoring docking widgets: %s",
+			     CefWriteJSON(dockingWidgetsState,
+					  JSON_WRITER_DEFAULT)
+				     .ToString()
+				     .c_str());
+		}
+
 		GetWidgetManager()->DeserializeDockingWidgets(
 			dockingWidgetsState);
 	}
 
 	if (notificationBarState.get()) {
-		blog(LOG_INFO,
-		     "obs-streamelements-core: state: restoring notification bar: %s",
-		     CefWriteJSON(notificationBarState, JSON_WRITER_DEFAULT)
-			     .ToString()
-			     .c_str());
+		if (IsTraceLogLevel()) {
+			blog(LOG_INFO,
+			     "obs-streamelements-core: state: restoring notification bar: %s",
+			     CefWriteJSON(notificationBarState,
+					  JSON_WRITER_DEFAULT)
+				     .ToString()
+				     .c_str());
+		}
+
 		GetWidgetManager()->DeserializeNotificationBar(
 			notificationBarState);
 	}
 
 	if (hotkeysState.get()) {
-		blog(LOG_INFO,
-		     "obs-streamelements-core: state: restoring hotkey bindings: %s",
-		     CefWriteJSON(hotkeysState, JSON_WRITER_DEFAULT)
-			     .ToString()
-			     .c_str());
+		if (IsTraceLogLevel()) {
+			blog(LOG_INFO,
+			     "obs-streamelements-core: state: restoring hotkey bindings: %s",
+			     CefWriteJSON(hotkeysState, JSON_WRITER_DEFAULT)
+				     .ToString()
+				     .c_str());
+		}
+
 		GetHotkeyManager()->DeserializeHotkeyBindings(hotkeysState);
 	}
 

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -1263,10 +1263,6 @@ static void remove_source_signals(obs_source_t *source, void *data)
 	signal_handler_disconnect(handler, "update_properties",
 				  handle_scene_item_source_update_props, data);
 
-	signal_handler_disconnect(handler, "streamelements_update_settings",
-				  handle_scene_item_source_update_settings,
-				  data);
-
 	signal_handler_disconnect(handler, "rename",
 				  handle_scene_item_source_rename, data);
 }
@@ -1277,9 +1273,6 @@ static void add_source_signals(obs_source_t *source, void *data)
 
 	signal_handler_connect(handler, "update_properties",
 			       handle_scene_item_source_update_props, data);
-
-	signal_handler_connect(handler, "streamelements_update_settings",
-			       handle_scene_item_source_update_settings, data);
 
 	signal_handler_connect(handler, "rename",
 			       handle_scene_item_source_rename, data);

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -68,6 +68,32 @@ static const char *ENV_PRODUCT_NAME = "OBS.Live";
 
 /* ========================================================= */
 
+bool IsTraceLogLevel() {
+	static bool has_result = false;
+	static bool result = false;
+
+	if (!has_result) {
+		std::string search = "--setrace";
+
+		QStringList args = QCoreApplication::instance()->arguments();
+
+		for (int i = 0; i < args.size() && !has_result; ++i) {
+			std::string arg = args.at(i).toStdString();
+
+			if (arg.substr(0, search.size()) == search) {
+				result = true;
+				break;
+			}
+		}
+	}
+
+	has_result = true;
+
+	return result;
+}
+
+/* ========================================================= */
+
 // convert wstring to UTF-8 string
 std::string wstring_to_utf8(const std::wstring wstr)
 {

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -38,6 +38,10 @@
 
 /* ========================================================= */
 
+bool IsTraceLogLevel();
+
+/* ========================================================= */
+
 std::string wstring_to_utf8(const std::wstring wstr);
 std::wstring utf8_to_wstring(const std::string str);
 


### PR DESCRIPTION
Trace logs now require `--setrace` command-line argument to be specified to be logged.