### PR TITLE
API 6.1: Added event at the beginning of scene change sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set(obs-streamelements-core_SOURCES
 	streamelements/StreamElementsAudioCompositionManager.cpp
 	streamelements/StreamElementsOutput.cpp
 	streamelements/StreamElementsOutputManager.cpp
+	streamelements/StreamElementsObsActiveSceneTracker.cpp
 	streamelements/deps/StackWalker/StackWalker.cpp
 	streamelements/deps/zip/zip.c
 	streamelements/deps/server/NamedPipesServer.cpp
@@ -337,6 +338,7 @@ set(obs-streamelements-core_HEADERS
 	streamelements/StreamElementsAudioCompositionManager.hpp
 	streamelements/StreamElementsOutput.hpp
 	streamelements/StreamElementsOutputManager.hpp
+	streamelements/StreamElementsObsActiveSceneTracker.hpp
 	streamelements/canvas-config.hpp
 	streamelements/canvas-scan.hpp
 	streamelements/canvas-math.hpp

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -213,6 +213,13 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 
 			if (sourceName) {
 				json11::Json json = json11::Json::object{
+					{"sceneId",
+					 GetIdFromPointer(source)},
+					{"videoCompositionId",
+					 StreamElementsGlobalStateManager::GetInstance()
+						 ->GetVideoCompositionManager()
+						 ->GetObsNativeVideoComposition()
+						 ->GetId()},
 					{"name", sourceName},
 					{"width",
 					 (int)obs_source_get_width(source)},
@@ -438,6 +445,9 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 		std::make_shared<StreamElementsOutputManager>(
 			m_videoCompositionManager, m_audioCompositionManager);
 
+	m_obsActiveSceneTracker =
+		std::make_shared<StreamElementsObsActiveSceneTracker>();
+
 	m_appStateListener = new ApplicationStateListener();
 	m_themeChangeListener = new ThemeChangeListener();
 #ifdef WIN32
@@ -639,6 +649,7 @@ void StreamElementsGlobalStateManager::Shutdown()
 		m_appStateListener = nullptr;
 	}
 
+	m_obsActiveSceneTracker = nullptr;
 	m_analyticsEventsManager = nullptr;
 	m_performanceHistoryTracker = nullptr;
 	m_outputSettingsManager = nullptr;

--- a/streamelements/StreamElementsGlobalStateManager.hpp
+++ b/streamelements/StreamElementsGlobalStateManager.hpp
@@ -31,6 +31,7 @@ struct QCefCookieManager;
 #include "StreamElementsVideoCompositionManager.hpp"
 #include "StreamElementsAudioCompositionManager.hpp"
 #include "StreamElementsOutputManager.hpp"
+#include "StreamElementsObsActiveSceneTracker.hpp"
 
 class StreamElementsGlobalStateManager : public StreamElementsObsAppMonitor {
 private:
@@ -201,6 +202,11 @@ public:
 	{
 		return m_outputManager;
 	}
+	std::shared_ptr<StreamElementsObsActiveSceneTracker>
+		GetObsActiveSceneTracker()
+	{
+		return m_obsActiveSceneTracker;
+	}
 		
 	QMainWindow *mainWindow() { return m_mainWindow; }
 
@@ -282,6 +288,8 @@ private:
 	std::shared_ptr<StreamElementsAudioCompositionManager>
 		m_audioCompositionManager = nullptr;
 	std::shared_ptr<StreamElementsOutputManager> m_outputManager = nullptr;
+	std::shared_ptr<StreamElementsObsActiveSceneTracker>
+		m_obsActiveSceneTracker = nullptr;
 
 private:
 	static std::shared_ptr<

--- a/streamelements/StreamElementsObsActiveSceneTracker.cpp
+++ b/streamelements/StreamElementsObsActiveSceneTracker.cpp
@@ -1,0 +1,156 @@
+#include "StreamElementsObsActiveSceneTracker.hpp"
+#include "StreamElementsMessageBus.hpp"
+#include "StreamElementsGlobalStateManager.hpp"
+
+#include "callback/calldata.h"
+
+static void dispatch_event(std::string name, std::string args)
+{
+	if (!StreamElementsGlobalStateManager::IsInstanceAvailable())
+		return;
+
+	auto apiServer = StreamElementsGlobalStateManager::GetInstance()
+				 ->GetWebsocketApiServer();
+
+	if (!apiServer)
+		return;
+
+	apiServer->DispatchJSEvent("system", name, args);
+
+	std::string externalEventName =
+		name.c_str() + 4; /* remove 'host' prefix */
+	externalEventName[0] =
+		tolower(externalEventName[0]); /* lower case first letter */
+
+	auto msgBus = StreamElementsMessageBus::GetInstance();
+
+	if (!msgBus)
+		return;
+
+	msgBus->NotifyAllExternalEventListeners(
+		StreamElementsMessageBus::DEST_ALL_EXTERNAL,
+		StreamElementsMessageBus::SOURCE_APPLICATION, "OBS",
+		externalEventName,
+		CefParseJSON(args, JSON_PARSER_ALLOW_TRAILING_COMMAS));
+}
+
+StreamElementsObsActiveSceneTracker::StreamElementsObsActiveSceneTracker()
+{
+	UpdateTransition();
+
+	obs_frontend_add_event_callback(handle_obs_frontend_event, this);
+}
+
+StreamElementsObsActiveSceneTracker::~StreamElementsObsActiveSceneTracker()
+{
+	obs_frontend_remove_event_callback(handle_obs_frontend_event, this);
+
+	ClearTransition();
+}
+
+void StreamElementsObsActiveSceneTracker::handle_obs_frontend_event(
+	enum obs_frontend_event event,
+	void* data)
+{
+	SEAsyncCallContextMarker asyncMarker(__FILE__, __LINE__);
+
+	auto self =
+		static_cast<StreamElementsObsActiveSceneTracker *>(data);
+
+	switch (event)
+	{
+	case OBS_FRONTEND_EVENT_TRANSITION_CHANGED:
+		self->UpdateTransition();
+		break;
+
+	case OBS_FRONTEND_EVENT_PROFILE_CHANGED:
+	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED:
+		self->UpdateTransition();
+		break;
+	}
+}
+
+void StreamElementsObsActiveSceneTracker::ClearTransition()
+{
+	if (m_currentTransition) {
+		auto handler =
+			obs_source_get_signal_handler(m_currentTransition);
+
+		signal_handler_disconnect(handler, "transition_start",
+					  handle_transition_start, this);
+
+		obs_source_release(m_currentTransition);
+
+		m_currentTransition = nullptr;
+	}
+}
+
+void StreamElementsObsActiveSceneTracker::UpdateTransition()
+{
+	ClearTransition();
+
+	m_currentTransition = obs_frontend_get_current_transition();
+
+	if (!m_currentTransition)
+		return;
+
+	auto handler = obs_source_get_signal_handler(m_currentTransition);
+
+	signal_handler_connect(handler, "transition_start",
+			       handle_transition_start, this);
+}
+
+void StreamElementsObsActiveSceneTracker::handle_transition_start(
+	void* my_data, calldata_t* cd)
+{
+	SEAsyncCallContextMarker asyncMarker(__FILE__, __LINE__);
+
+	auto self = static_cast<StreamElementsObsActiveSceneTracker *>(my_data);
+	OBSSourceAutoRelease destSource = nullptr;
+
+	//
+	// In case you are wondering what is going on here, here's a discussion around transitions and studio mode
+	//
+	// https://obsproject.com/forum/threads/transition-starting-event.81769/
+	//
+
+	if (obs_frontend_preview_program_mode_active()) {
+		destSource = obs_frontend_get_current_scene();
+	} else {
+		obs_source_t *source =
+			static_cast<obs_source_t *>(calldata_ptr(cd, "source"));
+
+		if (!source)
+			return;
+
+		destSource = obs_transition_get_source(source,
+						       OBS_TRANSITION_SOURCE_B);
+
+		//if (!destSource)
+		//	destSource = obs_transition_get_source(
+		//		source, OBS_TRANSITION_SOURCE_A);
+	}
+
+	if (!destSource)
+		return;
+
+	const char *sourceName = obs_source_get_name(destSource);
+
+	if (sourceName) {
+		json11::Json json = json11::Json::object{
+			{"sceneId", GetIdFromPointer(destSource.Get())},
+			{"videoCompositionId",
+			 StreamElementsGlobalStateManager::GetInstance()
+				 ->GetVideoCompositionManager()
+				 ->GetObsNativeVideoComposition()
+				 ->GetId()},
+			{"name", sourceName},
+			{"width", (int)obs_source_get_width(destSource)},
+			{"height", (int)obs_source_get_height(destSource)}};
+
+		std::string name = "hostActiveSceneChanging";
+		std::string args = json.dump();
+
+		dispatch_event(name, args);
+	}
+}

--- a/streamelements/StreamElementsObsActiveSceneTracker.hpp
+++ b/streamelements/StreamElementsObsActiveSceneTracker.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "obs.h"
+#include "obs.hpp"
+#include "obs-frontend-api.h"
+
+#include "StreamElementsUtils.hpp"
+
+class StreamElementsObsActiveSceneTracker
+{
+public:
+	StreamElementsObsActiveSceneTracker();
+	~StreamElementsObsActiveSceneTracker();
+
+private:
+	static void handle_obs_frontend_event(enum obs_frontend_event event,
+					      void *data);
+
+	static void handle_transition_start(void *my_data, calldata_t *cd);
+
+	void ClearTransition();
+	void UpdateTransition();
+
+private:
+	obs_source_t* m_currentTransition = nullptr;
+};

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -103,6 +103,7 @@ dispatch_scene_changed_event(StreamElementsVideoCompositionBase *self,
 
 	json11::Json json = json11::Json::object{
 		{"name", sourceName},
+		{"sceneId", GetIdFromPointer(source)},
 		{"videoCompositionId", self->GetId()},
 		{"width", (int)obs_source_get_width(source)},
 		{"height", (int)obs_source_get_height(source)}};

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 0
+#define HOST_API_VERSION_MINOR 1
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Add Events:

- `hostActiveSceneChanging`

The only event reported by the OBS front-end which is related to
scene changes, is fired when scene change has completed - i.e.
the transition sequence from scene A to scene B has completed.

A transition can take a long time to complete, based on user
settings. This means that if we want to react to the users'
_intention_ to change scenes instead of a completed transition
sequence, we need a different mechanism.

We implement it by listening to the current OBS transition's
`transition_start` signal, and based on whether we are in OBS
studio mode or not, either query the OBS frontend API for the
current selected Scene (we have to do this because in studio
mode, transition target scenes do not match the ones used in
normal mode), _or_, in non-studio mode, query the current OBS
transition for it's second (target) source.

There still may be edge cases when the transition bar is used
in OBS studio mode, however, they require a deeper product
thought to tackle and are left for a later time.