### PR TITLE
Add support for Audio compositions and track selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,8 @@ set(obs-streamelements-core_SOURCES
 	streamelements/StreamElementsVideoComposition.cpp
 	streamelements/StreamElementsVideoCompositionManager.cpp
 	streamelements/StreamElementsVideoCompositionViewWidget.cpp
+	streamelements/StreamElementsAudioComposition.cpp
+	streamelements/StreamElementsAudioCompositionManager.cpp
 	streamelements/StreamElementsOutput.cpp
 	streamelements/StreamElementsOutputManager.cpp
 	streamelements/deps/StackWalker/StackWalker.cpp
@@ -317,6 +319,8 @@ set(obs-streamelements-core_HEADERS
 	streamelements/StreamElementsVideoComposition.hpp
 	streamelements/StreamElementsVideoCompositionManager.hpp
 	streamelements/StreamElementsVideoCompositionViewWidget.hpp
+	streamelements/StreamElementsAudioComposition.hpp
+	streamelements/StreamElementsAudioCompositionManager.hpp
 	streamelements/StreamElementsOutput.hpp
 	streamelements/StreamElementsOutputManager.hpp
 	streamelements/canvas-config.hpp

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2590,12 +2590,31 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("getAllAudioCompositions");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetAudioCompositionManager()
+			->SerializeAllCompositions(result);
+	}
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("removeVideoCompositionsByIds");
 	{
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetVideoCompositionManager()
 				->RemoveCompositionsByIds(args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("removeAudioCompositionsByIds");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetAudioCompositionManager()
+				->RemoveCompositionsByIds(args->GetValue(0),
+							  result);
 		}
 	}
 	API_HANDLER_END();
@@ -2611,11 +2630,33 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("addAudioComposition");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetAudioCompositionManager()
+				->DeserializeComposition(args->GetValue(0),
+							 result);
+		}
+	}
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("setVideoCompositionProperties");
 	{
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetVideoCompositionManager()
+				->DeserializeExistingCompositionProperties(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("setAudioCompositionProperties");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetAudioCompositionManager()
 				->DeserializeExistingCompositionProperties(
 					args->GetValue(0), result);
 		}

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -1,1 +1,377 @@
 #include "StreamElementsAudioComposition.hpp"
+#include <util/config-file.h>
+
+#include "deps/json11/json11.hpp"
+
+#include "StreamElementsUtils.hpp"
+#include "StreamElementsObsSceneManager.hpp"
+#include "StreamElementsMessageBus.hpp"
+#include "StreamElementsGlobalStateManager.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// Composition base
+////////////////////////////////////////////////////////////////////////////////
+
+void StreamElementsAudioCompositionBase::SetName(std::string name)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	if (m_name == name)
+		return;
+
+	m_name = name;
+
+	auto jsonValue = CefValue::Create();
+	SerializeComposition(jsonValue);
+
+	auto json = CefWriteJSON(jsonValue, JSON_WRITER_DEFAULT);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// OBS Main Composition
+////////////////////////////////////////////////////////////////////////////////
+
+class StreamElementsDefaultAudioCompositionInfo
+	: public StreamElementsAudioCompositionBase::CompositionInfo {
+private:
+	StreamElementsAudioCompositionEventListener *m_listener;
+
+public:
+	StreamElementsDefaultAudioCompositionInfo(
+		std::shared_ptr<StreamElementsAudioCompositionBase> owner,
+		StreamElementsAudioCompositionEventListener *listener)
+		: StreamElementsAudioCompositionBase::CompositionInfo(owner,
+								      listener),
+		  m_listener(listener)
+	{
+	}
+
+	virtual ~StreamElementsDefaultAudioCompositionInfo() {}
+
+public:
+	virtual bool IsObsNative() { return true; }
+
+	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index)
+	{
+		auto output = obs_frontend_get_streaming_output();
+
+		auto result = obs_output_get_audio_encoder(output, index);
+
+		obs_output_release(output);
+
+		return result;
+	}
+
+	virtual obs_encoder_t *GetRecordingAudioEncoder(size_t index)
+	{
+		auto output = obs_frontend_get_recording_output();
+
+		auto result = obs_output_get_audio_encoder(output, index);
+
+		obs_output_release(output);
+
+		return result;
+	}
+
+	virtual audio_t *GetAudio() { return obs_get_audio(); }
+};
+
+std::shared_ptr<StreamElementsAudioCompositionBase::CompositionInfo>
+StreamElementsObsNativeAudioComposition::GetCompositionInfo(
+	StreamElementsAudioCompositionEventListener *listener)
+{
+	return std::make_shared<StreamElementsDefaultAudioCompositionInfo>(
+		shared_from_this(), listener);
+}
+
+void StreamElementsObsNativeAudioComposition::SerializeComposition(
+	CefRefPtr<CefValue> &output)
+{
+	auto root = CefDictionaryValue::Create();
+
+	root->SetString("id", GetId());
+	root->SetString("name", GetName());
+
+	root->SetBool("isObsNativeComposition", true);
+	root->SetBool("canRemove", CanRemove());
+
+	SerializeObsEncoders(this, root);
+
+	output->SetDictionary(root);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Custom audio encoding
+////////////////////////////////////////////////////////////////////////////////
+
+class StreamElementsCustomAudioCompositionInfo
+	: public StreamElementsAudioCompositionBase::CompositionInfo {
+private:
+	StreamElementsAudioCompositionEventListener *m_listener;
+
+	audio_t *m_audio = nullptr;
+	obs_encoder_t *m_streamingAudioEncoders[MAX_AUDIO_MIXES] = {nullptr};
+	obs_encoder_t *m_recordingAudioEncoders[MAX_AUDIO_MIXES] = {nullptr};
+
+public:
+	StreamElementsCustomAudioCompositionInfo(
+		std::shared_ptr<StreamElementsAudioCompositionBase> owner,
+		StreamElementsAudioCompositionEventListener *listener,
+		audio_t *audio, obs_encoder_t *streamingAudioEncoders[MAX_AUDIO_MIXES],
+		obs_encoder_t *recordingAudioEncoders[MAX_AUDIO_MIXES])
+		: StreamElementsAudioCompositionBase::CompositionInfo(owner,
+								      listener),
+		  m_audio(audio),
+		  m_listener(listener)
+	{
+		for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+			m_streamingAudioEncoders[i] = streamingAudioEncoders[i];
+			m_recordingAudioEncoders[i] = recordingAudioEncoders[i];
+		}
+	}
+
+	virtual ~StreamElementsCustomAudioCompositionInfo() {}
+
+public:
+	virtual bool IsObsNative() { return false; }
+
+	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index)
+	{
+		if (index > MAX_AUDIO_MIXES)
+			return nullptr;
+
+		return m_streamingAudioEncoders[index];
+	}
+
+	virtual obs_encoder_t *GetRecordingAudioEncoder(size_t index)
+	{
+		if (index > MAX_AUDIO_MIXES)
+			return nullptr;
+
+		return m_recordingAudioEncoders[index];
+	}
+
+	virtual audio_t *GetAudio() { return m_audio; }
+};
+
+// ctor only usable by this class
+StreamElementsCustomAudioComposition::StreamElementsCustomAudioComposition(
+	StreamElementsCustomAudioComposition::Private, std::string id,
+	std::string name, std::string streamingAudioEncoderId,
+	obs_data_t *streamingAudioEncoderSettings,
+	obs_data_t *streamingAudioEncoderHotkeyData)
+	: StreamElementsAudioCompositionBase(id, name)
+{
+	m_audio = obs_get_audio();
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		m_streamingAudioEncoders[i] = obs_audio_encoder_create(
+			streamingAudioEncoderId.c_str(),
+			(name + ": streaming audio encoder").c_str(),
+			streamingAudioEncoderSettings, i,
+			streamingAudioEncoderHotkeyData);
+
+		if (!m_streamingAudioEncoders[i]) {
+			for (size_t di = 0; di < i; ++di) {
+				// Destroy previously created encoders
+				obs_encoder_release(
+					m_streamingAudioEncoders[di]);
+			}
+
+			throw std::exception(
+				"obs_audio_encoder_create() failed", 2);
+		}
+
+		obs_encoder_set_audio(m_streamingAudioEncoders[i], m_audio);
+	}
+}
+
+void StreamElementsCustomAudioComposition::SetRecordingEncoder(
+	std::string recordingAudioEncoderId,
+	obs_data_t *recordingAudioEncoderSettings,
+	obs_data_t *recordingAudioEncoderHotkeyData)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		m_recordingAudioEncoders[i] = obs_audio_encoder_create(
+			recordingAudioEncoderId.c_str(),
+			(GetName() + ": recording audio encoder").c_str(),
+			recordingAudioEncoderSettings, i,
+			recordingAudioEncoderHotkeyData);
+
+		if (!m_recordingAudioEncoders[i]) {
+			for (size_t di = 0; di < i; ++di) {
+				// Destroy previously created encoders
+				obs_encoder_release(
+					m_recordingAudioEncoders[di]);
+
+				m_recordingAudioEncoders[di] = nullptr;
+			}
+
+			throw std::exception(
+				"obs_audio_encoder_create() failed", 2);
+		}
+
+		obs_encoder_set_audio(m_recordingAudioEncoders[i],
+				      m_audio);
+	}
+}
+
+StreamElementsCustomAudioComposition::~StreamElementsCustomAudioComposition()
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		if (m_streamingAudioEncoders[i]) {
+			obs_encoder_release(m_streamingAudioEncoders[i]);
+			m_streamingAudioEncoders[i] = nullptr;
+		}
+
+		if (m_recordingAudioEncoders[i]) {
+			obs_encoder_release(m_recordingAudioEncoders[i]);
+			m_recordingAudioEncoders[i] = nullptr;
+		}
+	}
+
+	m_audio = nullptr;
+}
+
+std::shared_ptr<StreamElementsAudioCompositionBase::CompositionInfo>
+StreamElementsCustomAudioComposition::GetCompositionInfo(
+	StreamElementsAudioCompositionEventListener *listener)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	return std::make_shared<StreamElementsCustomAudioCompositionInfo>(
+		shared_from_this(), listener, m_audio, m_streamingAudioEncoders,
+		m_recordingAudioEncoders);
+}
+
+void StreamElementsCustomAudioComposition::SerializeComposition(
+	CefRefPtr<CefValue> &output)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	auto root = CefDictionaryValue::Create();
+
+	root->SetString("id", GetId());
+	root->SetString("name", GetName());
+
+	root->SetBool("isObsNativeComposition", false);
+	root->SetBool("canRemove", this->CanRemove());
+
+	SerializeObsEncoders(this, root);
+
+	output->SetDictionary(root);
+}
+
+std::shared_ptr<StreamElementsCustomAudioComposition>
+StreamElementsCustomAudioComposition::Create(
+	std::string id, std::string name,
+	CefRefPtr<CefValue> streamingAudioEncoder,
+	CefRefPtr<CefValue> recordingAudioEncoder)
+{
+	if (!streamingAudioEncoder.get() ||
+	    streamingAudioEncoder->GetType() != VTYPE_DICTIONARY)
+		return nullptr;
+
+	std::string streamingAudioEncoderId;
+	obs_data_t *streamingAudioEncoderSettings;
+	obs_data_t *streamingAudioEncoderHotkeyData = nullptr;
+
+	// For each encoder
+	{
+		auto encoderRoot = streamingAudioEncoder->GetDictionary();
+
+		if (!encoderRoot->HasKey("class") ||
+		    encoderRoot->GetType("class") != VTYPE_STRING)
+			return nullptr;
+
+		if (!encoderRoot->HasKey("settings") ||
+		    encoderRoot->GetType("settings") != VTYPE_DICTIONARY)
+			return nullptr;
+
+		streamingAudioEncoderId = encoderRoot->GetString("class");
+
+		streamingAudioEncoderSettings = obs_data_create();
+
+		if (!DeserializeObsData(encoderRoot->GetValue("settings"),
+					streamingAudioEncoderSettings)) {
+			obs_data_release(streamingAudioEncoderSettings);
+
+			return nullptr;
+		}
+	}
+
+	std::exception_ptr exception = nullptr;
+	std::shared_ptr<StreamElementsCustomAudioComposition> result = nullptr;
+
+	try {
+		result = Create(id, name, streamingAudioEncoderId,
+				streamingAudioEncoderSettings,
+				streamingAudioEncoderHotkeyData);
+	} catch (...) {
+		result = nullptr;
+
+		exception = std::current_exception();
+	}
+
+	if (streamingAudioEncoderSettings)
+		obs_data_release(streamingAudioEncoderSettings);
+
+	if (streamingAudioEncoderHotkeyData)
+		obs_data_release(streamingAudioEncoderHotkeyData);
+
+	if (exception)
+		std::rethrow_exception(exception);
+
+	// Recording encoders
+	if (recordingAudioEncoder.get() &&
+	    recordingAudioEncoder->GetType() == VTYPE_DICTIONARY) {
+		std::string recordingAudioEncoderId;
+		obs_data_t *recordingAudioEncoderSettings = nullptr;
+		obs_data_t *recordingAudioEncoderHotkeyData = nullptr;
+
+		auto encoderRoot = recordingAudioEncoder->GetDictionary();
+
+		if (!encoderRoot->HasKey("class") ||
+			encoderRoot->GetType("class") != VTYPE_STRING)
+			return nullptr;
+
+		if (!encoderRoot->HasKey("settings") ||
+			encoderRoot->GetType("settings") !=
+				VTYPE_DICTIONARY)
+			return nullptr;
+
+		recordingAudioEncoderId =
+			encoderRoot->GetString("class");
+
+		recordingAudioEncoderSettings = obs_data_create();
+
+		if (DeserializeObsData(encoderRoot->GetValue("settings"),
+				       recordingAudioEncoderSettings)) {
+			try {
+				result->SetRecordingEncoder(
+					recordingAudioEncoderId,
+					recordingAudioEncoderSettings,
+					recordingAudioEncoderHotkeyData);
+			} catch (...) {
+				result = nullptr;
+
+				exception = std::current_exception();
+			}
+		}
+
+		if (recordingAudioEncoderSettings)
+			obs_data_release(recordingAudioEncoderSettings);
+
+		if (recordingAudioEncoderHotkeyData)
+			obs_data_release(recordingAudioEncoderHotkeyData);
+
+		if (exception)
+			std::rethrow_exception(exception);
+	}
+
+	return result;
+}

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -14,6 +14,7 @@ SerializeObsAudioEncoders(StreamElementsAudioCompositionBase *composition,
 {
 	auto info = composition->GetCompositionInfo(nullptr);
 
+	/*
 	auto streamingAudioEncoders = CefListValue::Create();
 	for (size_t i = 0;; ++i) {
 		auto encoder = info->GetStreamingAudioEncoder(i);
@@ -26,9 +27,19 @@ SerializeObsAudioEncoders(StreamElementsAudioCompositionBase *composition,
 	}
 
 	root->SetList("streamingAudioEncoders", streamingAudioEncoders);
+	*/
+
+	if (info->GetStreamingAudioEncoder(0)) {
+		root->SetDictionary(
+			"streamingAudioEncoder",
+			SerializeObsEncoder(info->GetStreamingAudioEncoder(0)));
+	} else {
+		root->SetNull("streamingAudioEncoder");
+	}
 
 	// Recording
 
+	/*
 	bool hasDifferentAudioEncoder = false;
 	auto recordingAudioEncoders = CefListValue::Create();
 	for (size_t i = 0;; ++i) {
@@ -46,6 +57,15 @@ SerializeObsAudioEncoders(StreamElementsAudioCompositionBase *composition,
 
 	if (hasDifferentAudioEncoder)
 		root->SetList("recordingAudioEncoders", recordingAudioEncoders);
+	*/
+
+	if (info->GetRecordingAudioEncoder(0)) {
+		root->SetDictionary(
+			"recordingAudioEncoder",
+			SerializeObsEncoder(info->GetRecordingAudioEncoder(0)));
+	} else {
+		root->SetNull("recordingAudioEncoder");
+	}
 }
 
 static void

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -65,6 +65,7 @@ SerializeObsAudioTracks(StreamElementsAudioCompositionBase *composition,
 
 		sprintf(stringBuffer, "Track%dName", i + 1);
 
+		// This might apply not for "SimpleOutput", but we have a default fallback below
 		auto nameStr = config_get_string(obs_frontend_get_profile_config(),
 					    advOut ? "AdvOut" : "SimpleOutput",
 					    stringBuffer);

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -1,0 +1,1 @@
+#include "StreamElementsAudioComposition.hpp"

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -48,6 +48,43 @@ SerializeObsAudioEncoders(StreamElementsAudioCompositionBase *composition,
 		root->SetList("recordingAudioEncoders", recordingAudioEncoders);
 }
 
+static void
+SerializeObsAudioTracks(StreamElementsAudioCompositionBase *composition,
+			CefRefPtr<CefDictionaryValue> &root)
+{
+	const char *mode = config_get_string(obs_frontend_get_profile_config(),
+					     "Output", "Mode");
+	bool advOut = stricmp(mode, "Advanced") == 0;
+
+	auto audioTracks = CefListValue::Create();
+
+	char stringBuffer[128];
+
+	for (int i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		auto track = CefDictionaryValue::Create();
+
+		sprintf(stringBuffer, "Track%dName", i + 1);
+
+		auto nameStr = config_get_string(obs_frontend_get_profile_config(),
+					    advOut ? "AdvOut" : "SimpleOutput",
+					    stringBuffer);
+
+		track->SetInt("id", i);
+
+		if (nameStr && strlen(nameStr) > 0) {
+			track->SetString("name", nameStr);
+		} else {
+			sprintf(stringBuffer, "Track %d", i + 1);
+
+			track->SetString("name", stringBuffer);
+		}
+
+		audioTracks->SetDictionary(audioTracks->GetSize(), track);
+	}
+
+	root->SetList("audioTracks", audioTracks);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Composition base
 ////////////////////////////////////////////////////////////////////////////////
@@ -136,6 +173,7 @@ void StreamElementsObsNativeAudioComposition::SerializeComposition(
 	root->SetBool("canRemove", CanRemove());
 
 	SerializeObsAudioEncoders(this, root);
+	SerializeObsAudioTracks(this, root);
 
 	output->SetDictionary(root);
 }
@@ -302,6 +340,7 @@ void StreamElementsCustomAudioComposition::SerializeComposition(
 	root->SetBool("canRemove", this->CanRemove());
 
 	SerializeObsAudioEncoders(this, root);
+	SerializeObsAudioTracks(this, root);
 
 	output->SetDictionary(root);
 }

--- a/streamelements/StreamElementsAudioComposition.hpp
+++ b/streamelements/StreamElementsAudioComposition.hpp
@@ -3,4 +3,219 @@
 #include <obs.h>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
+#include "cef-headers.hpp"
+
 #include "StreamElementsUtils.hpp"
+
+class StreamElementsAudioCompositionEventListener {
+public:
+	StreamElementsAudioCompositionEventListener() {}
+	~StreamElementsAudioCompositionEventListener() {}
+
+public:
+	//virtual void StopOutputRequested();
+};
+
+class StreamElementsAudioCompositionBase {
+public:
+	class CompositionInfo {
+	private:
+		std::shared_ptr<StreamElementsAudioCompositionBase> m_owner;
+		StreamElementsAudioCompositionEventListener *m_listener;
+
+	public:
+		CompositionInfo(
+			std::shared_ptr<StreamElementsAudioCompositionBase>
+				owner,
+			StreamElementsAudioCompositionEventListener *listener)
+			: m_owner(owner), m_listener(listener)
+		{
+			m_owner->AddRef();
+		}
+
+		virtual ~CompositionInfo() { m_owner->RemoveRef(); }
+
+	public:
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+		GetComposition()
+		{
+			return m_owner;
+		}
+
+	public:
+		// When true, consumers probably want to opt-in to streaming
+		// only when OBS main streaming output is active.
+		virtual bool IsObsNative() = 0;
+
+		virtual obs_encoder_t *
+		GetStreamingAudioEncoder(size_t index) = 0;
+
+		virtual obs_encoder_t *
+		GetRecordingAudioEncoder(size_t index) = 0;
+
+		virtual audio_t *GetAudio() = 0;
+	};
+
+private:
+	size_t m_refCounter = 0;
+	std::mutex m_refCounterMutex;
+
+	void AddRef()
+	{
+		std::lock_guard<decltype(m_refCounterMutex)> lock(
+			m_refCounterMutex);
+
+		++m_refCounter;
+	}
+
+	void RemoveRef()
+	{
+		std::lock_guard<decltype(m_refCounterMutex)> lock(
+			m_refCounterMutex);
+
+		--m_refCounter;
+	}
+
+public:
+	virtual bool CanRemove()
+	{
+		std::lock_guard<decltype(m_refCounterMutex)> lock(
+			m_refCounterMutex);
+
+		return m_refCounter == 0;
+	}
+
+	virtual std::shared_ptr<CompositionInfo> GetCompositionInfo(
+		StreamElementsAudioCompositionEventListener *listener) = 0;
+
+private:
+	std::string m_id;
+	std::string m_name;
+
+	std::recursive_mutex m_mutex;
+
+protected:
+	StreamElementsAudioCompositionBase(const std::string id,
+					   const std::string name)
+		: m_id(id), m_name(name)
+	{
+	}
+	virtual ~StreamElementsAudioCompositionBase() {}
+
+public:
+	std::string GetId() { return m_id; }
+
+	std::string GetName()
+	{
+		std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+		return m_name;
+	}
+
+	void SetName(std::string name);
+
+public:
+	virtual bool IsObsNativeComposition() = 0;
+
+	virtual void SerializeComposition(CefRefPtr<CefValue> &output) = 0;
+};
+
+// OBS Main Composition
+class StreamElementsObsNativeAudioComposition
+	: public StreamElementsAudioCompositionBase,
+	  public std::enable_shared_from_this<
+		  StreamElementsAudioCompositionBase> {
+private:
+	struct Private {
+		explicit Private() = default;
+	};
+
+public:
+	// ctor only usable by this class
+	StreamElementsObsNativeAudioComposition(Private)
+		: StreamElementsAudioCompositionBase("default", "Default")
+	{
+	}
+
+	virtual ~StreamElementsObsNativeAudioComposition() {}
+
+public:
+	static std::shared_ptr<StreamElementsAudioCompositionBase> Create()
+	{
+		return std::make_shared<StreamElementsObsNativeAudioComposition>(
+			Private());
+	}
+
+public:
+	virtual bool IsObsNativeComposition() { return true; }
+
+	virtual std::shared_ptr<
+		StreamElementsAudioCompositionBase::CompositionInfo>
+	GetCompositionInfo(
+		StreamElementsAudioCompositionEventListener *listener);
+
+	virtual bool CanRemove() { return false; }
+
+	virtual void SerializeComposition(CefRefPtr<CefValue> &output);
+};
+
+// Custom Composition
+class StreamElementsCustomAudioComposition
+	: public StreamElementsAudioCompositionBase,
+	  public std::enable_shared_from_this<
+		  StreamElementsAudioCompositionBase> {
+private:
+	struct Private {
+		explicit Private() = default;
+	};
+
+private:
+	std::recursive_mutex m_mutex;
+
+public:
+	// ctor only usable by this class
+	StreamElementsCustomAudioComposition(
+		Private, std::string id, std::string name, std::string streamingAudioEncoderId,
+		obs_data_t *streamingAudioEncoderSettings,
+		obs_data_t *streamingAudioEncoderHotkeyData);
+
+	virtual ~StreamElementsCustomAudioComposition();
+
+public:
+	static std::shared_ptr<StreamElementsCustomAudioComposition>
+	Create(std::string id, std::string name,
+	       std::string streamingAudioEncoderId,
+	       obs_data_t *streamingAudioEncoderSettings,
+	       obs_data_t *streamingAudioEncoderHotkeyData)
+	{
+		return std::make_shared<StreamElementsCustomAudioComposition>(
+			Private(), id, name, streamingAudioEncoderId,
+			streamingAudioEncoderSettings,
+			streamingAudioEncoderHotkeyData);
+	}
+
+	static std::shared_ptr<StreamElementsCustomAudioComposition>
+	Create(std::string id, std::string name,
+	       CefRefPtr<CefValue> streamingAudioEncoders,
+	       CefRefPtr<CefValue> recordingAudioEncoders);
+
+private:
+	audio_t *m_audio = nullptr;
+	obs_encoder_t *m_streamingAudioEncoders[MAX_AUDIO_MIXES] = {nullptr};
+	obs_encoder_t *m_recordingAudioEncoders[MAX_AUDIO_MIXES] = {nullptr};
+
+private:
+	void SetRecordingEncoder(std::string recordingAudioEncoderId,
+				 obs_data_t *recordingAudioEncoderSettings,
+				 obs_data_t *recordingAudioEncoderHotkeyData);
+
+		public:
+	virtual bool IsObsNativeComposition() { return false; }
+
+	virtual std::shared_ptr<
+		StreamElementsAudioCompositionBase::CompositionInfo>
+	GetCompositionInfo(
+		StreamElementsAudioCompositionEventListener *listener);
+
+	virtual void SerializeComposition(CefRefPtr<CefValue> &output);
+};

--- a/streamelements/StreamElementsAudioComposition.hpp
+++ b/streamelements/StreamElementsAudioComposition.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <obs.h>
+#include <obs.hpp>
+#include <obs-frontend-api.h>
+#include "StreamElementsUtils.hpp"

--- a/streamelements/StreamElementsAudioCompositionManager.cpp
+++ b/streamelements/StreamElementsAudioCompositionManager.cpp
@@ -1,0 +1,1 @@
+#include "StreamElementsAudioCompositionManager.hpp"

--- a/streamelements/StreamElementsAudioCompositionManager.cpp
+++ b/streamelements/StreamElementsAudioCompositionManager.cpp
@@ -104,7 +104,7 @@ void StreamElementsAudioCompositionManager::DeserializeComposition(
 	if (!root->HasKey("name") || root->GetType("name") != VTYPE_STRING)
 		return;
 
-	if (!root->HasKey("streamingAudioEncoders"))
+	if (!root->HasKey("streamingAudioEncoder"))
 		return;
 
 	std::string id = root->GetString("id");
@@ -116,13 +116,13 @@ void StreamElementsAudioCompositionManager::DeserializeComposition(
 		auto recordingAudioEncoders = CefValue::Create();
 		recordingAudioEncoders->SetNull();
 
-		if (root->HasKey("recordingAudioEncoders"))
+		if (root->HasKey("recordingAudioEncoder"))
 			recordingAudioEncoders =
-				root->GetValue("recordingAudioEncoders");
+				root->GetValue("recordingAudioEncoder");
 
 		auto composition = StreamElementsCustomAudioComposition::Create(
 			id, root->GetString("name"),
-			root->GetValue("streamingAudioEncoders"),
+			root->GetValue("streamingAudioEncoder"),
 			recordingAudioEncoders);
 
 		if (!composition)

--- a/streamelements/StreamElementsAudioCompositionManager.cpp
+++ b/streamelements/StreamElementsAudioCompositionManager.cpp
@@ -1,1 +1,250 @@
 #include "StreamElementsAudioCompositionManager.hpp"
+#include "StreamElementsGlobalStateManager.hpp"
+
+static void dispatch_external_event(std::string name, std::string args)
+{
+	std::string externalEventName =
+		name.c_str() + 4; /* remove 'host' prefix */
+	externalEventName[0] =
+		tolower(externalEventName[0]); /* lower case first letter */
+
+	StreamElementsMessageBus::GetInstance()->NotifyAllExternalEventListeners(
+		StreamElementsMessageBus::DEST_ALL_EXTERNAL,
+		StreamElementsMessageBus::SOURCE_APPLICATION, "OBS",
+		externalEventName,
+		CefParseJSON(args, JSON_PARSER_ALLOW_TRAILING_COMMAS));
+}
+
+static void dispatch_js_event(std::string name, std::string args)
+{
+	auto apiServer = StreamElementsGlobalStateManager::GetInstance()
+				 ->GetWebsocketApiServer();
+
+	if (!apiServer)
+		return;
+
+	apiServer->DispatchJSEvent("system", name, args);
+}
+
+StreamElementsAudioCompositionManager::StreamElementsAudioCompositionManager()
+{
+	m_nativeAudioComposition =
+		StreamElementsObsNativeAudioComposition::Create();
+
+	m_audioCompositionsMap[m_nativeAudioComposition->GetId()] =
+		m_nativeAudioComposition;
+}
+
+StreamElementsAudioCompositionManager::~StreamElementsAudioCompositionManager()
+{
+	Reset();
+
+	m_audioCompositionsMap.clear();
+}
+
+void StreamElementsAudioCompositionManager::Reset()
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	for (auto it = m_audioCompositionsMap.cbegin();
+	     it != m_audioCompositionsMap.cend(); ++it) {
+		if (!it->second->IsObsNativeComposition())
+			m_audioCompositionsMap.erase(it->first);
+	}
+
+	dispatch_js_event("hostAudioCompositionListChanged", "null");
+	dispatch_external_event("hostAudioCompositionListChanged", "null");
+}
+
+void StreamElementsAudioCompositionManager::
+	DeserializeExistingCompositionProperties(CefRefPtr<CefValue> input,
+						 CefRefPtr<CefValue> &output)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	output->SetNull();
+
+	if (!input.get() || input->GetType() != VTYPE_DICTIONARY)
+		return;
+
+	auto root = input->GetDictionary();
+
+	if (!root->HasKey("id") || root->GetType("id") != VTYPE_STRING)
+		return;
+
+	std::string id = root->GetString("id");
+
+	auto audioComposition = GetAudioCompositionById(id);
+
+	if (!audioComposition.get())
+		return;
+
+	if (root->HasKey("name") && root->GetType("name") == VTYPE_STRING) {
+		audioComposition->SetName(root->GetString("name"));
+	}
+
+	audioComposition->SerializeComposition(output);
+}
+
+void StreamElementsAudioCompositionManager::DeserializeComposition(
+	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	output->SetNull();
+
+	if (!input.get() || input->GetType() != VTYPE_DICTIONARY)
+		return;
+
+	auto root = input->GetDictionary();
+
+	if (!root->HasKey("id") || root->GetType("id") != VTYPE_STRING)
+		return;
+
+	if (!root->HasKey("name") || root->GetType("name") != VTYPE_STRING)
+		return;
+
+	if (!root->HasKey("streamingAudioEncoders"))
+		return;
+
+	std::string id = root->GetString("id");
+
+	if (m_audioCompositionsMap.count(id))
+		return;
+
+	try {
+		auto recordingAudioEncoders = CefValue::Create();
+		recordingAudioEncoders->SetNull();
+
+		if (root->HasKey("recordingAudioEncoders"))
+			recordingAudioEncoders =
+				root->GetValue("recordingAudioEncoders");
+
+		auto composition = StreamElementsCustomAudioComposition::Create(
+			id, root->GetString("name"),
+			root->GetValue("streamingAudioEncoders"),
+			recordingAudioEncoders);
+
+		if (!composition)
+			return;
+
+		m_audioCompositionsMap[id] = composition;
+
+		composition->SerializeComposition(output);
+
+		dispatch_js_event("hostAudioCompositionListChanged", "null");
+		dispatch_external_event("hostAudioCompositionListChanged",
+					"null");
+	} catch (...) {
+		// Creation failed
+		return;
+	}
+}
+
+void StreamElementsAudioCompositionManager::SerializeAllCompositions(
+	CefRefPtr<CefValue> &output)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	CefRefPtr<CefDictionaryValue> d = CefDictionaryValue::Create();
+
+	for (auto kv : m_audioCompositionsMap) {
+		auto composition = CefValue::Create();
+
+		kv.second->SerializeComposition(composition);
+
+		d->SetValue(kv.second->GetId(), composition);
+	}
+
+	output->SetDictionary(d);
+}
+
+void StreamElementsAudioCompositionManager::RemoveCompositionsByIds(
+	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
+{
+	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+	output->SetBool(false);
+
+	if (input->GetType() != VTYPE_LIST)
+		return;
+
+	auto list = input->GetList();
+
+	std::map<std::string, bool> map;
+
+	// Check if all IDs are valid
+	for (size_t i = 0; i < list->GetSize(); ++i) {
+		if (list->GetType(i) != VTYPE_STRING)
+			return;
+
+		std::string id = list->GetString(i);
+
+		if (!id.size())
+			return;
+
+		if (!m_audioCompositionsMap.count(id))
+			return;
+
+		if (!m_audioCompositionsMap[id]->CanRemove())
+			return;
+
+		map[id] = true;
+	}
+
+	// Remove all valid IDs
+	for (auto kv : map) {
+		m_audioCompositionsMap.erase(kv.first);
+	}
+
+	dispatch_js_event("hostAudioCompositionListChanged", "null");
+	dispatch_external_event("hostAudioCompositionListChanged", "null");
+
+	output->SetBool(true);
+}
+
+void StreamElementsAudioCompositionManager::SerializeAvailableEncoderClasses(
+	obs_encoder_type type, CefRefPtr<CefValue> &output)
+{
+	auto root = CefListValue::Create();
+
+	const char *id;
+	for (size_t i = 0; obs_enum_encoder_types(i, &id); ++i) {
+		if (obs_get_encoder_type(id) != type)
+			continue;
+
+		auto d = CefDictionaryValue::Create();
+
+		d->SetString("class", id);
+		d->SetString("label", obs_encoder_get_display_name(id));
+		d->SetString("codec", obs_get_encoder_codec(id));
+		d->SetValue("properties", SerializeObsEncoderProperties(id));
+
+		obs_encoder_t *encoder = nullptr;
+
+		if (type == OBS_ENCODER_VIDEO)
+			encoder = obs_video_encoder_create(id, id, nullptr,
+							   nullptr);
+		else if (type == OBS_ENCODER_AUDIO)
+			encoder = obs_audio_encoder_create(id, id, nullptr, 0,
+							   nullptr);
+
+		if (encoder) {
+			auto defaultSettings =
+				obs_encoder_get_defaults(encoder);
+
+			if (defaultSettings) {
+				d->SetValue("defaultSettings",
+					    SerializeObsData(defaultSettings));
+
+				obs_data_release(defaultSettings);
+			}
+
+			obs_encoder_release(encoder);
+		}
+
+		root->SetDictionary(root->GetSize(), d);
+	}
+
+	output->SetList(root);
+}

--- a/streamelements/StreamElementsAudioCompositionManager.hpp
+++ b/streamelements/StreamElementsAudioCompositionManager.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "StreamElementsAudioComposition.hpp"
+
+#include <obs.h>
+#include <obs.hpp>
+#include <obs-frontend-api.h>
+#include "StreamElementsUtils.hpp"

--- a/streamelements/StreamElementsAudioCompositionManager.hpp
+++ b/streamelements/StreamElementsAudioCompositionManager.hpp
@@ -6,3 +6,76 @@
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 #include "StreamElementsUtils.hpp"
+
+class StreamElementsAudioCompositionManager {
+private:
+	std::recursive_mutex m_mutex;
+	std::map<std::string,
+		 std::shared_ptr<StreamElementsAudioCompositionBase>>
+		m_audioCompositionsMap;
+	std::shared_ptr<StreamElementsAudioCompositionBase>
+		m_nativeAudioComposition;
+
+public:
+	StreamElementsAudioCompositionManager();
+	~StreamElementsAudioCompositionManager();
+
+public:
+	void
+	DeserializeExistingCompositionProperties(CefRefPtr<CefValue> input,
+						 CefRefPtr<CefValue> &output);
+	void DeserializeComposition(CefRefPtr<CefValue> input,
+				    CefRefPtr<CefValue> &output);
+	void SerializeAllCompositions(CefRefPtr<CefValue> &output);
+	void RemoveCompositionsByIds(CefRefPtr<CefValue> input,
+				     CefRefPtr<CefValue> &output);
+
+	void SerializeAvailableEncoderClasses(obs_encoder_type type,
+					      CefRefPtr<CefValue> &output);
+
+	void SerializeAvailableTransitionClasses(CefRefPtr<CefValue> &output);
+
+	void Reset();
+
+public:
+	std::shared_ptr<StreamElementsAudioCompositionBase>
+	GetObsNativeAudioComposition()
+	{
+		std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+		return m_nativeAudioComposition;
+	}
+
+	std::shared_ptr<StreamElementsAudioCompositionBase>
+	GetAudioCompositionById(std::string id)
+	{
+		std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+		if (!m_audioCompositionsMap.count(id))
+			return nullptr;
+
+		return m_audioCompositionsMap[id];
+	}
+
+	std::shared_ptr<StreamElementsAudioCompositionBase>
+	GetAudioCompositionById(CefRefPtr<CefValue> input)
+	{
+		std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+		if (!input.get() || input->GetType() != VTYPE_DICTIONARY)
+			return GetObsNativeAudioComposition();
+
+		auto d = input->GetDictionary();
+
+		if (!d->HasKey("audioCompositionId") ||
+		    d->GetType("audioCompositionId") != VTYPE_STRING)
+			return GetObsNativeAudioComposition();
+
+		std::string id = d->GetString("audioCompositionId");
+
+		if (!m_audioCompositionsMap.count(id))
+			return nullptr;
+
+		return m_audioCompositionsMap[id];
+	}
+};

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -385,9 +385,11 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 
 			m_videoCompositionManager = std::make_shared<
 				StreamElementsVideoCompositionManager>();
+			m_audioCompositionManager = std::make_shared<
+				StreamElementsAudioCompositionManager>();
 			m_outputManager =
 				std::make_shared<StreamElementsOutputManager>(
-					m_videoCompositionManager);
+					m_videoCompositionManager, m_audioCompositionManager);
 
 						m_appStateListener = new ApplicationStateListener();
 			m_themeChangeListener = new ThemeChangeListener();
@@ -591,6 +593,7 @@ void StreamElementsGlobalStateManager::Shutdown()
 
 			m_outputManager = nullptr;
 			m_videoCompositionManager = nullptr;
+			m_audioCompositionManager = nullptr;
 
 			delete m_menuManager;
 			m_menuManager = nullptr;

--- a/streamelements/StreamElementsGlobalStateManager.hpp
+++ b/streamelements/StreamElementsGlobalStateManager.hpp
@@ -29,6 +29,7 @@ struct QCefCookieManager;
 #include "StreamElementsWebsocketApiServer.hpp"
 #include "StreamElementsBrowserDialog.hpp"
 #include "StreamElementsVideoCompositionManager.hpp"
+#include "StreamElementsAudioCompositionManager.hpp"
 #include "StreamElementsOutputManager.hpp"
 
 class StreamElementsGlobalStateManager : public StreamElementsObsAppMonitor {
@@ -170,6 +171,11 @@ public:
 	{
 		return m_videoCompositionManager;
 	}
+	std::shared_ptr<StreamElementsAudioCompositionManager>
+	GetAudioCompositionManager()
+	{
+		return m_audioCompositionManager;
+	}
 	std::shared_ptr<StreamElementsOutputManager> GetOutputManager()
 	{
 		return m_outputManager;
@@ -240,8 +246,10 @@ private:
 	StreamElementsPreviewManager *m_previewManager = nullptr;
 	StreamElementsWebsocketApiServer *m_websocketApiServer = nullptr;
 	WindowStateChangeEventFilter *m_windowStateEventFilter = nullptr;
-	std::shared_ptr<StreamElementsVideoCompositionManager> m_videoCompositionManager =
-		nullptr;
+	std::shared_ptr<StreamElementsVideoCompositionManager>
+		m_videoCompositionManager = nullptr;
+	std::shared_ptr<StreamElementsAudioCompositionManager>
+		m_audioCompositionManager = nullptr;
 	std::shared_ptr<StreamElementsOutputManager> m_outputManager = nullptr;
 
 private:

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -889,7 +889,6 @@ std::vector<uint32_t> StreamElementsObsNativeStreamingOutput::GetAudioTracks()
 			1;
 
 		result.push_back(streamTrack);
-
 	} else {
 		result.push_back(0);
 	}
@@ -954,7 +953,11 @@ std::vector<uint32_t> StreamElementsObsNativeRecordingOutput::GetAudioTracks()
 				    advOut ? "AdvOut" : "SimpleOutput",
 				    "RecTracks");
 
-	result.push_back(tracks);
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		if (tracks & (1 << i)) {
+			result.push_back(i);
+		}
+	}
 
 	return result;
 }

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -286,11 +286,15 @@ void StreamElementsOutputBase::SerializeOutput(CefRefPtr<CefValue>& output)
 	d->SetString("id", GetId());
 	d->SetString("name", GetName());
 	d->SetString("videoCompositionId", m_videoComposition->GetId());
+	d->SetString("audioCompositionId", m_audioComposition->GetId());
 	d->SetBool("isEnabled", IsEnabled());
 	d->SetBool("isActive", IsActive());
 	d->SetBool("canDisable", CanDisable());
 	d->SetBool("canRemove", !IsObsNativeOutput());
-	d->SetBool("isObsNativeVideoComposition", m_videoComposition->IsObsNativeComposition());
+	d->SetBool("isObsNativeVideoComposition",
+		   m_videoComposition->IsObsNativeComposition());
+	d->SetBool("isObsNativeAudioComposition",
+		   m_audioComposition->IsObsNativeComposition());
 	d->SetBool("isObsNativeOutput", IsObsNativeOutput());
 
 	if (m_error.size()) {

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -785,6 +785,10 @@ std::shared_ptr <StreamElementsCustomStreamingOutput> StreamElementsCustomStream
 		return nullptr;
 	}
 
+	if (!audioComposition) {
+		return nullptr;
+	}
+
 	// Streaming service
 	obs_service_t *service = obs_service_create(
 		"rtmp_custom", "default_service", NULL, NULL);

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -154,6 +154,7 @@ public:
 		} else {
 			m_bindToIP = "";
 		}
+
 	}
 
 	virtual ~StreamElementsCustomStreamingOutput()
@@ -304,7 +305,8 @@ public:
 		: StreamElementsOutputBase(id, name, RecordingOutput, None,
 					   videoComposition, audioComposition,
 					   auxData),
-		  m_recordingSettings(recordingSettings)
+		  m_recordingSettings(recordingSettings),
+		  m_audioTracks(audioTracks)
 	{
 	}
 

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -3,7 +3,7 @@
 #include <obs-frontend-api.h>
 #include "StreamElementsVideoComposition.hpp"
 
-class StreamElementsOutputBase : public StreamElementsCompositionEventListener {
+class StreamElementsOutputBase : public StreamElementsVideoCompositionEventListener {
 public:
 	enum ObsStateDependencyType {
 		Streaming,

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -2,8 +2,11 @@
 
 #include <obs-frontend-api.h>
 #include "StreamElementsVideoComposition.hpp"
+#include "StreamElementsAudioComposition.hpp"
 
-class StreamElementsOutputBase : public StreamElementsVideoCompositionEventListener {
+class StreamElementsOutputBase
+	: public StreamElementsVideoCompositionEventListener,
+	  public StreamElementsAudioCompositionEventListener {
 public:
 	enum ObsStateDependencyType {
 		Streaming,
@@ -23,6 +26,9 @@ private:
 	std::shared_ptr<StreamElementsVideoCompositionBase> m_videoComposition;
 	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
 		m_videoCompositionInfo;
+	std::shared_ptr<StreamElementsAudioCompositionBase> m_audioComposition;
+	std::shared_ptr<StreamElementsAudioCompositionBase::CompositionInfo>
+		m_audioCompositionInfo;
 	std::recursive_mutex m_mutex;
 
 	CefRefPtr<CefDictionaryValue> m_auxData;
@@ -41,6 +47,8 @@ public:
 		ObsStateDependencyType obsStateDependency,
 		std::shared_ptr<StreamElementsVideoCompositionBase>
 			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition,
 		CefRefPtr<CefDictionaryValue> auxData);
 	virtual ~StreamElementsOutputBase();
 
@@ -75,7 +83,10 @@ protected:
 
 	virtual bool StartInternal(
 		std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
-			videoCompositionInfo) = 0;
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo) = 0;
 	virtual void StopInternal() = 0;
 
 protected:
@@ -123,9 +134,11 @@ public:
 	StreamElementsCustomStreamingOutput(
 		std::string id, std::string name,
 		std::shared_ptr<StreamElementsVideoCompositionBase> videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition,
 		obs_service_t *service, const char *bindToIP,
 		CefRefPtr<CefDictionaryValue> auxData)
-		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming, videoComposition, auxData),
+		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming, videoComposition, audioComposition, auxData),
 		  m_service(service)
 	{
 		if (bindToIP) {
@@ -156,8 +169,13 @@ public:
 protected:
 	virtual obs_output_t *GetOutput() override { return m_output; }
 
-	virtual bool
-		StartInternal(std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo> videoCompositionInfo);
+	virtual bool StartInternal(
+		std::shared_ptr<
+			StreamElementsVideoCompositionBase::CompositionInfo>
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo);
 	virtual void StopInternal();
 };
 
@@ -165,8 +183,11 @@ class StreamElementsObsNativeStreamingOutput : public StreamElementsOutputBase {
 public:
 	StreamElementsObsNativeStreamingOutput(
 		std::string id, std::string name,
-		std::shared_ptr<StreamElementsVideoCompositionBase> videoComposition)
-		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming, videoComposition, CefDictionaryValue::Create())
+		std::shared_ptr<StreamElementsVideoCompositionBase>
+			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition)
+		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming, videoComposition, audioComposition, CefDictionaryValue::Create())
 	{
 	}
 
@@ -187,7 +208,10 @@ protected:
 
 	virtual bool StartInternal(
 		std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
-			videoCompositionInfo) override;
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo) override;
 	virtual void StopInternal() override;
 
 	virtual void
@@ -199,9 +223,11 @@ public:
 	StreamElementsObsNativeRecordingOutput(
 		std::string id, std::string name,
 		std::shared_ptr<StreamElementsVideoCompositionBase>
-			videoComposition)
+			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition)
 		: StreamElementsOutputBase(id, name, RecordingOutput, Recording,
-					   videoComposition,
+					   videoComposition, audioComposition,
 					   CefDictionaryValue::Create())
 	{
 	}
@@ -225,7 +251,10 @@ protected:
 	virtual bool
 	StartInternal(std::shared_ptr<
 		      StreamElementsVideoCompositionBase::CompositionInfo>
-			      videoCompositionInfo) override;
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo) override;
 	virtual void StopInternal() override;
 
 	virtual void
@@ -252,9 +281,12 @@ public:
 		CefRefPtr<CefDictionaryValue> recordingSettings,
 		std::shared_ptr<StreamElementsVideoCompositionBase>
 			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, RecordingOutput, None,
-					   videoComposition, auxData),
+					   videoComposition, audioComposition,
+					   auxData),
 		  m_recordingSettings(recordingSettings),
 		  m_videoComposition(videoComposition)
 	{
@@ -284,6 +316,9 @@ protected:
 	virtual bool
 	StartInternal(std::shared_ptr<
 		      StreamElementsVideoCompositionBase::CompositionInfo>
-			      videoCompositionInfo);
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo);
 	virtual void StopInternal();
 };

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -73,6 +73,8 @@ public:
 	virtual void
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) = 0;
 
+	virtual std::vector<uint32_t> GetAudioTracks() = 0;
+
 	virtual bool CanSplitRecordingOutput() { return false; }
 	virtual bool TriggerSplitRecordingOutput() { return false; }
 
@@ -130,16 +132,22 @@ private:
 
 	std::string m_bindToIP;
 
+	std::vector<uint32_t> m_audioTracks = {0};
+
 public:
 	StreamElementsCustomStreamingOutput(
 		std::string id, std::string name,
-		std::shared_ptr<StreamElementsVideoCompositionBase> videoComposition,
+		std::shared_ptr<StreamElementsVideoCompositionBase>
+			videoComposition,
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
-		obs_service_t *service, const char *bindToIP,
-		CefRefPtr<CefDictionaryValue> auxData)
-		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming, videoComposition, audioComposition, auxData),
-		  m_service(service)
+		std::vector<uint32_t> audioTracks, obs_service_t *service,
+		const char *bindToIP, CefRefPtr<CefDictionaryValue> auxData)
+		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming,
+					   videoComposition, audioComposition,
+					   auxData),
+		  m_service(service),
+		  m_audioTracks(audioTracks)
 	{
 		if (bindToIP) {
 			m_bindToIP = bindToIP;
@@ -160,6 +168,11 @@ public:
 
 	virtual void
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override
+	{
+		return m_audioTracks;
+	}
 
 	static std::shared_ptr<StreamElementsCustomStreamingOutput>
 	Create(CefRefPtr<CefValue> input);
@@ -216,6 +229,8 @@ protected:
 
 	virtual void
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override;
 };
 
 class StreamElementsObsNativeRecordingOutput : public StreamElementsOutputBase {
@@ -259,14 +274,13 @@ protected:
 
 	virtual void
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override;
 };
 
 class StreamElementsCustomRecordingOutput : public StreamElementsOutputBase {
 private:
 	std::recursive_mutex m_mutex;
-
-	std::shared_ptr<StreamElementsVideoCompositionBase>
-		m_videoComposition = nullptr;
 
 	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
 		m_videoCompositionInfo = nullptr;
@@ -274,6 +288,8 @@ private:
 	obs_output_t *m_output = nullptr;
 
 	CefRefPtr<CefDictionaryValue> m_recordingSettings = CefDictionaryValue::Create();
+
+	std::vector<uint32_t> m_audioTracks;
 
 public:
 	StreamElementsCustomRecordingOutput(
@@ -283,12 +299,12 @@ public:
 			videoComposition,
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
+		std::vector<uint32_t> audioTracks,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, RecordingOutput, None,
 					   videoComposition, audioComposition,
 					   auxData),
-		  m_recordingSettings(recordingSettings),
-		  m_videoComposition(videoComposition)
+		  m_recordingSettings(recordingSettings)
 	{
 	}
 
@@ -301,6 +317,11 @@ public:
 
 	virtual void
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override
+	{
+		return m_audioTracks;
+	}
 
 	static std::shared_ptr<StreamElementsCustomRecordingOutput>
 	Create(CefRefPtr<CefValue> input);

--- a/streamelements/StreamElementsOutputManager.cpp
+++ b/streamelements/StreamElementsOutputManager.cpp
@@ -5,19 +5,25 @@
 #define RecordingOutput StreamElementsOutputBase::RecordingOutput
 
 StreamElementsOutputManager::StreamElementsOutputManager(
-	std::shared_ptr<StreamElementsVideoCompositionManager> compositionManager)
-	: m_compositionManager(compositionManager)
+	std::shared_ptr<StreamElementsVideoCompositionManager>
+		videoCompositionManager,
+	std::shared_ptr<StreamElementsAudioCompositionManager>
+		audioCompositionManager)
+	: m_videoCompositionManager(videoCompositionManager), m_audioCompositionManager(audioCompositionManager)
 {
-	auto nativeStreamingOutput = std::make_shared<StreamElementsObsNativeStreamingOutput>(
+	auto nativeStreamingOutput = std::make_shared<
+		StreamElementsObsNativeStreamingOutput>(
 		"default", "OBS Native Streaming",
-		m_compositionManager->GetObsNativeVideoComposition());
+		m_videoCompositionManager->GetObsNativeVideoComposition(),
+		m_audioCompositionManager->GetObsNativeAudioComposition());
 
 	m_map[StreamingOutput][nativeStreamingOutput->GetId()] = nativeStreamingOutput;
 
 	auto nativeRecordingOutput =
 		std::make_shared<StreamElementsObsNativeRecordingOutput>(
 			"default", "OBS Native Recording",
-			m_compositionManager->GetObsNativeVideoComposition());
+		m_videoCompositionManager->GetObsNativeVideoComposition(),
+		m_audioCompositionManager->GetObsNativeAudioComposition());
 
 	m_map[RecordingOutput][nativeRecordingOutput->GetId()] = nativeRecordingOutput;
 }

--- a/streamelements/StreamElementsOutputManager.hpp
+++ b/streamelements/StreamElementsOutputManager.hpp
@@ -2,6 +2,7 @@
 
 #include "StreamElementsOutput.hpp"
 #include "StreamElementsVideoCompositionManager.hpp"
+#include "StreamElementsAudioCompositionManager.hpp"
 
 class StreamElementsOutputManager {
 private:
@@ -9,11 +10,17 @@ private:
 	std::map<StreamElementsOutputBase::ObsOutputType,
 		 std::map<std::string, std::shared_ptr<StreamElementsOutputBase>>>
 		m_map;
-	std::shared_ptr<StreamElementsVideoCompositionManager> m_compositionManager;
+	std::shared_ptr<StreamElementsVideoCompositionManager>
+		m_videoCompositionManager;
+	std::shared_ptr<StreamElementsAudioCompositionManager>
+		m_audioCompositionManager;
 
 public:
 	StreamElementsOutputManager(
-		std::shared_ptr<StreamElementsVideoCompositionManager> compositionManager);
+		std::shared_ptr<StreamElementsVideoCompositionManager>
+			videoCompositionManager,
+		std::shared_ptr<StreamElementsAudioCompositionManager>
+			audioCompositionManager);
 	~StreamElementsOutputManager();
 
 public:

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -423,3 +423,16 @@ SerializeObsEncoderProperties(std::string id, obs_data_t *settings = nullptr);
 
 uint32_t GetInt32FromAlignmentId(std::string alignment);
 std::string GetAlignmentIdFromInt32(uint32_t a);
+
+/* ========================================================= */
+
+void SerializeObsTransition(std::string videoCompositionId, obs_source_t *t,
+			    int durationMilliseconds,
+			    CefRefPtr<CefValue> &output);
+
+obs_source_t *GetExistingObsTransition(std::string lookupId);
+
+bool DeserializeObsTransition(CefRefPtr<CefValue> input, obs_source_t **t,
+			      int *durationMilliseconds, bool useExisting);
+
+CefRefPtr<CefDictionaryValue> SerializeObsEncoder(obs_encoder_t *e);

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -121,7 +121,7 @@ public:
 	void operator=(obs_graphics_guard & other) = delete;
 };
 
-static void SerializeObsEncoders(StreamElementsVideoCompositionBase* composition, CefRefPtr<CefDictionaryValue>& root)
+static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* composition, CefRefPtr<CefDictionaryValue>& root)
 {
 	auto info = composition->GetCompositionInfo(nullptr);
 
@@ -652,7 +652,7 @@ void StreamElementsObsNativeVideoComposition::SerializeComposition(
 
 	root->SetDictionary("videoFrame", videoFrame);
 
-	SerializeObsEncoders(this, root);
+	SerializeObsVideoEncoders(this, root);
 
 	output->SetDictionary(root);
 }
@@ -899,7 +899,7 @@ void StreamElementsCustomVideoComposition::SerializeComposition(
 
 	root->SetDictionary("videoFrame", videoFrame);
 
-	SerializeObsEncoders(this, root);
+	SerializeObsVideoEncoders(this, root);
 
 	output->SetDictionary(root);
 }

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -121,219 +121,6 @@ public:
 	void operator=(obs_graphics_guard & other) = delete;
 };
 
-static void SerializeObsTransition(std::string videoCompositionId, obs_source_t* t, int durationMilliseconds, CefRefPtr<CefValue> &output)
-{
-	output->SetNull();
-
-	if (!t)
-		return;
-
-	auto d = CefDictionaryValue::Create();
-
-	std::string id = obs_source_get_id(t);
-	d->SetString("class", id);
-	d->SetString("videoCompositionId", id);
-
-	auto settings = obs_source_get_settings(t);
-
-	auto props = obs_get_source_properties(id.c_str());
-	auto propsValue = CefValue::Create();
-	obs_properties_apply_settings(props, settings);
-	SerializeObsProperties(props, propsValue);
-	obs_properties_destroy(props);
-
-	auto settingsValue = SerializeObsData(settings);
-
-	obs_data_release(settings);
-
-	d->SetValue("properties", propsValue);
-	d->SetValue("settings", settingsValue);
-
-	auto defaultsData = obs_get_source_defaults(id.c_str());
-	d->SetValue("defaultSettings", SerializeObsData(defaultsData));
-	obs_data_release(defaultsData);
-
-	d->SetString("label", obs_source_get_display_name(id.c_str()));
-
-	uint32_t cx, cy;
-	obs_transition_get_size(t, &cx, &cy);
-	d->SetInt("width", cx);
-	d->SetInt("height", cy);
-
-	auto scaleType = obs_transition_get_scale_type(t);
-	switch (scaleType) {
-	case OBS_TRANSITION_SCALE_MAX_ONLY:
-		d->SetString("scaleType", "maxOnly");
-		break;
-	case OBS_TRANSITION_SCALE_ASPECT:
-		d->SetString("scaleType", "aspect");
-		break;
-	case OBS_TRANSITION_SCALE_STRETCH:
-		d->SetString("scaleType", "stretch");
-		break;
-	default:
-		d->SetString("scaleType", "unknown");
-		break;
-	}
-
-	d->SetString("alignment",
-		     GetAlignmentIdFromInt32(obs_transition_get_alignment(t)));
-
-	d->SetInt("durationMilliseconds", durationMilliseconds);
-
-	output->SetDictionary(d);
-}
-
-static obs_source_t* GetExistingObsTransition(std::string lookupId)
-{
-	obs_source_t *result = nullptr;
-
-	obs_frontend_source_list l = {};
-	obs_frontend_get_transitions(&l);
-
-	for (size_t idx = 0; idx < l.sources.num; ++idx) {
-		auto source = l.sources.array[idx];
-
-		std::string id = obs_source_get_id(source);
-
-		if (id == lookupId) {
-			result = source;
-
-			obs_source_addref(result);
-
-			break;
-		}
-	}
-
-	obs_frontend_source_list_free(&l);
-
-	return result;
-}
-
-bool DeserializeObsTransition(CefRefPtr<CefValue> input, obs_source_t **t, int *durationMilliseconds, bool useExisting)
-{
-	if (!input.get() || input->GetType() != VTYPE_DICTIONARY)
-		return false;
-
-	auto d = input->GetDictionary();
-
-	if (!d->HasKey("class") || d->GetType("class") != VTYPE_STRING)
-		return false;
-
-	std::string id = d->GetString("class");
-
-	if (useExisting) {
-		*t = GetExistingObsTransition(id);
-
-		if (!*t)
-			return false;
-	} else {
-		*t = obs_source_create_private(id.c_str(), id.c_str(),
-					       nullptr);
-	}
-
-	if (d->HasKey("settings")) {
-		auto settings = obs_data_create();
-
-		DeserializeObsData(d->GetValue("settings"), settings);
-
-		obs_source_update(*t, settings);
-
-		obs_data_release(settings);
-	}
-
-	if (d->HasKey("width") &&
-	    d->GetType("width") == VTYPE_INT && d->HasKey("height") && d->GetType("height") == VTYPE_INT) {
-		int cx = d->GetInt("width");
-		int cy = d->GetInt("height");
-
-		if (cx <= 0 || cy <= 0)
-			return false;
-
-		obs_transition_set_size(*t, cx, cy);
-	}
-
-	if (d->HasKey("scaleType") && d->GetType("scaleType") == VTYPE_STRING) {
-		auto scaleType = d->GetString("scaleType");
-
-		if (scaleType == "maxOnly") {
-			obs_transition_set_scale_type(
-				*t, OBS_TRANSITION_SCALE_MAX_ONLY);
-		} else if (scaleType == "aspect") {
-			obs_transition_set_scale_type(
-				*t, OBS_TRANSITION_SCALE_ASPECT);
-		} else if (scaleType == "stretch") {
-			obs_transition_set_scale_type(
-				*t, OBS_TRANSITION_SCALE_STRETCH);
-		} else {
-			return false;
-		}
-	}
-
-	if (d->HasKey("alignment") && d->GetType("alignment") == VTYPE_STRING) {
-		obs_transition_set_alignment(
-			*t, GetInt32FromAlignmentId(
-				    d->GetString("alignment").c_str()));
-	}
-
-	if (d->HasKey("durationMilliseconds") &&
-	    d->GetType("durationMilliseconds") == VTYPE_INT) {
-		*durationMilliseconds = d->GetInt("durationMilliseconds");
-	} else {
-		*durationMilliseconds = 300; // OBS FE default
-	}
-
-	return true;
-}
-
-static CefRefPtr<CefDictionaryValue> SerializeObsEncoder(obs_encoder_t *e)
-{
-	auto result = CefDictionaryValue::Create();
-
-	auto id = obs_encoder_get_id(e);
-	result->SetString("class", id);
-
-	auto name = obs_encoder_get_name(e);
-	result->SetString("name", name ? name : id);
-
-	auto displayName = obs_encoder_get_display_name(obs_encoder_get_id(e));
-	result->SetString("label",
-			  displayName ? displayName : (name ? name : id));
-
-	auto codec = obs_encoder_get_codec(e);
-
-	if (codec)
-		result->SetString("codec", obs_encoder_get_codec(e));
-	else
-		result->SetNull("codec");
-
-	if (obs_encoder_get_type(e) == OBS_ENCODER_VIDEO) {
-		result->SetInt("width", obs_encoder_get_width(e));
-		result->SetInt("height", obs_encoder_get_height(e));
-	}
-
-	auto settings = obs_encoder_get_settings(e);
-
-	result->SetValue("settings",
-			 CefParseJSON(obs_data_get_json(settings),
-				      JSON_PARSER_ALLOW_TRAILING_COMMAS));
-
-	result->SetValue("properties", SerializeObsEncoderProperties(obs_encoder_get_id(e), settings));
-
-	auto defaultSettings = obs_encoder_get_defaults(e);
-
-	if (defaultSettings) {
-		result->SetValue("defaultSettings",
-			    SerializeObsData(defaultSettings));
-
-		obs_data_release(defaultSettings);
-	}
-
-	obs_data_release(settings);
-
-	return result;
-}
-
 static void SerializeObsEncoders(StreamElementsVideoCompositionBase* composition, CefRefPtr<CefDictionaryValue>& root)
 {
 	auto info = composition->GetCompositionInfo(nullptr);
@@ -631,12 +418,12 @@ void StreamElementsVideoCompositionBase::DeserializeTransition(
 class StreamElementsDefaultVideoCompositionInfo
 	: public StreamElementsVideoCompositionBase::CompositionInfo {
 private:
-	StreamElementsCompositionEventListener *m_listener;
+	StreamElementsVideoCompositionEventListener *m_listener;
 
 public:
 	StreamElementsDefaultVideoCompositionInfo(
 		std::shared_ptr<StreamElementsVideoCompositionBase> owner,
-		StreamElementsCompositionEventListener* listener)
+		StreamElementsVideoCompositionEventListener* listener)
 		: StreamElementsVideoCompositionBase::CompositionInfo(
 			  owner, listener),
 		  m_listener(listener)
@@ -720,7 +507,7 @@ public:
 std::shared_ptr<
 	StreamElementsVideoCompositionBase::CompositionInfo>
 StreamElementsObsNativeVideoComposition::GetCompositionInfo(
-	StreamElementsCompositionEventListener* listener)
+	StreamElementsVideoCompositionEventListener* listener)
 {
 	return std::make_shared<StreamElementsDefaultVideoCompositionInfo>(
 		shared_from_this(), listener);
@@ -889,7 +676,7 @@ obs_scene_t* StreamElementsObsNativeVideoComposition::GetCurrentScene()
 class StreamElementsCustomVideoCompositionInfo
 	: public StreamElementsVideoCompositionBase::CompositionInfo {
 private:
-	StreamElementsCompositionEventListener *m_listener;
+	StreamElementsVideoCompositionEventListener *m_listener;
 
 	video_t *m_video = nullptr;
 	obs_encoder_t *m_streamingVideoEncoder = nullptr;
@@ -901,7 +688,7 @@ private:
 public:
 	StreamElementsCustomVideoCompositionInfo(
 		std::shared_ptr<StreamElementsVideoCompositionBase> owner,
-		StreamElementsCompositionEventListener *listener,
+		StreamElementsVideoCompositionEventListener *listener,
 		video_t *video, uint32_t baseWidth, uint32_t baseHeight,
 		obs_encoder_t *streamingVideoEncoder,
 		obs_encoder_t *recordingVideoEncoder, obs_view_t *videoView)
@@ -1076,7 +863,7 @@ StreamElementsCustomVideoComposition::~StreamElementsCustomVideoComposition()
 
 std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
 StreamElementsCustomVideoComposition::GetCompositionInfo(
-	StreamElementsCompositionEventListener *listener)
+	StreamElementsVideoCompositionEventListener *listener)
 {
 	std::lock_guard<decltype(m_mutex)> lock(m_mutex);
 
@@ -1209,9 +996,8 @@ StreamElementsCustomVideoComposition::Create(
 
 			recordingVideoEncoderSettings = obs_data_create();
 
-			if (DeserializeObsData(
-				    encoderRoot->GetValue("settings"),
-				    streamingVideoEncoderSettings)) {
+			if (DeserializeObsData(encoderRoot->GetValue("settings"),
+					       recordingVideoEncoderSettings)) {
 				try {
 					result->SetRecordingEncoder(
 						recordingVideoEncoderId,

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -136,19 +136,6 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 		0, SerializeObsEncoder(streamingVideoEncoder));
 	root->SetList("streamingVideoEncoders", streamingVideoEncoders);
 
-	auto streamingAudioEncoders = CefListValue::Create();
-	for (size_t i = 0;; ++i) {
-		auto encoder = info->GetStreamingAudioEncoder(i);
-
-		if (!encoder)
-			break;
-
-		streamingAudioEncoders->SetDictionary(
-			i, SerializeObsEncoder(encoder));
-	}
-
-	root->SetList("streamingAudioEncoders", streamingAudioEncoders);
-
 	// Recording
 
 	auto recordingVideoEncoder = info->GetRecordingVideoEncoder();
@@ -162,24 +149,6 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 
 		root->SetList("recordingVideoEncoders", recordingVideoEncoders);
 	}
-
-	bool hasDifferentAudioEncoder = false;
-	auto recordingAudioEncoders = CefListValue::Create();
-	for (size_t i = 0;; ++i) {
-		auto encoder = info->GetRecordingAudioEncoder(i);
-
-		if (!encoder)
-			break;
-
-		if (encoder != info->GetStreamingAudioEncoder(i))
-			hasDifferentAudioEncoder = true;
-
-		recordingAudioEncoders->SetDictionary(
-			i, SerializeObsEncoder(encoder));
-	}
-
-	if (hasDifferentAudioEncoder)
-		root->SetList("recordingAudioEncoders", recordingAudioEncoders);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -445,16 +414,6 @@ public:
 		return result;
 	}
 
-	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index) {
-		auto output = obs_frontend_get_streaming_output();
-
-		auto result = obs_output_get_audio_encoder(output, index);
-
-		obs_output_release(output);
-
-		return result;
-	}
-
 	virtual obs_encoder_t* GetRecordingVideoEncoder() {
 		auto output = obs_frontend_get_recording_output();
 
@@ -472,18 +431,7 @@ public:
 		return result;
 	}
 
-	virtual obs_encoder_t* GetRecordingAudioEncoder(size_t index) {
-		auto output = obs_frontend_get_recording_output();
-
-		auto result = obs_output_get_audio_encoder(output, index);
-
-		obs_output_release(output);
-
-		return result;
-	}
-
 	virtual video_t *GetVideo() { return obs_get_video(); }
-	virtual audio_t *GetAudio() { return obs_get_audio(); }
 
 	virtual void GetVideoBaseDimensions(uint32_t *videoWidth,
 					    uint32_t *videoHeight)
@@ -714,35 +662,12 @@ public:
 		return m_streamingVideoEncoder;
 	}
 
-	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index)
-	{
-		auto output = obs_frontend_get_streaming_output();
-
-		auto result = obs_output_get_audio_encoder(output, index);
-
-		obs_output_release(output);
-
-		return result;
-	}
-
 	virtual obs_encoder_t *GetRecordingVideoEncoder()
 	{
 		return m_recordingVideoEncoder ? m_recordingVideoEncoder : m_streamingVideoEncoder;
 	}
 
-	virtual obs_encoder_t *GetRecordingAudioEncoder(size_t index)
-	{
-		auto output = obs_frontend_get_streaming_output();
-
-		auto result = obs_output_get_audio_encoder(output, index);
-
-		obs_output_release(output);
-
-		return result;
-	}
-
 	virtual video_t *GetVideo() { return m_video; }
-	virtual audio_t *GetAudio() { return obs_get_audio(); }
 
 	virtual void GetVideoBaseDimensions(uint32_t *videoWidth,
 					    uint32_t *videoHeight)

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -48,15 +48,10 @@ public:
 		virtual bool IsObsNative() = 0;
 
 		virtual obs_encoder_t *GetStreamingVideoEncoder() = 0;
-		virtual obs_encoder_t *
-		GetStreamingAudioEncoder(size_t index) = 0;
 
 		virtual obs_encoder_t *GetRecordingVideoEncoder() = 0;
-		virtual obs_encoder_t *
-		GetRecordingAudioEncoder(size_t index) = 0;
 
 		virtual video_t *GetVideo() = 0;
-		virtual audio_t *GetAudio() = 0;
 
 		virtual void GetVideoBaseDimensions(uint32_t *videoWidth,
 						    uint32_t *videoHeight) = 0;

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -7,10 +7,10 @@
 #include "StreamElementsUtils.hpp"
 #include "StreamElementsScenesListWidgetManager.hpp"
 
-class StreamElementsCompositionEventListener {
+class StreamElementsVideoCompositionEventListener {
 public:
-	StreamElementsCompositionEventListener() {}
-	~StreamElementsCompositionEventListener() {}
+	StreamElementsVideoCompositionEventListener() {}
+	~StreamElementsVideoCompositionEventListener() {}
 
 public:
 	//virtual void StopOutputRequested();
@@ -21,12 +21,12 @@ public:
 	class CompositionInfo {
 	private:
 		std::shared_ptr<StreamElementsVideoCompositionBase> m_owner;
-		StreamElementsCompositionEventListener *m_listener;
+		StreamElementsVideoCompositionEventListener *m_listener;
 
 	public:
 		CompositionInfo(
 			std::shared_ptr<StreamElementsVideoCompositionBase> owner,
-			StreamElementsCompositionEventListener* listener)
+			StreamElementsVideoCompositionEventListener* listener)
 			: m_owner(owner), m_listener(listener)
 		{
 			m_owner->AddRef();
@@ -93,7 +93,7 @@ public:
 	}
 
 	virtual std::shared_ptr<CompositionInfo>
-		GetCompositionInfo(StreamElementsCompositionEventListener* listener) = 0;
+		GetCompositionInfo(StreamElementsVideoCompositionEventListener* listener) = 0;
 
 private:
 	std::string m_id;
@@ -289,7 +289,7 @@ public:
 
 	virtual std::shared_ptr<
 		StreamElementsVideoCompositionBase::CompositionInfo>
-		GetCompositionInfo(StreamElementsCompositionEventListener* listener);
+		GetCompositionInfo(StreamElementsVideoCompositionEventListener* listener);
 
 	virtual bool CanRemove() { return false; }
 
@@ -381,7 +381,7 @@ public:
 
 	virtual std::shared_ptr<
 		StreamElementsVideoCompositionBase::CompositionInfo>
-	GetCompositionInfo(StreamElementsCompositionEventListener *listener);
+	GetCompositionInfo(StreamElementsVideoCompositionEventListener *listener);
 
 	virtual void SerializeComposition(CefRefPtr<CefValue> &output);
 

--- a/streamelements/StreamElementsVideoCompositionViewWidget.hpp
+++ b/streamelements/StreamElementsVideoCompositionViewWidget.hpp
@@ -8,7 +8,7 @@
 
 #include "canvas-scan.hpp"
 
-class StreamElementsVideoCompositionViewWidget : public QWidget, public StreamElementsCompositionEventListener
+class StreamElementsVideoCompositionViewWidget : public QWidget, public StreamElementsVideoCompositionEventListener
 {
 public:
 	class VisualElementBase {


### PR DESCRIPTION
Add API Methods:

- getAllAudioCompositions
- removeAudioCompositionsByIds
- addAudioComposition
- setAudioCompositionProperties

Add Data Structures:

- AudioCompositionInfo

Modify Data Structures:

- OutputInfo (add `audioCompositionId`, `isObsNativeAudioComposition`, `audioTracks`)
