### PR TITLE
[LT-2081] Fix "report issue" dialog submit button

### DIFF
--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -133,11 +133,17 @@ StreamElementsReportIssueDialog::StreamElementsReportIssueDialog(QWidget *parent
 	    (windowFlags() | Qt::CustomizeWindowHint)
 	    & ~Qt::WindowContextHelpButtonHint
 	    ));
+
+    QObject::connect(ui->txtIssue, &QPlainTextEdit::textChanged, this,
+		     &StreamElementsReportIssueDialog::update);
 }
 
 StreamElementsReportIssueDialog::~StreamElementsReportIssueDialog()
 {
-    delete ui;
+	QObject::disconnect(ui->txtIssue, &QPlainTextEdit::textChanged, this,
+			 &StreamElementsReportIssueDialog::update);
+
+	delete ui;
 }
 
 void StreamElementsReportIssueDialog::update()


### PR DESCRIPTION
Since transition to Qt6, QDialog::update() stopped being called when child controls have updated their state. This impacts the submit button enabled state, since it is waiting for the textbox to have content to enable.

We now listen to the textbox textChanged() event instead.