### PR TITLE
Make audio in custom canvases work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ set(obs-streamelements-core_SOURCES
 	deps/cef-stub/cef_value_json.cpp
 	deps/cef-stub/cef_value_list.cpp
 	streamelements/Version.cpp
+	streamelements/audio-wrapper-source.c
 	streamelements/StreamElementsAsyncTaskQueue.cpp
 	streamelements/StreamElementsBrowserWidget.cpp
 	streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -273,6 +274,7 @@ set(obs-streamelements-core_HEADERS
 	streamelements/deps/utf8/cpp17.h
 	streamelements/Version.hpp
 	streamelements/Version.generated.hpp
+	streamelements/audio-wrapper-source.h
 	streamelements/StreamElementsUtils.hpp
 	streamelements/StreamElementsAsyncTaskQueue.hpp
 	streamelements/StreamElementsBrowserWidget.hpp

--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -16,6 +16,9 @@
 #include "obs-websocket-api/obs-websocket-api.h"
 #include "cef-headers.hpp"
 
+#include "streamelements/audio-wrapper-source.h"
+#include "streamelements/Version.generated.hpp"
+
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-streamelements-core", "en-US")
 MODULE_EXPORT const char *obs_module_description(void)
@@ -36,7 +39,10 @@ using namespace json11;
 
 bool obs_module_load(void)
 {
-	blog(LOG_INFO, "[obs-streamelements-core]: Version %s", "unknown");
+	blog(LOG_INFO, "[obs-streamelements-core]: Version %lu",
+	     STREAMELEMENTS_PLUGIN_VERSION);
+
+	obs_register_source(&audio_wrapper_source);
 
 	return true;
 }

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -332,6 +332,8 @@ private:
 	uint32_t m_baseWidth;
 	uint32_t m_baseHeight;
 
+	obs_source_t *m_audioWrapperSource = nullptr;
+
 public:
 	// ctor only usable by this class
 	StreamElementsCustomVideoComposition(

--- a/streamelements/audio-wrapper-source.c
+++ b/streamelements/audio-wrapper-source.c
@@ -1,0 +1,118 @@
+
+#include <obs-module.h>
+#include "audio-wrapper-source.h"
+
+const char *audio_wrapper_get_name(void *type_data)
+{
+	UNUSED_PARAMETER(type_data);
+	return "transition_audio_wrapper";
+}
+
+static obs_source_t* null_target(void* param) {
+	return NULL;
+}
+
+void *audio_wrapper_create(obs_data_t *settings, obs_source_t *source)
+{
+	UNUSED_PARAMETER(settings);
+	struct audio_wrapper_info *audio_wrapper =
+		bzalloc(sizeof(struct audio_wrapper_info));
+	audio_wrapper->source = source;
+	audio_wrapper->target = null_target;
+	return audio_wrapper;
+}
+
+void audio_wrapper_destroy(void *data)
+{
+	bfree(data);
+}
+
+bool audio_wrapper_render(void *data, uint64_t *ts_out,
+			  struct obs_source_audio_mix *audio, uint32_t mixers,
+			  size_t channels, size_t sample_rate)
+{
+	UNUSED_PARAMETER(sample_rate);
+	struct audio_wrapper_info *aw = (struct audio_wrapper_info *)data;
+	obs_source_t *source = aw->target(aw->param);
+	if (!source)
+		return false;
+
+	uint64_t timestamp = obs_source_get_audio_timestamp(source);
+	if (!timestamp) {
+		obs_source_release(source);
+		return false;
+	}
+
+	/*
+	if (!aw->mixers) {
+		*ts_out = timestamp;
+		obs_source_release(source);
+		return true;
+	}
+	mixers &= aw->mixers(aw->param);
+	if (mixers == 0) {
+		*ts_out = timestamp;
+		obs_source_release(source);
+		return true;
+	}
+	*/
+
+	struct obs_source_audio_mix child_audio;
+	obs_source_get_audio_mix(source, &child_audio);
+	for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
+		if ((mixers & (1 << mix)) == 0)
+			continue;
+
+		for (size_t ch = 0; ch < channels; ch++) {
+			float *out = audio->output[mix].data[ch];
+			float *in = child_audio.output[mix].data[ch];
+			float *end = in + AUDIO_OUTPUT_FRAMES;
+			while (in < end)
+				*(out++) += *(in++);
+		}
+	}
+	*ts_out = timestamp;
+	obs_source_release(source);
+	return true;
+}
+
+static void audio_wrapper_enum_sources(void *data,
+				       obs_source_enum_proc_t enum_callback,
+				       void *param, bool active)
+{
+	UNUSED_PARAMETER(active);
+	struct audio_wrapper_info *aw = (struct audio_wrapper_info *)data;
+	obs_source_t *source = aw->target(aw->param);
+	if (!source)
+		return;
+
+	enum_callback(aw->source, source, param);
+
+	obs_source_release(source);
+}
+
+void audio_wrapper_enum_active_sources(void *data,
+				       obs_source_enum_proc_t enum_callback,
+				       void *param)
+{
+	audio_wrapper_enum_sources(data, enum_callback, param, true);
+}
+
+void audio_wrapper_enum_all_sources(void *data,
+				    obs_source_enum_proc_t enum_callback,
+				    void *param)
+{
+	audio_wrapper_enum_sources(data, enum_callback, param, false);
+}
+
+struct obs_source_info audio_wrapper_source = {
+	.id = AUDIO_WRAPPER_SOURCE_ID,
+	.type = OBS_SOURCE_TYPE_SCENE,
+	.output_flags = OBS_SOURCE_COMPOSITE | OBS_SOURCE_CAP_DISABLED,
+	.get_name = audio_wrapper_get_name,
+	.create = audio_wrapper_create,
+	.destroy = audio_wrapper_destroy,
+	.audio_render = audio_wrapper_render,
+	.enum_active_sources = audio_wrapper_enum_active_sources,
+	.enum_all_sources = audio_wrapper_enum_all_sources,
+};

--- a/streamelements/audio-wrapper-source.h
+++ b/streamelements/audio-wrapper-source.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <obs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct audio_wrapper_info {
+	obs_source_t *source;
+	void *param;
+	obs_source_t *(*target)(void *param);
+	uint32_t (*mixers)(void *param);
+};
+
+extern struct obs_source_info audio_wrapper_source;
+
+#define AUDIO_WRAPPER_SOURCE_ID "streamelements_transition_audio_wrapper_source"
+
+#ifdef __cplusplus
+};
+#endif


### PR DESCRIPTION
This requires building an audio root transition wrapper source, which only extracts audio from the transition, and assigning it to an available output channel.

We have to do this, since if we assign the root transition to the output channel, it will overlay the video in the main, native OBS canvas.