### PR TITLE
Safer properties retrieval when enumerating existing sources

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -1353,7 +1353,8 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 
 	API_HANDLER_BEGIN("getAllExistingVideoInputSources");
 	{
-		SerializeExistingInputSources(result, OBS_SOURCE_VIDEO);
+		SerializeExistingInputSources(result, OBS_SOURCE_VIDEO,
+					      {OBS_SOURCE_TYPE_INPUT});
 	}
 	API_HANDLER_END();
 

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -2815,7 +2815,13 @@ void StreamElementsObsSceneManager::SerializeSourceClassProperties(
 
 	std::lock_guard<decltype(m_mutex)> guard(m_mutex);
 
-	obs_properties_t *props = obs_get_source_properties(id.c_str());
+	// We need all of this create-destroy dance since some 3rd party source types just do not support obs_get_source_properties :(
+	obs_data_t *settings = obs_data_create();
+	auto source = obs_source_create_private(
+		id.c_str(), CreateGloballyUniqueIdString().c_str(), settings);
+	obs_properties_t *props = obs_source_properties(source);
+	obs_source_release(source);
+	obs_data_release(settings);
 
 	if (!props)
 		return;

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -141,8 +141,9 @@ void SerializeSystemHardwareProperties(CefRefPtr<CefValue> &output);
 /* ========================================================= */
 
 void SerializeAvailableInputSourceTypes(CefRefPtr<CefValue> &output);
-void SerializeExistingInputSources(CefRefPtr<CefValue> &output,
-				   uint32_t requireOutputFlagsMask);
+void SerializeExistingInputSources(
+	CefRefPtr<CefValue> &output, uint32_t requireOutputFlagsMask,
+	std::vector<obs_source_type> requireSourceTypes);
 
 /* ========================================================= */
 


### PR DESCRIPTION
Some sources do not support retrieval of properties by source id (type), since in that case, the argument which is passed to the get_properties source function is NULL.

Sources like Spout and Bongobs Cat Plugin do not support this way of retrieving properties, and throw an exception.

To mitigate this, we only retireve properties for a fully-instantiated source.