### PR TITLE
Remove unused features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,18 +436,6 @@ if(ENABLE_ANGELSCRIPT)
 		deps/angelscript/add_on/scriptbuilder/scriptbuilder.cpp
 	)
 
-	if(MSVC AND CMAKE_CL_64)
-			enable_language(ASM_MASM)
-			if(CMAKE_ASM_MASM_COMPILER_WORKS)
-					set(obs-streamelements-core-streamelements-restore-script-host_SOURCES
-						${obs-streamelements-core-streamelements-restore-script-host_SOURCES}
-						deps/angelscript/source/as_callfunc_x64_msvc_asm.asm
-					)
-			else()
-					message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
-			endif()
-	endif()
-
 	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
 			enable_language(ASM)
 			if(CMAKE_ASM_COMPILER_WORKS)
@@ -475,10 +463,28 @@ if(ENABLE_ANGELSCRIPT)
 	#if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
 	#endif()
 
-	add_executable(obs-streamelements-core-streamelements-restore-script-host
-		${obs-streamelements-core-streamelements-restore-script-host_SOURCES}
-		${obs-streamelements-core-streamelements-restore-script-host_HEADERS}
+	if(MSVC AND CMAKE_CL_64)
+			enable_language(ASM_MASM)
+			if(CMAKE_ASM_MASM_COMPILER_WORKS)
+				ADD_CUSTOM_COMMAND(OUTPUT as_callfunc_x64_msvc_asm.obj
+					COMMAND "${CMAKE_ASM_MASM_COMPILER}" -c "${CMAKE_CURRENT_SOURCE_DIR}/deps/angelscript/source/as_callfunc_x64_msvc_asm.asm"
+					DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/deps/angelscript/source/as_callfunc_x64_msvc_asm.asm"
+					COMMENT "generate as_callfunc_x64_msvc_asm.obj")
+
+				add_executable(obs-streamelements-core-streamelements-restore-script-host
+					${obs-streamelements-core-streamelements-restore-script-host_SOURCES}
+					${obs-streamelements-core-streamelements-restore-script-host_HEADERS}
+					as_callfunc_x64_msvc_asm.obj
+				)
+			else()
+					message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
+			endif()
+	else()
+		add_executable(obs-streamelements-core-streamelements-restore-script-host
+			${obs-streamelements-core-streamelements-restore-script-host_SOURCES}
+			${obs-streamelements-core-streamelements-restore-script-host_HEADERS}
 		)
+	endif()
 
 	target_link_libraries(obs-streamelements-core-streamelements-restore-script-host
 		${obs-streamelements-core-streamelements-restore-script-host_LIBRARIES}

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2265,6 +2265,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	API_HANDLER_BEGIN("showOutputPreviewTitleBar");
 	{
 		if (args->GetSize()) {
@@ -2318,6 +2319,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		StreamElementsGlobalStateManager::GetInstance()->PersistState();
 	}
 	API_HANDLER_END();
+	#endif
 
 	API_HANDLER_BEGIN("getNativeStreamingServiceIntegrationStatus");
 	{

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -876,28 +876,37 @@ void StreamElementsGlobalStateManager::PersistState(bool sendEventToGuest)
 	CefRefPtr<CefValue> workersState = CefValue::Create();
 	CefRefPtr<CefValue> hotkeysState = CefValue::Create();
 	CefRefPtr<CefValue> userInterfaceState = CefValue::Create();
+
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	CefRefPtr<CefValue> outputPreviewTitleBarState = CefValue::Create();
 	CefRefPtr<CefValue> outputPreviewFrameState = CefValue::Create();
+	#endif
 
 	GetWidgetManager()->SerializeDockingWidgets(dockingWidgetsState);
 	GetWidgetManager()->SerializeNotificationBar(notificationBarState);
 	GetWorkerManager()->Serialize(workersState);
 	GetHotkeyManager()->SerializeHotkeyBindings(hotkeysState, true);
 	SerializeUserInterfaceState(userInterfaceState);
+
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	GetNativeOBSControlsManager()->SerializePreviewTitleBar(
 		outputPreviewTitleBarState);
 	GetNativeOBSControlsManager()->SerializePreviewFrame(
 		outputPreviewFrameState);
+	#endif
 
 	rootDictionary->SetValue("dockingBrowserWidgets", dockingWidgetsState);
 	rootDictionary->SetValue("notificationBar", notificationBarState);
 	rootDictionary->SetValue("workers", workersState);
 	rootDictionary->SetValue("hotkeyBindings", hotkeysState);
 	rootDictionary->SetValue("userInterfaceState", userInterfaceState);
+
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	rootDictionary->SetValue("outputPreviewTitleBarState",
 				 outputPreviewTitleBarState);
 	rootDictionary->SetValue("outputPreviewFrameState",
 				 outputPreviewFrameState);
+	#endif
 
 	root->SetDictionary(rootDictionary);
 
@@ -954,10 +963,13 @@ void StreamElementsGlobalStateManager::RestoreState()
 	auto hotkeysState = rootDictionary->GetValue("hotkeyBindings");
 	auto userInterfaceState =
 		rootDictionary->GetValue("userInterfaceState");
+
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	auto outputPreviewTitleBarState =
 		rootDictionary->GetValue("outputPreviewTitleBarState");
 	auto outputPreviewFrameState =
 		rootDictionary->GetValue("outputPreviewFrameState");
+	#endif
 
 
 	if (workersState.get()) {
@@ -1016,6 +1028,7 @@ void StreamElementsGlobalStateManager::RestoreState()
 		DeserializeUserInterfaceState(userInterfaceState);
 	}
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	if (outputPreviewTitleBarState.get()) {
 		GetNativeOBSControlsManager()->DeserializePreviewTitleBar(
 			outputPreviewTitleBarState);
@@ -1025,6 +1038,7 @@ void StreamElementsGlobalStateManager::RestoreState()
 		GetNativeOBSControlsManager()->DeserializePreviewFrame(
 			outputPreviewFrameState);
 	}
+	#endif
 }
 
 void StreamElementsGlobalStateManager::OnObsExit()

--- a/streamelements/StreamElementsNativeOBSControlsManager.cpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.cpp
@@ -78,6 +78,7 @@ StreamElementsNativeOBSControlsManager::StreamElementsNativeOBSControlsManager(Q
 
 	m_nativeCentralWidget = mainWindow->centralWidget();
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	m_nativePreviewLayout =
 		m_nativeCentralWidget->findChild<QLayout *>("previewLayout");
 
@@ -124,6 +125,7 @@ StreamElementsNativeOBSControlsManager::StreamElementsNativeOBSControlsManager(Q
 		HidePreviewTitleBar();
 		HidePreviewFrame();
 	}
+	#endif
 }
 
 StreamElementsNativeOBSControlsManager::~StreamElementsNativeOBSControlsManager()
@@ -153,6 +155,7 @@ StreamElementsNativeOBSControlsManager::~StreamElementsNativeOBSControlsManager(
 		m_nativeManageBroadcastButton = nullptr;
 	}
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	HidePreviewTitleBar();
 	HidePreviewFrame();
 
@@ -173,10 +176,12 @@ StreamElementsNativeOBSControlsManager::~StreamElementsNativeOBSControlsManager(
 		m_previewTitleLayout = nullptr;
 		m_previewTitleContainer = nullptr;
 	}
+	#endif
 
 	m_nativeCentralWidget = nullptr;
 }
 
+#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 bool StreamElementsNativeOBSControlsManager::DeserializePreviewFrame(
 	CefRefPtr<CefValue> input)
 {
@@ -316,13 +321,16 @@ void StreamElementsNativeOBSControlsManager::HidePreviewTitleBar()
 
 	m_previewTitleSettings = CefDictionaryValue::Create();
 }
+#endif
 
 void StreamElementsNativeOBSControlsManager::Reset()
 {
 	SetStartStreamingMode(StreamElementsNativeOBSControlsManager::start);
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	HidePreviewTitleBar();
 	HidePreviewFrame();
+	#endif
 }
 
 void StreamElementsNativeOBSControlsManager::SetStreamingInitialState()

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -20,6 +20,8 @@
 
 #include "StreamElementsBrowserWidget.hpp"
 
+#define SE_ENABLE_CENTRAL_WIDGET_DECORATIONS 0
+
 class StreamElementsNativeOBSControlsManager : public QObject
 {
 	Q_OBJECT
@@ -106,12 +108,14 @@ public:
 	void AdviseRequestStartStreamingAccepted();
 	void AdviseRequestStartStreamingRejected();
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	bool DeserializePreviewFrame(CefRefPtr<CefValue> input);
 	void SerializePreviewFrame(CefRefPtr<CefValue>& output);
 	void HidePreviewFrame();
 	bool DeserializePreviewTitleBar(CefRefPtr<CefValue> input);
 	void SerializePreviewTitleBar(CefRefPtr<CefValue>& output);
 	void HidePreviewTitleBar();
+	#endif
 
 	void Reset();
 
@@ -160,6 +164,7 @@ private:
 	QTimer* m_timeoutTimer = nullptr;
 	std::recursive_mutex m_timeoutTimerMutex;
 
+	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	QFrame *m_previewFrame = nullptr;
 	QVBoxLayout *m_previewFrameLayout = nullptr;
 	QLayout *m_nativePreviewLayout = nullptr;
@@ -174,4 +179,5 @@ private:
 	StreamElementsBrowserWidget *m_previewTitleBrowser = nullptr;
 	CefRefPtr<CefDictionaryValue> m_previewTitleSettings =
 		CefDictionaryValue::Create();
+	#endif
 };

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -852,39 +852,49 @@ static void SerializeSourceAndSceneItem(CefRefPtr<CefValue> &result,
 			/* Not a group and not a scene, handled above */
 		}
 
+		#if SE_ENABLE_SCENEITEM_ACTIONS
 		root->SetList(
 			"actions",
 			StreamElementsSceneItemsMonitor::GetSceneItemActions(
 				sceneitem)
 				->Copy());
+		#endif
 
+		#if SE_ENABLE_SCENEITEM_ICONS
 		root->SetValue(
 			"icon",
 			StreamElementsSceneItemsMonitor::GetSceneItemIcon(
 				sceneitem)
 				->Copy());
+		#endif
 
+		#if SE_ENABLE_SCENEITEM_DEFAULT_ACTION 
 		root->SetValue("defaultAction",
 			       StreamElementsSceneItemsMonitor::
 				       GetSceneItemDefaultAction(sceneitem)
 					       ->Copy());
+		#endif
 
 		root->SetValue("auxiliaryData",
 			       StreamElementsSceneItemsMonitor::
 				       GetSceneItemAuxiliaryData(sceneitem)
 					       ->Copy());
 
+		#if SE_ENABLE_SCENEITEM_CONTEXT_MENU
 		root->SetValue(
 			"contextMenu",
 			StreamElementsSceneItemsMonitor::GetSceneItemContextMenu(
 				sceneitem)
 				->Copy());
+		#endif
 
+		#if SE_ENABLE_SCENEITEM_RENDERING_SETTINGS
 		root->SetValue(
 			"uiSettings",
 			StreamElementsSceneItemsMonitor::GetSceneItemUISettings(
 				sceneitem)
 				->Copy());
+		#endif
 	}
 
 	result->SetDictionary(root);
@@ -2598,6 +2608,7 @@ void StreamElementsObsSceneManager::RemoveObsSceneItemsByIds(
 void StreamElementsObsSceneManager::DeserializeAuxiliaryObsSceneItemProperties(
 	obs_sceneitem_t *sceneitem, CefRefPtr<CefDictionaryValue> d)
 {
+	#if SE_ENABLE_SCENEITEM_ACTIONS
 	if (d->HasKey("actions")) {
 		if (d->GetType("actions") == VTYPE_LIST) {
 			CefRefPtr<CefListValue> actionsList =
@@ -2613,17 +2624,22 @@ void StreamElementsObsSceneManager::DeserializeAuxiliaryObsSceneItemProperties(
 				sceneitem, emptyList);
 		}
 	}
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_ICONS
 	if (d->HasKey("icon")) {
 		m_sceneItemsMonitor->SetSceneItemIcon(
 			sceneitem, d->GetValue("icon")->Copy());
 	}
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_DEFAULT_ACTION
 	if (d->HasKey("defaultAction")) {
 		m_sceneItemsMonitor->SetSceneItemDefaultAction(
 			sceneitem,
 			d->GetValue("defaultAction")->Copy());
 	}
+	#endif
 
 	if (d->HasKey("auxiliaryData")) {
 		m_sceneItemsMonitor->SetSceneItemAuxiliaryData(
@@ -2631,15 +2647,19 @@ void StreamElementsObsSceneManager::DeserializeAuxiliaryObsSceneItemProperties(
 			d->GetValue("auxiliaryData")->Copy());
 	}
 
+	#if SE_ENABLE_SCENEITEM_CONTEXT_MENU
 	if (d->HasKey("contextMenu")) {
 		m_sceneItemsMonitor->SetSceneItemContextMenu(
 			sceneitem, d->GetValue("contextMenu")->Copy());
 	}
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_RENDERING_SETTINGS
 	if (d->HasKey("uiSettings")) {
 		m_sceneItemsMonitor->SetSceneItemUISettings(
 			sceneitem, d->GetValue("uiSettings")->Copy());
 	}
+	#endif
 
 #if ENABLE_OBS_GROUP_ADD_REMOVE_ITEM
 	std::string groupId = d->HasKey("parentId") && d->GetType("parentId") ==

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -899,9 +899,11 @@ static void SerializeObsScene(obs_source_t *scene, CefRefPtr<CefValue> &result)
 
 	d->SetBool("active", is_active_scene(obs_scene_from_source(scene)));
 
+	#if SE_ENABLE_SCENE_ICONS
 	d->SetValue("icon",
 		    StreamElementsScenesListWidgetManager::GetSceneIcon(scene)
 			    ->Copy());
+	#endif
 
 	d->SetValue(
 		"auxiliaryData",
@@ -909,16 +911,20 @@ static void SerializeObsScene(obs_source_t *scene, CefRefPtr<CefValue> &result)
 			scene)
 			->Copy());
 
+	#if SE_ENABLE_SCENE_DEFAULT_ACTION
 	d->SetValue(
 		"defaultAction",
 		StreamElementsScenesListWidgetManager::GetSceneDefaultAction(
 			scene)
 			->Copy());
+	#endif
 
+	#if SE_ENABLE_SCENE_CONTEXT_MENU
 	d->SetValue("contextMenu",
 		    StreamElementsScenesListWidgetManager::GetSceneContextMenu(
 			    scene)
 			    ->Copy());
+	#endif
 
 	result->SetDictionary(d);
 }
@@ -2509,22 +2515,28 @@ void StreamElementsObsSceneManager::SetObsScenePropertiesById(
 				result = true;
 			}
 
+			#if SE_ENABLE_SCENE_ICONS
 			if (d->HasKey("icon")) {
 				m_scenesWidgetManager->SetSceneIcon(
 					scene, d->GetValue("icon")->Copy());
 			}
+			#endif
 
+			#if SE_ENABLE_SCENE_DEFAULT_ACTION
 			if (d->HasKey("defaultAction")) {
 				m_scenesWidgetManager->SetSceneDefaultAction(
 					scene,
 					d->GetValue("defaultAction")->Copy());
 			}
+			#endif
 
+			#if SE_ENABLE_SCENE_CONTEXT_MENU
 			if (d->HasKey("contextMenu")) {
 				m_scenesWidgetManager->SetSceneContextMenu(
 					scene,
 					d->GetValue("contextMenu")->Copy());
 			}
+			#endif
 
 			if (d->HasKey("auxiliaryData")) {
 				m_scenesWidgetManager->SetSceneAuxiliaryData(

--- a/streamelements/StreamElementsSceneItemsMonitor.hpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.hpp
@@ -16,6 +16,17 @@
 
 #include "cef-headers.hpp"
 
+#define SE_ENABLE_SCENEITEM_ACTIONS 0
+#define SE_ENABLE_SCENEITEM_ICONS 0
+#define SE_ENABLE_SCENEITEM_DEFAULT_ACTION 0
+#define SE_ENABLE_SCENEITEM_CONTEXT_MENU 0
+#define SE_ENABLE_SCENEITEM_RENDERING_SETTINGS 0
+#define SE_ENABLE_SCENEITEM_UI_EXTENSIONS                            \
+	(SE_ENABLE_SCENEITEM_ACTIONS || SE_ENABLE_SCENEITEM_ICONS || \
+	 SE_ENABLE_SCENEITEM_DEFAULT_ACTION ||                       \
+	 SE_ENABLE_SCENEITEM_CONTEXT_MENU ||                         \
+	 SE_ENABLE_SCENEITEM_RENDERING_SETTINGS)
+
 class StreamElementsSceneItemsMonitor : public QObject,
 					public StreamElementsObsAppMonitor {
 public:
@@ -32,29 +43,37 @@ public:
 				       CefRefPtr<CefValue> value,
 				       bool triggerUpdate = true);
 
+	#if SE_ENABLE_SCENEITEM_ACTIONS
 	static CefRefPtr<CefListValue>
 	GetSceneItemActions(obs_sceneitem_t *scene_item);
 
 	void SetSceneItemActions(obs_sceneitem_t *scene_item,
 				 CefRefPtr<CefListValue> m_actions);
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_ICONS
 	static CefRefPtr<CefValue>
 	GetSceneItemIcon(obs_sceneitem_t *scene_item);
 
 	void SetSceneItemIcon(obs_sceneitem_t *scene_item,
 			      CefRefPtr<CefValue> m_icon);
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_DEFAULT_ACTION
 	static CefRefPtr<CefValue>
 	GetSceneItemDefaultAction(obs_sceneitem_t *scene_item);
 
 	void SetSceneItemDefaultAction(obs_sceneitem_t *scene_item,
 				       CefRefPtr<CefValue> action);
+	#endif
 
+	#if SE_ENABLE_SCENEITEM_CONTEXT_MENU
 	static CefRefPtr<CefValue>
 	GetSceneItemContextMenu(obs_sceneitem_t *scene_item);
 
 	void SetSceneItemContextMenu(obs_sceneitem_t *scene_item,
 				     CefRefPtr<CefValue> menu);
+	#endif
 
 	CefRefPtr<CefValue> static GetSceneItemAuxiliaryData(
 		obs_sceneitem_t *scene_item);
@@ -62,17 +81,18 @@ public:
 	void SetSceneItemAuxiliaryData(obs_sceneitem_t *scene_item,
 				       CefRefPtr<CefValue> data);
 
+	#if SE_ENABLE_SCENEITEM_RENDERING_SETTINGS
 	CefRefPtr<CefValue> static GetSceneItemUISettings(
 		obs_sceneitem_t *scene_item);
+	void SetSceneItemUISettings(obs_sceneitem_t *scene_item,
+				    CefRefPtr<CefValue> data);
+	#endif
 
 	bool static GetSceneItemUISettingsEnabled(
 		obs_sceneitem_t *scene_item);
 
 	bool static GetSceneItemUISettingsMultiselectContextMenuEnabled(
 		obs_sceneitem_t *scene_item);
-
-	void SetSceneItemUISettings(obs_sceneitem_t *scene_item,
-				       CefRefPtr<CefValue> data);
 
 	bool InvokeCurrentSceneItemDefaultAction(obs_sceneitem_t *scene_item);
 
@@ -94,7 +114,11 @@ public:
 		output = m_sceneItemsToolBarActions->Copy();
 	}
 
-	void Update() { ScheduleUpdateSceneItemsWidgets(); }
+	void Update() {
+		#if SE_ENABLE_SCENEITEM_UI_EXTENSIONS
+		ScheduleUpdateSceneItemsWidgets();
+		#endif
+	}
 
 	QWidget* GetWidgetAtLocalPosition(const QPointF &p) {
 		QModelIndex index = m_sceneItemsListView->indexAt(QPoint(p.x(), p.y()));
@@ -110,9 +134,11 @@ public:
 private:
 	void DisconnectSignalHandlers();
 
+	#if SE_ENABLE_SCENEITEM_UI_EXTENSIONS
 	void ScheduleUpdateSceneItemsWidgets();
 
 	void UpdateSceneItemsWidgets();
+	#endif
 
 	void UpdateSceneItemsToolbar();
 

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -272,6 +272,7 @@ protected:
 
 			bool handled = false;
 
+			#if SE_ENABLE_SCENE_DEFAULT_ACTION
 			CefRefPtr<CefValue> value =
 				m_manager->GetSceneDefaultAction(scene);
 
@@ -294,6 +295,7 @@ protected:
 					value, defaultAction,
 					defaultContextMenu);
 			}
+			#endif
 
 			obs_source_release(scene);
 
@@ -306,10 +308,11 @@ protected:
 			if (!scene)
 				return false;
 
+			bool handled = false;
+
+			#if SE_ENABLE_SCENE_CONTEXT_MENU
 			CefRefPtr<CefValue> value =
 				m_manager->GetSceneContextMenu(scene);
-
-			bool handled = false;
 
 			if (value->GetType() == VTYPE_LIST &&
 			    value->GetList()->GetSize()) {
@@ -345,6 +348,7 @@ protected:
 						handled = false;
 				}
 			}
+			#endif
 
 			obs_source_release(scene);
 
@@ -421,7 +425,10 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 				 &StreamElementsScenesListWidgetManager::
 					 HandleScenesItemDoubleClicked);
 
+		#if SE_ENABLE_SCENES_UI_EXTENSIONS
 		ScheduleUpdateWidgets();
+		#endif
+
 		UpdateScenesToolbar();
 
 		m_enableSignals = true;
@@ -435,7 +442,9 @@ void StreamElementsScenesListWidgetManager::CheckViewMode()
 	if (mode != m_prevViewMode) {
 		m_prevViewMode = mode;
 
+		#if SE_ENABLE_SCENES_UI_EXTENSIONS
 		ScheduleUpdateWidgets();
+		#endif
 	}
 }
 
@@ -493,7 +502,9 @@ void StreamElementsScenesListWidgetManager::HandleSceneRename(
 	StreamElementsScenesListWidgetManager *self =
 		(StreamElementsScenesListWidgetManager *)data;
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	self->ScheduleUpdateWidgets();
+	#endif
 }
 
 void StreamElementsScenesListWidgetManager::HandleScenesModelReset()
@@ -501,7 +512,9 @@ void StreamElementsScenesListWidgetManager::HandleScenesModelReset()
 	if (!m_enableSignals)
 		return;
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	ScheduleUpdateWidgets();
+	#endif
 }
 
 void StreamElementsScenesListWidgetManager::HandleScenesModelItemInsertedRemoved(
@@ -510,7 +523,9 @@ void StreamElementsScenesListWidgetManager::HandleScenesModelItemInsertedRemoved
 	if (!m_enableSignals)
 		return;
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	ScheduleUpdateWidgets();
+	#endif
 }
 
 void StreamElementsScenesListWidgetManager::HandleScenesModelItemMoved(
@@ -519,7 +534,9 @@ void StreamElementsScenesListWidgetManager::HandleScenesModelItemMoved(
 	if (!m_enableSignals)
 		return;
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	ScheduleUpdateWidgets();
+	#endif
 }
 
 CefRefPtr<CefValue>
@@ -560,9 +577,11 @@ void StreamElementsScenesListWidgetManager::SetScenePropertyValue(
 
 	obs_data_release(private_data);
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	if (triggerUpdate) {
 		ScheduleUpdateWidgets();
 	}
+	#endif
 }
 
 CefRefPtr<CefValue>
@@ -578,6 +597,7 @@ void StreamElementsScenesListWidgetManager::SetSceneAuxiliaryData(
 			      false);
 }
 
+#if SE_ENABLE_SCENE_ICONS
 CefRefPtr<CefValue>
 StreamElementsScenesListWidgetManager::GetSceneIcon(obs_source_t *scene)
 {
@@ -601,7 +621,9 @@ void StreamElementsScenesListWidgetManager::SetSceneIcon(
 
 	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_ICON, icon);
 }
+#endif
 
+#if SE_ENABLE_SCENE_DEFAULT_ACTION
 CefRefPtr<CefValue>
 StreamElementsScenesListWidgetManager::GetSceneDefaultAction(obs_source_t *scene)
 {
@@ -626,7 +648,9 @@ void StreamElementsScenesListWidgetManager::SetSceneDefaultAction(
 	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_DEFAULT_ACTION,
 			      defaultAction);
 }
+#endif
 
+#if SE_ENABLE_SCENE_CONTEXT_MENU
 CefRefPtr<CefValue>
 StreamElementsScenesListWidgetManager::GetSceneContextMenu(obs_source_t *scene)
 {
@@ -651,7 +675,9 @@ void StreamElementsScenesListWidgetManager::SetSceneContextMenu(
 	SetScenePropertyValue(scene, ITEM_PRIVATE_DATA_KEY_UI_CONTEXT_MENU,
 			      contextMenu);
 }
+#endif
 
+#if SE_ENABLE_SCENES_UI_EXTENSIONS
 void StreamElementsScenesListWidgetManager::ScheduleUpdateWidgets()
 {
 	if (!m_enableSignals)
@@ -660,6 +686,7 @@ void StreamElementsScenesListWidgetManager::ScheduleUpdateWidgets()
 	m_updateWidgetsDeferredExecutive.Signal([this]() { UpdateWidgets(); },
 						250);
 }
+#endif
 
 void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
 {
@@ -730,6 +757,7 @@ void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
 	}
 }
 
+#if SE_ENABLE_SCENES_UI_EXTENSIONS
 void StreamElementsScenesListWidgetManager::UpdateWidgets()
 {
 	struct obs_frontend_source_list sources = {};
@@ -750,8 +778,10 @@ void StreamElementsScenesListWidgetManager::UpdateWidgets()
 				rowIndex < sources.sources.num;
 		++rowIndex) {
 		if (!isSignedIn) {
+			#if SE_ENABLE_SCENE_ICONS
 			m_nativeWidget->item(rowIndex)->setIcon(
 				QIcon());
+			#endif
 
 			continue;
 		}
@@ -768,21 +798,29 @@ void StreamElementsScenesListWidgetManager::UpdateWidgets()
 			SourceDataManager::instance()->setData(scene,
 								data);
 
+			#if SE_ENABLE_SCENE_ICONS
 			data->DeserializeIcon(GetSceneIcon(scene));
+			#endif
 
+			#if SE_ENABLE_SCENE_DEFAULT_ACTION
 			data->DeserializeDefaultAction(
 				GetSceneDefaultAction(scene));
+			#endif
 
+			#if SE_ENABLE_SCENE_CONTEXT_MENU
 			data->DeserializeContextMenu(
 				GetSceneContextMenu(scene));
+			#endif
 		}
 
+		#if SE_ENABLE_SCENE_ICONS
 		if (m_nativeWidget->viewMode() == QListView::IconMode) {
 			/* Grid Mode: icons are not supported */
 			m_nativeWidget->item(rowIndex)->setIcon(QIcon());
 		} else {
 			m_nativeWidget->item(rowIndex)->setIcon(data->icon());
 		}
+		#endif
 	}
 
 	obs_source_release(current_scene);
@@ -790,6 +828,7 @@ void StreamElementsScenesListWidgetManager::UpdateWidgets()
 	obs_frontend_source_list_free(
 		(obs_frontend_source_list *)&sources);
 }
+#endif
 
 void StreamElementsScenesListWidgetManager::HandleScenesItemDoubleClicked(
 	QListWidgetItem *item)

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -399,6 +399,7 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 
 		/* Subscribe to signals */
 
+		#if SE_ENABLE_SCENES_UI_EXTENSIONS
 		QObject::connect(model, &QAbstractItemModel::modelReset, this,
 				 &StreamElementsScenesListWidgetManager::
 					 HandleScenesModelReset);
@@ -424,6 +425,7 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 				 &QListWidget::itemDoubleClicked, this,
 				 &StreamElementsScenesListWidgetManager::
 					 HandleScenesItemDoubleClicked);
+		#endif
 
 		#if SE_ENABLE_SCENES_UI_EXTENSIONS
 		ScheduleUpdateWidgets();
@@ -467,6 +469,7 @@ StreamElementsScenesListWidgetManager::
 
 	auto model = m_nativeWidget->model();
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	QObject::disconnect(m_nativeWidget, &QListWidget::itemDoubleClicked,
 			    this,
 			    &StreamElementsScenesListWidgetManager::
@@ -491,6 +494,7 @@ StreamElementsScenesListWidgetManager::
 	QObject::disconnect(model, &QAbstractItemModel::rowsMoved, this,
 			    &StreamElementsScenesListWidgetManager::
 				    HandleScenesModelItemMoved);
+	#endif
 
 	//m_nativeWidget->setItemDelegate(m_prevEditDelegate);
 	//m_editDelegate->deleteLater();

--- a/streamelements/StreamElementsScenesListWidgetManager.hpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.hpp
@@ -12,6 +12,13 @@
 #include <QListView>
 #include <QToolBar>
 
+#define SE_ENABLE_SCENE_ICONS 0
+#define SE_ENABLE_SCENE_DEFAULT_ACTION 0
+#define SE_ENABLE_SCENE_CONTEXT_MENU 0
+#define SE_ENABLE_SCENES_UI_EXTENSIONS \
+	(SE_ENABLE_SCENE_ICONS || SE_ENABLE_SCENE_DEFAULT_ACTION || \
+	 SE_ENABLE_SCENE_CONTEXT_MENU)
+
 class StreamElementsScenesListWidgetManager : public QObject {
 public:
 	StreamElementsScenesListWidgetManager(QMainWindow *mainWindow);
@@ -30,18 +37,24 @@ public:
 	void SetSceneAuxiliaryData(obs_source_t *scene,
 				   CefRefPtr<CefValue> data);
 
+	#if SE_ENABLE_SCENE_ICONS
 	static CefRefPtr<CefValue> GetSceneIcon(obs_source_t *scene);
 
 	void SetSceneIcon(obs_source_t *scene, CefRefPtr<CefValue> icon);
+	#endif
 
+	#if SE_ENABLE_SCENE_DEFAULT_ACTION
 	static CefRefPtr<CefValue> GetSceneDefaultAction(obs_source_t *scene);
 
 	void SetSceneDefaultAction(obs_source_t *scene,
 				   CefRefPtr<CefValue> icon);
+	#endif
 
+	#if SE_ENABLE_SCENE_CONTEXT_MENU
 	static CefRefPtr<CefValue> GetSceneContextMenu(obs_source_t *scene);
 
 	void SetSceneContextMenu(obs_source_t *scene, CefRefPtr<CefValue> icon);
+	#endif
 
 	bool InvokeCurrentSceneDefaultAction();
 	bool InvokeCurrentSceneDefaultContextMenu();
@@ -60,7 +73,11 @@ public:
 		output = m_scenesToolBarActions->Copy();
 	}
 
-	void Update() { ScheduleUpdateWidgets(); }
+	void Update() {
+		#if SE_ENABLE_SCENES_UI_EXTENSIONS
+		ScheduleUpdateWidgets();
+		#endif
+	}
 
 	QListWidget *GetScenesListWidget() { return m_nativeWidget; }
 
@@ -77,8 +94,10 @@ private:
 
 	void HandleScenesItemDoubleClicked(QListWidgetItem *item);
 
+	#if SE_ENABLE_SCENES_UI_EXTENSIONS
 	void ScheduleUpdateWidgets();
 	void UpdateWidgets();
+	#endif
 
 	void UpdateScenesToolbar();
 

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -6,7 +6,7 @@
  * signatures).
  */
 #ifndef HOST_API_VERSION_MAJOR
-#define HOST_API_VERSION_MAJOR 3
+#define HOST_API_VERSION_MAJOR 4
 #endif
 
 /* Numeric value indicating the current minor version of the API.
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 3
+#define HOST_API_VERSION_MINOR 0
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
This is a stability update. It removes MVP features which have never been put to production use:
- Custom behavior and rendering of Scenes UI
- Custom behavior and rendering of Sources UI

It does so by disabling code which would replace items in both docks on update, and code which would intercept mouse events to replace default behaviors (context menus, default actions, etc.)

The update increases SE.Live API version to 4.0 and removes the following data structure members:

* SceneInfo

	Remove SceneInfo.icon
	Remove SceneInfo.defaultAction
	Remove SceneInfo.contextMenu

* SceneItemInfo

	Remove SceneItemInfo.icon
	Remove SceneItemInfo.defaultAction
	Remove SceneItemInfo.contextMenu
	Remove SceneItemInfo.actions
	Remove SceneItemInfo.uiSettings

The changes should be semi- backwards compatible: i.e. code which updates those data fields should still work, while code which relies on existence of those data fields should continue working if it checks for their existence first.

This update also removes the following API calls:

	showOutputPreviewTitleBar
	hideOutputPreviewTitleBar
	showOutputPreviewFrame
	hideOutputPreviewFrame

Those API calls are not used in any production code.

Since those features have been used ~2-3 years ago for constructing a proof-of-concept for breaking overlays apart into widgets to be repositioned in OBS canvas to be reconstructed later into the same overlay, and haven't been ever put to actual production use, it should be safe to remove them while at the same time removing a moderate-risk area of integration which relies on Qt components structure being constructed by core OBS in a certain way.