### PR TITLE
Refactor scenes and scene items signal handling code

### DIFF
--- a/streamelements/StreamElementsObsSceneManager.hpp
+++ b/streamelements/StreamElementsObsSceneManager.hpp
@@ -237,6 +237,8 @@ private:
 
 	void Clear()
 	{
+		Wait();
+
 		std::unique_lock lock(m_scenes_mutex);
 
 		m_videoCompositionBase = nullptr;

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -909,8 +909,6 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 	m_signalHandlerData = new SESignalHandlerData(nullptr, this);
 
 	add_scene_signals(currentScene, m_signalHandlerData);
-	add_source_signals(obs_scene_get_source(currentScene),
-			   m_signalHandlerData);
 
 	obs_transition_set(m_transition, obs_scene_get_source(currentScene));
 
@@ -1033,8 +1031,7 @@ StreamElementsCustomVideoComposition::~StreamElementsCustomVideoComposition()
 		m_currentScene = nullptr;
 	}
 
-	m_signalHandlerData->Clear();
-	delete m_signalHandlerData;
+	m_signalHandlerData->Release();
 	m_signalHandlerData = nullptr;
 }
 
@@ -1239,7 +1236,6 @@ StreamElementsCustomVideoComposition::AddScene(std::string requestName)
 
 	auto source = obs_scene_get_source(scene);
 
-	add_source_signals(source, m_signalHandlerData);
 	add_scene_signals(scene, m_signalHandlerData);
 
 	{
@@ -1261,7 +1257,6 @@ bool StreamElementsCustomVideoComposition::RemoveScene(obs_scene_t* scene)
 
 			auto source = obs_scene_get_source(scene);
 
-			remove_source_signals(source, m_signalHandlerData);
 			remove_scene_signals(scene, m_signalHandlerData);
 
 			obs_scene_release(scene);
@@ -1430,7 +1425,6 @@ void StreamElementsCustomVideoComposition::HandleObsSceneCollectionCleanup()
 	for (auto scene : scenesToRemove) {
 		auto source = obs_scene_get_source(scene);
 
-		remove_source_signals(source, m_signalHandlerData);
 		remove_scene_signals(scene, m_signalHandlerData);
 
 		obs_source_dec_showing(source);
@@ -1474,8 +1468,6 @@ void StreamElementsCustomVideoComposition::HandleObsSceneCollectionCleanup()
 		}
 
 		add_scene_signals(currentScene, m_signalHandlerData);
-		add_source_signals(obs_scene_get_source(currentScene),
-				   m_signalHandlerData);
 	}
 
 	dispatch_scene_list_changed_event(this);

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -1031,6 +1031,7 @@ StreamElementsCustomVideoComposition::~StreamElementsCustomVideoComposition()
 		m_currentScene = nullptr;
 	}
 
+	m_signalHandlerData->Wait();
 	m_signalHandlerData->Release();
 	m_signalHandlerData = nullptr;
 }
@@ -1474,4 +1475,6 @@ void StreamElementsCustomVideoComposition::HandleObsSceneCollectionCleanup()
 	dispatch_scene_changed_event(this, currentScene);
 
 	dispatch_scenes_reset_end_event(this);
+
+	m_signalHandlerData->Wait();
 }

--- a/streamelements/canvas-scan.hpp
+++ b/streamelements/canvas-scan.hpp
@@ -77,7 +77,7 @@ scanSceneItems(obs_scene_t *scene,
 			}
 
 			if (data->result)
-				data->callback(item, nullptr);
+				data->result = data->callback(item, nullptr);
 
 			return data->result;
 		},


### PR DESCRIPTION
Previously, not all signal handlers had a reference to `SESignalHandler`
context, which holds the video composition, scene manager and relevant
root scene context.

This resulted in limitations and sometimes unpredictable behavior when
processing signals for scene items which are located under Groups, which
are implemented as Scenes themselves internally by OBS.

One of the limitations was that there is no way to resolve a root parent
scene from a scene item which is located under a Group. This caused
all sorts of inconsistencies in JS API event payloads, and sometimes
led to crashes, supposedly due to inconsistencies in OBS internal state.

In addition, there was no way of tracking asynchronous operations
completion - i.e. when asynchronous signal handling code, built to
circumvent deadlocks due to OBS API internal locking shenanigans
has completed running.

This update solves all those issues: all signal handlers now have the
proper root scene context, asynchronous signal handling is tracked and
waited for, and references to `SESignalHandler` are tracked and
accounted for, to make sure that we are not leaking signal handler
registrations.

https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1490737
