### PR TITLE
API 6.1: Replay buffer support

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2722,6 +2722,76 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("getAllReplayBufferOutputs");
+	{
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetOutputManager()
+			->SerializeAllOutputs(
+				StreamElementsOutputBase::ReplayBufferOutput,
+				result);
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("addReplayBufferOutput");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetOutputManager()
+				->DeserializeOutput(StreamElementsOutputBase::
+							    ReplayBufferOutput,
+						    args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("removeReplayBufferOutputsByIds");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetOutputManager()
+				->RemoveOutputsByIds(StreamElementsOutputBase::
+							     ReplayBufferOutput,
+						     args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("enableReplayBufferOutputsByIds");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetOutputManager()
+				->EnableOutputsByIds(StreamElementsOutputBase::
+							     ReplayBufferOutput,
+						     args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("disableReplayBufferOutputsByIds");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetOutputManager()
+				->DisableOutputsByIds(
+					StreamElementsOutputBase::
+						ReplayBufferOutput,
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("triggerReplayBufferOutputSaveById");
+	{
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetOutputManager()
+				->TriggerSaveReplayBufferById(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("readScopedStorageJsonItem");
 	{
 		if (args->GetSize()) {

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -485,6 +485,12 @@ StreamElementsCustomAudioComposition::Create(
 		std::rethrow_exception(exception);
 
 	// Recording encoders
+	if (!recordingAudioEncoder.get() ||
+	    recordingAudioEncoder->GetType() != VTYPE_DICTIONARY) {
+		// Default to streaming encoder settings
+		recordingAudioEncoder = streamingAudioEncoder;
+	}
+
 	if (recordingAudioEncoder.get() &&
 	    recordingAudioEncoder->GetType() == VTYPE_DICTIONARY) {
 		std::string recordingAudioEncoderId;

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -170,22 +170,22 @@ void StreamElementsAudioCompositionBase::SetName(std::string name)
 class StreamElementsDefaultAudioCompositionInfo
 	: public StreamElementsAudioCompositionBase::CompositionInfo {
 private:
-	StreamElementsAudioCompositionEventListener *m_listener;
+	StreamElementsAudioCompositionEventListener* m_listener;
 
 public:
 	StreamElementsDefaultAudioCompositionInfo(
 		std::shared_ptr<StreamElementsAudioCompositionBase> owner,
-		StreamElementsAudioCompositionEventListener *listener)
+		StreamElementsAudioCompositionEventListener* listener)
 		: StreamElementsAudioCompositionBase::CompositionInfo(owner,
-								      listener),
-		  m_listener(listener)
+			listener),
+		m_listener(listener)
 	{
 	}
 
 	virtual ~StreamElementsDefaultAudioCompositionInfo() {}
 
 protected:
-	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index)
+	virtual obs_encoder_t* GetStreamingAudioEncoder(size_t index)
 	{
 		if (!obs_frontend_streaming_active())
 			return nullptr;
@@ -202,19 +202,35 @@ protected:
 		return result;
 	}
 
-	virtual obs_encoder_t *GetRecordingAudioEncoder(size_t index)
+	virtual obs_encoder_t* GetRecordingAudioEncoder(size_t index)
 	{
-		if (!obs_frontend_recording_active())
-			return nullptr;
+		obs_encoder_t* result = nullptr;
 
-		auto output = obs_frontend_get_recording_output();
+		if (!result && obs_frontend_recording_active()) {
+			auto output = obs_frontend_get_recording_output();
 
-		if (!output)
-			return nullptr;
+			if (output) {
+				result = obs_output_get_audio_encoder(output,
+					index);
 
-		auto result = obs_output_get_audio_encoder(output, index);
+				obs_output_release(output);
+			}
+		}
 
-		obs_output_release(output);
+		if (!result && obs_frontend_replay_buffer_active()) {
+			auto output = obs_frontend_get_replay_buffer_output();
+
+			if (output) {
+				result = obs_output_get_audio_encoder(output,
+					index);
+
+				obs_output_release(output);
+			}
+		}
+
+		if (!result) {
+				result = GetStreamingAudioEncoder(index);
+		}
 
 		return result;
 	}

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -250,6 +250,7 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 		name = "hostProfileListChanged";
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
+	case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
 		name = "hostExit";
 		break;
 	/*case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:

--- a/streamelements/StreamElementsObsAppMonitor.hpp
+++ b/streamelements/StreamElementsObsAppMonitor.hpp
@@ -36,6 +36,7 @@ private:
 
 		switch (event) {
 		case OBS_FRONTEND_EVENT_EXIT:
+		case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
 			self->OnObsExit();
 			break;
 		}

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -1461,7 +1461,7 @@ static void handle_scene_item_add(void *my_data, calldata_t *cd)
 
 	dispatch_sceneitem_event(my_data, cd, "hostActiveSceneItemAdded",
 				 "hostSceneItemAdded", false);
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 
 	auto source = obs_sceneitem_get_source(sceneitem);
 
@@ -1512,7 +1512,7 @@ static void handle_scene_item_remove(void *my_data, calldata_t *cd)
 
 	dispatch_sceneitem_event(my_data, cd, "hostActiveSceneItemRemoved",
 				 "hostSceneItemRemoved", false);
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 
 	if (!obs_sceneitem_is_group(sceneitem))
 		return;

--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -1142,7 +1142,7 @@ static void handle_scene_item_select(void *my_data, calldata_t *cd)
 		dispatch_sceneitem_event(my_data, cd,
 					 "hostActiveSceneItemSelected",
 					 "hostSceneItemSelected", false);
-		dispatch_scene_update(my_data, cd);
+		dispatch_scene_update(my_data, cd, true);
 	} else {
 		obs_sceneitem_select(sceneitem, false);
 	}
@@ -1162,7 +1162,7 @@ static void handle_scene_item_deselect(void *my_data, calldata_t *cd)
 
 	dispatch_sceneitem_event(my_data, cd, "hostActiveSceneItemUnselected",
 				 "hostSceneItemUnselected", false);
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 
 	if (my_data) {
 		auto sceneManager =
@@ -1180,7 +1180,7 @@ static void handle_scene_item_reorder(void *my_data, calldata_t *cd)
 	dispatch_scene_event(my_data, cd, "hostActiveSceneItemsOrderChanged",
 			     "hostSceneItemOrderChanged");
 
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 
 	if (my_data) {
 		auto sceneManager =
@@ -1198,7 +1198,7 @@ static void handle_scene_item_source_update_props(void *my_data, calldata_t *cd)
 	dispatch_source_event(my_data, cd,
 			      "hostActiveSceneItemPropertiesChanged",
 			      "hostSceneItemPropertiesChanged");
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 }
 
 static void handle_scene_item_source_update_settings(void *my_data,
@@ -1208,7 +1208,7 @@ static void handle_scene_item_source_update_settings(void *my_data,
 
 	dispatch_source_event(my_data, cd, "hostActiveSceneItemSettingsChanged",
 			      "hostSceneItemSettingsChanged");
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 }
 
 static void handle_scene_item_source_rename(void *my_data, calldata_t *cd)
@@ -1217,7 +1217,7 @@ static void handle_scene_item_source_rename(void *my_data, calldata_t *cd)
 
 	dispatch_source_event(my_data, cd, "hostActiveSceneItemRenamed",
 			      "hostSceneItemRenamed");
-	dispatch_scene_update(my_data, cd);
+	dispatch_scene_update(my_data, cd, true);
 }
 
 static void handle_scene_item_source_filter_update_props(void *my_data,

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -58,8 +58,10 @@ static void dispatch_list_change_event(StreamElementsOutputBase *output)
 {
 	if (output->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		DispatchClientJSEvent("hostStreamingOutputListChanged", "null");
-	else
+	else if (output->GetOutputType() == StreamElementsOutputBase::RecordingOutput)
 		DispatchClientJSEvent("hostRecordingOutputListChanged", "null");
+	else
+		DispatchClientJSEvent("hostReplayBufferOutputListChanged", "null");
 }
 
 static void dispatch_event(
@@ -85,8 +87,11 @@ void StreamElementsOutputBase::handle_output_start(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStarted");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStarted");
+	else
+		dispatch_event(self, "hostReplayBufferOutputStarted");
 
 	dispatch_list_change_event(self);
 }
@@ -150,14 +155,20 @@ void StreamElementsOutputBase::handle_output_stop(void *my_data,
 		if (self->GetOutputType() ==
 		    StreamElementsOutputBase::StreamingOutput)
 			dispatch_event(self, "hostStreamingOutputError", args);
-		else
+		else if (self->GetOutputType() ==
+			 StreamElementsOutputBase::RecordingOutput)
 			dispatch_event(self, "hostRecordingOutputError", args);
+		else
+			dispatch_event(self, "hostReplayBufferOutputError", args);
 	}
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStopped");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStopped");
+	else
+		dispatch_event(self, "hostReplayBufferOutputStopped");
 
 	dispatch_list_change_event(self);
 }
@@ -171,8 +182,11 @@ void StreamElementsOutputBase::handle_output_pause(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputPaused");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputPaused");
+	else
+		dispatch_event(self, "hostReplayBufferOutputPaused");
 
 	dispatch_list_change_event(self);
 }
@@ -186,8 +200,11 @@ void StreamElementsOutputBase::handle_output_unpause(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputUnpaused");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputUnpaused");
+	else
+		dispatch_event(self, "hostReplayBufferOutputUnpaused");
 
 	dispatch_list_change_event(self);
 }
@@ -201,8 +218,11 @@ void StreamElementsOutputBase::handle_output_starting(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStarting");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStarting");
+	else
+		dispatch_event(self, "hostReplayBufferOutputStarting");
 
 	dispatch_list_change_event(self);
 }
@@ -216,8 +236,11 @@ void StreamElementsOutputBase::handle_output_stopping(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStopping");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStopping");
+	else
+		dispatch_event(self, "hostReplayBufferOutputStopping");
 
 	dispatch_list_change_event(self);
 }
@@ -231,8 +254,11 @@ void StreamElementsOutputBase::handle_output_activate(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputActivated");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputActivated");
+	else
+		dispatch_event(self, "hostReplayBufferOutputActivated");
 
 	dispatch_list_change_event(self);
 }
@@ -246,8 +272,11 @@ void StreamElementsOutputBase::handle_output_deactivate(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputDeactivated");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputDeactivated");
+	else
+		dispatch_event(self, "hostReplayBufferOutputDeactivated");
 
 	dispatch_list_change_event(self);
 }
@@ -261,8 +290,11 @@ void StreamElementsOutputBase::handle_output_reconnect(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputReconnecting");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputReconnecting");
+	else
+		dispatch_event(self, "hostReplayBufferOutputReconnecting");
 
 	dispatch_list_change_event(self);
 }
@@ -277,8 +309,11 @@ StreamElementsOutputBase::handle_output_reconnect_success(void *my_data,
 
 	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputReconnected");
-	else
+	else if (self->GetOutputType() ==
+		 StreamElementsOutputBase::RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputReconnected");
+	else
+		dispatch_event(self, "hostReplayBufferOutputReconnected");
 
 	dispatch_list_change_event(self);
 }
@@ -337,8 +372,18 @@ void StreamElementsOutputBase::handle_obs_frontend_event(
 			self->Start();
 		break;
 
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
+		if (self->m_obsStateDependency == ReplayBuffer)
+			self->Start();
+		break;
+
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
 		if (self->m_obsStateDependency == Recording)
+			self->Stop();
+		break;
+
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED:
+		if (self->m_obsStateDependency == ReplayBuffer)
 			self->Stop();
 		break;
 
@@ -435,6 +480,10 @@ void StreamElementsOutputBase::SerializeOutput(CefRefPtr<CefValue>& output)
 		break;
 	case RecordingOutput:
 		d->SetString("type", "recording");
+		d->SetValue("recordingSettings", outputSettings);
+		break;
+	case ReplayBufferOutput:
+		d->SetString("type", "replayBuffer");
 		d->SetValue("recordingSettings", outputSettings);
 		break;
 	default:
@@ -1123,7 +1172,7 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 	if (!recordingVideoEncoder &&
 	    videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
-		     "obs-streamelements-core: OBS Native streaming video encoder does not exist yet on recording output '%s'",
+		     "obs-streamelements-core: OBS Native recording video encoder does not exist yet on recording output '%s'",
 		     GetId().c_str());
 
 		SetError(
@@ -1471,4 +1520,541 @@ StreamElementsCustomRecordingOutput::Create(CefRefPtr<CefValue> input)
 	result->SetEnabled(isEnabled);
 
 	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// StreamElementsObsNativeReplayBufferOutput
+////////////////////////////////////////////////////////////////////////////////
+
+bool StreamElementsObsNativeReplayBufferOutput::StartInternal(
+	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
+		videoCompositionInfo,
+	std::shared_ptr<StreamElementsAudioCompositionBase::CompositionInfo>
+		audioCompositionInfo)
+{
+	// NOP: This is managed by the OBS front-end
+
+	ConnectOutputEvents();
+
+	return true;
+}
+
+void StreamElementsObsNativeReplayBufferOutput::StopInternal()
+{
+	// NOP: This is managed by the OBS front-end
+
+	DisconnectOutputEvents();
+}
+
+void StreamElementsObsNativeReplayBufferOutput::SerializeOutputSettings(
+	CefRefPtr<CefValue> &output)
+{
+	auto d = CefDictionaryValue::Create();
+
+	obs_output_t *obs_output = obs_frontend_get_replay_buffer_output();
+
+	obs_data_t *obs_output_settings = obs_output_get_settings(obs_output);
+
+	d->SetString("type", obs_output_get_id(obs_output));
+	d->SetValue("settings", SerializeObsData(obs_output_settings));
+
+	obs_data_release(obs_output_settings);
+
+	obs_output_release(obs_output);
+
+	output->SetDictionary(d);
+}
+
+std::vector<uint32_t>
+StreamElementsObsNativeReplayBufferOutput::GetAudioTracks()
+{
+	std::vector<uint32_t> result;
+
+	const char *mode = config_get_string(obs_frontend_get_profile_config(),
+					     "Output", "Mode");
+	bool advOut = stricmp(mode, "Advanced") == 0;
+
+	int tracks = config_get_int(obs_frontend_get_profile_config(),
+				    advOut ? "AdvOut" : "SimpleOutput",
+				    "RecTracks");
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; ++i) {
+		if (tracks & (1 << i)) {
+			result.push_back(i);
+		}
+	}
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// StreamElementsCustomReplayBufferOutput
+////////////////////////////////////////////////////////////////////////////////
+
+bool StreamElementsCustomReplayBufferOutput::CanDisable()
+{
+	return true;
+}
+
+bool StreamElementsCustomReplayBufferOutput::CanSplitRecordingOutput()
+{
+	OBSOutputAutoRelease output = GetOutput();
+
+	if (!output)
+		return false;
+
+	if (!obs_output_active(output))
+		return false;
+
+	if (!obs_output_paused(output))
+		return false;
+
+	return true;
+}
+
+bool StreamElementsCustomReplayBufferOutput::TriggerSplitRecordingOutput()
+{
+	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
+
+	if (!CanSplitRecordingOutput())
+		return false;
+
+	OBSOutputAutoRelease output = GetOutput();
+
+	proc_handler_t *ph = obs_output_get_proc_handler(output);
+	uint8_t stack[128];
+	calldata cd;
+	calldata_init_fixed(&cd, stack, sizeof(stack));
+	proc_handler_call(ph, "split_file", &cd);
+	bool result = calldata_bool(&cd, "split_file_enabled");
+
+	return result;
+}
+
+bool StreamElementsCustomReplayBufferOutput::StartInternal(
+	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
+		videoCompositionInfo,
+	std::shared_ptr<StreamElementsAudioCompositionBase::CompositionInfo>
+		audioCompositionInfo)
+{
+	if (m_output)
+		return false;
+
+	if (!videoCompositionInfo)
+		return false;
+
+	OBSEncoderAutoRelease recordingVideoEncoder =
+		videoCompositionInfo->GetRecordingVideoEncoderRef();
+
+	if (!recordingVideoEncoder && videoCompositionInfo->IsObsNative()) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: OBS Native recording video encoder does not exist yet on replay buffer output '%s'",
+		     GetId().c_str());
+
+		SetError(
+			"OBS Native recording video encoder does not exist yet");
+
+		auto args = CefDictionaryValue::Create();
+		args->SetString(
+			"reason",
+			"OBS Native recording video encoder does not exist yet");
+
+		dispatch_event(this, "hostReplayBufferOutputError", args);
+		dispatch_event(this, "hostReplayBufferOutputStopped");
+		dispatch_list_change_event(this);
+
+		return false;
+	}
+
+	bool ffmpegOutput =
+		strcmpi(config_get_string(obs_frontend_get_profile_config(),
+					  "AdvOut", "RecType"),
+			"FFmpeg") == 0;
+
+	bool ffmpegRecording =
+		ffmpegOutput &&
+		config_get_bool(obs_frontend_get_profile_config(), "AdvOut",
+				"FFOutputToFile");
+
+	//////////////////////////////////
+	// Parse OBS settings (defaults)
+	//////////////////////////////////
+
+	std::string basePath = "";
+
+	auto advBasePath = config_get_string(
+		obs_frontend_get_profile_config(), "AdvOut",
+		ffmpegRecording ? "FFFilePath" : "RecFilePath");
+	if (advBasePath) {
+		basePath = advBasePath;
+	} else {
+		basePath = config_get_string(obs_frontend_get_profile_config(),
+					     "SimpleOutput", "FilePath");
+	}
+
+	std::string recFormat = config_get_string(
+		obs_frontend_get_profile_config(), "AdvOut",
+		ffmpegRecording ? "FFExtension" : "RecFormat2");
+	std::string filenameFormat =
+		config_get_string(obs_frontend_get_profile_config(), "Output",
+				  "FilenameFormatting");
+	if (!filenameFormat.size())
+		filenameFormat = "Replay %CCYY-%MM-%DD %hh-%mm-%ss";
+
+	filenameFormat = std::string("SE.Live  ") + filenameFormat +
+			 std::string(" ") + GetName() + std::string(".mkv");
+
+	bool overwriteIfExists =
+		config_get_bool(obs_frontend_get_profile_config(), "Output",
+				"OverwriteIfExists");
+	bool noSpace =
+		config_get_bool(obs_frontend_get_profile_config(), "AdvOut",
+				ffmpegRecording ? "FFFileNameWithoutSpace"
+						: "RecFileNameWithoutSpace");
+	bool splitFile = config_get_bool(obs_frontend_get_profile_config(),
+					 "AdvOut", "RecSplitFile");
+
+	auto splitFileType =
+		splitFile ? config_get_string(obs_frontend_get_profile_config(),
+					      "AdvOut", "RecSplitFileType")
+			  : "";
+
+	auto splitFileTime =
+		(strcmpi(splitFileType, "Time") == 0)
+			? config_get_int(obs_frontend_get_profile_config(),
+					 "AdvOut", "RecSplitFileTime")
+			: 0;
+
+	auto splitFileSize =
+		(strcmpi(splitFileType, "Size") == 0)
+			? config_get_int(obs_frontend_get_profile_config(),
+					 "AdvOut", "RecSplitFileSize")
+			: 0;
+
+	splitFile = true; // Always enable file splitting, even if only manual
+
+	//////////////////////////////
+	// m_recordingSettings parse
+	//////////////////////////////
+
+	if (m_recordingSettings->HasKey("settings") &&
+	    m_recordingSettings->GetType("settings") == VTYPE_DICTIONARY) {
+		auto d = m_recordingSettings->GetDictionary("settings");
+
+		if (d->HasKey("fileNameFormat") &&
+		    d->GetType("fileNameFormat") == VTYPE_STRING) {
+			filenameFormat = d->GetString("fileNameFormat");
+		}
+
+		if (d->HasKey("splitAtMaximumMegabytes") &&
+		    d->GetType("splitAtMaximumMegabytes") == VTYPE_INT) {
+			splitFileSize = d->GetInt("splitAtMaximumMegabytes");
+		}
+
+		if (d->HasKey("splitAtMaximumDurationSeconds") &&
+		    d->GetType("splitAtMaximumDurationSeconds") == VTYPE_INT) {
+			splitFileTime =
+				d->GetInt("splitAtMaximumDurationSeconds");
+		}
+
+		if (d->HasKey("overwriteExistingFiles") &&
+		    d->GetType("overwriteExistingFiles") == VTYPE_BOOL) {
+			overwriteIfExists =
+				d->GetBool("overwriteExistingFiles");
+		}
+
+		if (d->HasKey("allowSpacesInFileNames") &&
+		    d->GetType("allowSpacesInFileNames") == VTYPE_BOOL) {
+			noSpace = !d->GetBool("allowSpacesInFileNames");
+		}
+	}
+
+	splitFile = splitFileSize > 0 || splitFileTime > 0;
+
+	////////////////////////////////////////////////
+	// Parse actual filename format and extenstion
+	////////////////////////////////////////////////
+
+	std::string filenameExtension = "mkv";
+	{
+		auto ext = os_get_path_extension(filenameFormat.c_str());
+		if (ext && strlen(ext) > 1) {
+			filenameExtension = (ext + 1);
+
+			filenameFormat = filenameFormat.substr(
+				0, filenameFormat.size() - strlen(ext));
+		}
+	}
+
+	////////////////////////////////////////////////
+	// Setup output settings
+	////////////////////////////////////////////////
+
+	OBSDataAutoRelease settings = obs_data_create();
+
+	//std::string formattedFilename = os_generate_formatted_filename(
+	//	filenameExtension.c_str(), !noSpace, filenameFormat.c_str());
+	//
+	//std::string formattedPath = basePath + "/" + formattedFilename;
+
+	obs_data_set_string(settings, "muxer_settings", "");
+	//obs_data_set_string(settings, "path", formattedPath.c_str());
+
+	obs_data_set_string(settings, "directory", basePath.c_str());
+	obs_data_set_string(settings, "format", filenameFormat.c_str());
+	obs_data_set_string(settings, "extension", filenameExtension.c_str());
+	obs_data_set_bool(settings, "allow_spaces", !noSpace);
+	obs_data_set_bool(settings, "allow_overwrite", overwriteIfExists);
+	obs_data_set_bool(settings, "split_file", true);
+	obs_data_set_int(settings, "max_time_sec", splitFileTime);
+	obs_data_set_int(settings, "max_size_mb", splitFileSize);
+
+	OBSDataAutoRelease hotkeyData = obs_data_create();
+
+	const char *output_type = "replay_buffer";
+
+	m_output = obs_output_create(output_type, GetId().c_str(), settings,
+				     hotkeyData);
+
+	if (m_output) {
+		OBSEncoderAutoRelease recordingVideoEncoder =
+			videoCompositionInfo->GetRecordingVideoEncoderRef();
+
+		obs_output_set_video_encoder(m_output, recordingVideoEncoder);
+
+		size_t audioEncodersCount = 0;
+
+		for (size_t i = 0; i < m_audioTracks.size(); ++i) {
+			OBSEncoderAutoRelease encoder =
+				audioCompositionInfo
+					->GetRecordingAudioEncoderRef(
+						m_audioTracks[i]);
+
+			if (!encoder) {
+				blog(LOG_WARNING,
+				     "obs-streamelements-core: audio encoder for audio track %d does not exist on replay buffer output '%s'",
+				     m_audioTracks[i], GetId().c_str());
+
+				break;
+			}
+
+			obs_output_set_audio_encoder(m_output, encoder, i);
+
+			++audioEncodersCount;
+		}
+
+		if (audioEncodersCount) {
+			ConnectOutputEvents();
+
+			if (obs_output_start(m_output)) {
+				m_videoCompositionInfo = videoCompositionInfo;
+
+				return true;
+			} else {
+				SetErrorIfEmpty("Failed to start output");
+			}
+		} else {
+			blog(LOG_ERROR,
+			     "obs-streamelements-core: no audio encoders were set up on replay buffer output '%s'",
+			     GetId().c_str());
+
+			SetError(
+				"No audio encoders were set up for requested audio tracks");
+		}
+
+		DisconnectOutputEvents();
+
+		obs_output_release(m_output);
+		m_output = nullptr;
+	} else {
+		blog(LOG_ERROR,
+		     "obs-streamelements-core: failed to create replay buffer output '%s' of type '%s'",
+		     GetId().c_str(), output_type);
+
+		SetError("Failed to create output");
+	}
+
+	return false;
+}
+
+void StreamElementsCustomReplayBufferOutput::StopInternal()
+{
+	if (!m_videoCompositionInfo)
+		return;
+
+	if (!m_output)
+		return;
+
+	// obs_output_stop(m_output);
+
+	obs_output_force_stop(m_output);
+
+	DisconnectOutputEvents();
+
+	obs_output_release(m_output);
+	m_output = nullptr;
+}
+
+void StreamElementsCustomReplayBufferOutput::SerializeOutputSettings(
+	CefRefPtr<CefValue> &output)
+{
+	output->SetDictionary(m_recordingSettings);
+}
+
+std::shared_ptr<StreamElementsCustomReplayBufferOutput>
+StreamElementsCustomReplayBufferOutput::Create(CefRefPtr<CefValue> input)
+{
+	if (!input.get())
+		return nullptr;
+
+	if (input->GetType() != VTYPE_DICTIONARY)
+		return nullptr;
+
+	auto rootDict = input->GetDictionary();
+
+	if (!rootDict->HasKey("id") || !rootDict->HasKey("name"))
+		return nullptr;
+
+	if (rootDict->GetType("id") != VTYPE_STRING ||
+	    rootDict->GetType("name") != VTYPE_STRING)
+		return nullptr;
+
+	auto auxData = (rootDict->HasKey("auxiliaryData") &&
+			rootDict->GetType("auxiliaryData") == VTYPE_DICTIONARY)
+			       ? rootDict->GetDictionary("auxiliaryData")
+			       : CefDictionaryValue::Create();
+
+	std::string id = rootDict->GetString("id");
+	std::string name = rootDict->GetString("name");
+	std::string videoCompositionId =
+		(rootDict->HasKey("videoCompositionId") &&
+				 rootDict->GetType("videoCompositionId") ==
+					 VTYPE_STRING
+			 ? rootDict->GetString("videoCompositionId")
+			 : "");
+	std::string audioCompositionId =
+		(rootDict->HasKey("audioCompositionId") &&
+				 rootDict->GetType("audioCompositionId") ==
+					 VTYPE_STRING
+			 ? rootDict->GetString("audioCompositionId")
+			 : "");
+	bool isEnabled = rootDict->HasKey("isEnabled") &&
+					 rootDict->GetType("isEnabled") ==
+						 VTYPE_BOOL
+				 ? rootDict->GetBool("isEnabled")
+				 : true;
+
+	auto videoComposition =
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetVideoCompositionManager()
+			->GetVideoCompositionById(videoCompositionId);
+
+	auto audioComposition =
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetAudioCompositionManager()
+			->GetAudioCompositionById(audioCompositionId);
+
+	auto recordingSettings = CefDictionaryValue::Create();
+
+	if (rootDict->HasKey("recordingSettings") &&
+	    rootDict->GetType("recordingSettings") == VTYPE_DICTIONARY) {
+		recordingSettings =
+			rootDict->GetDictionary("recordingSettings");
+	}
+
+	if (!videoComposition.get() && !videoCompositionId.size()) {
+		videoComposition =
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetVideoCompositionManager()
+				->GetObsNativeVideoComposition();
+	}
+
+	if (!audioComposition.get() && !audioCompositionId.size()) {
+		audioComposition =
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetAudioCompositionManager()
+				->GetObsNativeAudioComposition();
+	}
+
+	if (!videoComposition.get()) {
+		return nullptr;
+	}
+
+	if (!audioComposition.get()) {
+		return nullptr;
+	}
+
+	auto audioTracks = DeserializeAudioTracks(rootDict);
+
+	auto result = std::make_shared<StreamElementsCustomReplayBufferOutput>(
+		id, name, recordingSettings, videoComposition, audioComposition,
+		audioTracks, auxData);
+
+	result->SetEnabled(isEnabled);
+
+	return result;
+}
+
+void StreamElementsCustomReplayBufferOutput::ConnectOutputEvents()
+{
+	StreamElementsOutputBase::ConnectOutputEvents();
+
+	if (!m_output)
+		return;
+
+	auto handler = obs_output_get_signal_handler(m_output);
+
+	signal_handler_connect(handler, "saved", handle_output_saved, this);
+}
+
+void StreamElementsCustomReplayBufferOutput::DisconnectOutputEvents()
+{
+	if (!m_output)
+		return;
+
+	auto handler = obs_output_get_signal_handler(m_output);
+
+	signal_handler_disconnect(handler, "saved", handle_output_saved, this);
+
+	StreamElementsOutputBase::DisconnectOutputEvents();
+}
+
+void StreamElementsCustomReplayBufferOutput::handle_output_saved(
+	void* my_data, calldata_t* cd)
+{
+	auto self =
+		static_cast<StreamElementsCustomReplayBufferOutput *>(my_data);
+
+	if (!self->GetOutput())
+		return;
+
+	auto eventArgs = CefDictionaryValue::Create();
+
+	calldata_t *proc_cd = calldata_create();
+	auto proc_handler = obs_output_get_proc_handler(self->GetOutput());
+	proc_handler_call(proc_handler, "get_last_replay", proc_cd);
+
+	const char *path = nullptr;
+	if (calldata_get_string(proc_cd, "path", &path)) {
+		eventArgs->SetString("filePath", path);
+
+		dispatch_event(self, "hostReplayBufferOutputSavedToLocalFile");
+	}
+
+	calldata_destroy(proc_cd);
+}
+
+bool StreamElementsCustomReplayBufferOutput::TriggerSaveReplayBuffer()
+{
+	if (!IsActive() || !GetOutput())
+		return false;
+
+	calldata_t *cd = calldata_create();
+	auto proc_handler = obs_output_get_proc_handler(GetOutput());
+
+	proc_handler_call(proc_handler, "save", cd);
+
+	calldata_destroy(cd);
+
+	return true;
 }

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -1526,6 +1526,21 @@ StreamElementsCustomRecordingOutput::Create(CefRefPtr<CefValue> input)
 // StreamElementsObsNativeReplayBufferOutput
 ////////////////////////////////////////////////////////////////////////////////
 
+bool StreamElementsObsNativeReplayBufferOutput::CanSaveReplayBuffer()
+{
+	return IsActive() && obs_frontend_replay_buffer_active();
+}
+
+bool StreamElementsObsNativeReplayBufferOutput::TriggerSaveReplayBuffer()
+{
+	if (!CanSaveReplayBuffer())
+		return;
+
+	obs_frontend_replay_buffer_save();
+
+	return true;
+}
+
 bool StreamElementsObsNativeReplayBufferOutput::StartInternal(
 	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
 		videoCompositionInfo,

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -1805,7 +1805,7 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 	obs_data_set_string(settings, "extension", filenameExtension.c_str());
 	obs_data_set_bool(settings, "allow_spaces", !noSpace);
 	obs_data_set_bool(settings, "allow_overwrite", overwriteIfExists);
-	obs_data_set_bool(settings, "split_file", true);
+	obs_data_set_bool(settings, "split_file", false);
 	obs_data_set_int(settings, "max_time_sec", splitFileTime);
 	obs_data_set_int(settings, "max_size_mb", splitFileSize);
 
@@ -2038,7 +2038,7 @@ void StreamElementsCustomReplayBufferOutput::handle_output_saved(
 	if (calldata_get_string(proc_cd, "path", &path)) {
 		eventArgs->SetString("filePath", path);
 
-		dispatch_event(self, "hostReplayBufferOutputSavedToLocalFile");
+		dispatch_event(self, "hostReplayBufferOutputSavedToLocalFile", eventArgs);
 	}
 
 	calldata_destroy(proc_cd);

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -1534,7 +1534,7 @@ bool StreamElementsObsNativeReplayBufferOutput::CanSaveReplayBuffer()
 bool StreamElementsObsNativeReplayBufferOutput::TriggerSaveReplayBuffer()
 {
 	if (!CanSaveReplayBuffer())
-		return;
+		return false;
 
 	obs_frontend_replay_buffer_save();
 

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -33,6 +33,8 @@ static void CleanStopObsOutput(obs_output_t *output, bool forceStop)
 	signal_handler_connect(handler, "stop", handle_signal, &future);
 	signal_handler_connect(handler, "error", handle_signal, &future);
 
+	obs_output_pause(output, true);
+
 	if (forceStop)
 		obs_output_force_stop(output);
 	else
@@ -40,6 +42,12 @@ static void CleanStopObsOutput(obs_output_t *output, bool forceStop)
 
 	while (future.wait_for(std::chrono::milliseconds(10)) ==
 	       std::future_status::timeout) {
+		if (!obs_output_active(output))
+			break;
+
+		if (forceStop)
+			obs_output_force_stop(output);
+
 		QApplication::processEvents();
 	}
 
@@ -1748,7 +1756,7 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 	if (!filenameFormat.size())
 		filenameFormat = "Replay %CCYY-%MM-%DD %hh-%mm-%ss";
 
-	filenameFormat = std::string("SE.Live  ") + filenameFormat +
+	filenameFormat = std::string("SE.Live Replay ") + filenameFormat +
 			 std::string(" ") + GetName() + std::string(".mkv");
 
 	bool overwriteIfExists =

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -428,6 +428,7 @@ void StreamElementsOutputBase::handle_obs_frontend_event(
 		break;
 
 	case OBS_FRONTEND_EVENT_EXIT:
+	case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
 		self->Stop();
 		break;
 	default:
@@ -1649,41 +1650,6 @@ StreamElementsObsNativeReplayBufferOutput::GetAudioTracks()
 bool StreamElementsCustomReplayBufferOutput::CanDisable()
 {
 	return true;
-}
-
-bool StreamElementsCustomReplayBufferOutput::CanSplitRecordingOutput()
-{
-	OBSOutputAutoRelease output = GetOutput();
-
-	if (!output)
-		return false;
-
-	if (!obs_output_active(output))
-		return false;
-
-	if (!obs_output_paused(output))
-		return false;
-
-	return true;
-}
-
-bool StreamElementsCustomReplayBufferOutput::TriggerSplitRecordingOutput()
-{
-	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
-
-	if (!CanSplitRecordingOutput())
-		return false;
-
-	OBSOutputAutoRelease output = GetOutput();
-
-	proc_handler_t *ph = obs_output_get_proc_handler(output);
-	uint8_t stack[128];
-	calldata cd;
-	calldata_init_fixed(&cd, stack, sizeof(stack));
-	proc_handler_call(ph, "split_file", &cd);
-	bool result = calldata_bool(&cd, "split_file_enabled");
-
-	return result;
 }
 
 bool StreamElementsCustomReplayBufferOutput::StartInternal(

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -401,6 +401,9 @@ public:
 
 	virtual bool CanStart() override { return true; }
 
+	virtual bool CanSaveReplayBuffer();
+	virtual bool TriggerSaveReplayBuffer();
+
 protected:
 	virtual obs_output_t *GetOutput() override
 	{

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -88,6 +88,9 @@ public:
 	virtual bool CanSaveReplayBuffer() { return false; }
 	virtual bool TriggerSaveReplayBuffer() { return false; }
 
+	virtual void ConnectOutputEvents();
+	virtual void DisconnectOutputEvents();
+
 protected:
 	virtual obs_output_t *GetOutput() = 0;
 
@@ -104,9 +107,6 @@ protected:
 protected:
 	bool Start();
 	void Stop();
-
-	virtual void ConnectOutputEvents();
-	virtual void DisconnectOutputEvents();
 
 protected:
 	void SetError(std::string error) { m_error = error; }

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -474,9 +474,6 @@ public:
 
 	virtual bool IsObsNativeOutput() override { return false; }
 
-	virtual bool CanSplitRecordingOutput();
-	virtual bool TriggerSplitRecordingOutput();
-
 protected:
 	virtual obs_output_t *GetOutput() override
 	{

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -13,12 +13,14 @@ public:
 	enum ObsStateDependencyType {
 		Streaming,
 		Recording,
+		ReplayBuffer,
 		None
 	};
 
 	enum ObsOutputType {
 		StreamingOutput,
-		RecordingOutput
+		RecordingOutput,
+		ReplayBufferOutput
 	};
 
 protected:
@@ -83,6 +85,9 @@ public:
 	virtual bool CanSplitRecordingOutput() { return false; }
 	virtual bool TriggerSplitRecordingOutput() { return false; }
 
+	virtual bool CanSaveReplayBuffer() { return false; }
+	virtual bool TriggerSaveReplayBuffer() { return false; }
+
 protected:
 	virtual obs_output_t *GetOutput() = 0;
 
@@ -100,8 +105,8 @@ protected:
 	bool Start();
 	void Stop();
 
-	void ConnectOutputEvents();
-	void DisconnectOutputEvents();
+	virtual void ConnectOutputEvents();
+	virtual void DisconnectOutputEvents();
 
 protected:
 	void SetError(std::string error) { m_error = error; }
@@ -369,4 +374,127 @@ protected:
 			StreamElementsAudioCompositionBase::CompositionInfo>
 			audioCompositionInfo);
 	virtual void StopInternal();
+};
+
+class StreamElementsObsNativeReplayBufferOutput : public StreamElementsOutputBase {
+public:
+	StreamElementsObsNativeReplayBufferOutput(
+		std::string id, std::string name,
+		std::shared_ptr<StreamElementsVideoCompositionBase>
+			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition)
+		: StreamElementsOutputBase(id, name, ReplayBufferOutput,
+					   ReplayBuffer,
+					   videoComposition, audioComposition,
+					   CefDictionaryValue::Create())
+	{
+	}
+
+	virtual ~StreamElementsObsNativeReplayBufferOutput() {}
+
+	virtual bool CanRemove() override { return false; }
+	virtual bool CanChange() override { return false; }
+	virtual bool CanDisable() override { return false; }
+
+	virtual bool IsObsNativeOutput() override { return true; }
+
+	virtual bool CanStart() override { return true; }
+
+protected:
+	virtual obs_output_t *GetOutput() override
+	{
+		return obs_frontend_get_replay_buffer_output();
+	}
+
+	virtual bool StartInternal(
+		std::shared_ptr<
+			StreamElementsVideoCompositionBase::CompositionInfo>
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo) override;
+	virtual void StopInternal() override;
+
+	virtual void
+	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override;
+};
+
+class StreamElementsCustomReplayBufferOutput : public StreamElementsOutputBase {
+private:
+	std::shared_mutex m_mutex;
+
+	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
+		m_videoCompositionInfo = nullptr;
+
+	obs_output_t *m_output = nullptr;
+
+	CefRefPtr<CefDictionaryValue> m_recordingSettings =
+		CefDictionaryValue::Create();
+
+	std::vector<uint32_t> m_audioTracks;
+
+public:
+	StreamElementsCustomReplayBufferOutput(
+		std::string id, std::string name,
+		CefRefPtr<CefDictionaryValue> recordingSettings,
+		std::shared_ptr<StreamElementsVideoCompositionBase>
+			videoComposition,
+		std::shared_ptr<StreamElementsAudioCompositionBase>
+			audioComposition,
+		std::vector<uint32_t> audioTracks,
+		CefRefPtr<CefDictionaryValue> auxData)
+		: StreamElementsOutputBase(id, name, ReplayBufferOutput, None,
+					   videoComposition, audioComposition,
+					   auxData),
+		  m_recordingSettings(recordingSettings),
+		  m_audioTracks(audioTracks)
+	{
+	}
+
+	virtual ~StreamElementsCustomReplayBufferOutput() { Stop(); }
+
+	virtual bool CanDisable() override;
+
+	virtual void
+	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
+
+	virtual std::vector<uint32_t> GetAudioTracks() override
+	{
+		return m_audioTracks;
+	}
+
+	static std::shared_ptr<StreamElementsCustomReplayBufferOutput>
+	Create(CefRefPtr<CefValue> input);
+
+	virtual bool IsObsNativeOutput() override { return false; }
+
+	virtual bool CanSplitRecordingOutput();
+	virtual bool TriggerSplitRecordingOutput();
+
+protected:
+	virtual obs_output_t *GetOutput() override
+	{
+		return m_output ? obs_output_get_ref(m_output) : nullptr;
+	}
+
+	virtual bool StartInternal(
+		std::shared_ptr<
+			StreamElementsVideoCompositionBase::CompositionInfo>
+			videoCompositionInfo,
+		std::shared_ptr<
+			StreamElementsAudioCompositionBase::CompositionInfo>
+			audioCompositionInfo) override;
+	virtual void StopInternal() override;
+
+	virtual void ConnectOutputEvents() override;
+	virtual void DisconnectOutputEvents() override;
+
+	virtual bool CanSaveReplayBuffer() override { return IsActive(); }
+	virtual bool TriggerSaveReplayBuffer() override;
+
+private:
+	static void handle_output_saved(void *my_data, calldata_t *cd);
 };

--- a/streamelements/StreamElementsOutputManager.cpp
+++ b/streamelements/StreamElementsOutputManager.cpp
@@ -3,6 +3,7 @@
 
 #define StreamingOutput StreamElementsOutputBase::StreamingOutput
 #define RecordingOutput StreamElementsOutputBase::RecordingOutput
+#define ReplayBufferOutput StreamElementsOutputBase::ReplayBufferOutput
 
 StreamElementsOutputManager::StreamElementsOutputManager(
 	std::shared_ptr<StreamElementsVideoCompositionManager>
@@ -26,6 +27,15 @@ StreamElementsOutputManager::StreamElementsOutputManager(
 		m_audioCompositionManager->GetObsNativeAudioComposition());
 
 	m_map[RecordingOutput][nativeRecordingOutput->GetId()] = nativeRecordingOutput;
+
+	auto nativeReplayBufferOutput = std::make_shared<
+		StreamElementsObsNativeReplayBufferOutput>(
+		"default", "OBS Native Replay Buffer",
+		m_videoCompositionManager->GetObsNativeVideoComposition(),
+		m_audioCompositionManager->GetObsNativeAudioComposition());
+
+	m_map[ReplayBufferOutput][nativeReplayBufferOutput->GetId()] =
+		nativeReplayBufferOutput;
 }
 
 StreamElementsOutputManager::~StreamElementsOutputManager()
@@ -88,10 +98,19 @@ void StreamElementsOutputManager::DeserializeOutput(
 
 		customOutput->SerializeOutput(output);
 	}
-	else
-	{
+	else if (outputType == RecordingOutput) {
 		auto customOutput =
 			StreamElementsCustomRecordingOutput::Create(input);
+
+		if (!customOutput.get())
+			return;
+
+		m_map[outputType][customOutput->GetId()] = customOutput;
+
+		customOutput->SerializeOutput(output);
+	} else {
+		auto customOutput =
+			StreamElementsCustomReplayBufferOutput::Create(input);
 
 		if (!customOutput.get())
 			return;
@@ -203,6 +222,23 @@ void StreamElementsOutputManager::TriggerSplitRecordingOutputById(
 	}
 }
 
+void StreamElementsOutputManager::TriggerSaveReplayBufferById(
+	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
+{
+	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
+
+	output->SetBool(false);
+
+	if (input->GetType() != VTYPE_STRING)
+		return;
+
+	std::string id = input->GetString();
+
+	if (m_map[RecordingOutput].count(id)) {
+		output->SetBool(m_map[RecordingOutput][id]
+					->TriggerSaveReplayBuffer());
+	}
+}
 
 bool StreamElementsOutputManager::GetValidIds(
 	StreamElementsOutputBase::ObsOutputType outputType, CefRefPtr<CefValue> input,

--- a/streamelements/StreamElementsOutputManager.cpp
+++ b/streamelements/StreamElementsOutputManager.cpp
@@ -234,8 +234,8 @@ void StreamElementsOutputManager::TriggerSaveReplayBufferById(
 
 	std::string id = input->GetString();
 
-	if (m_map[RecordingOutput].count(id)) {
-		output->SetBool(m_map[RecordingOutput][id]
+	if (m_map[ReplayBufferOutput].count(id)) {
+		output->SetBool(m_map[ReplayBufferOutput][id]
 					->TriggerSaveReplayBuffer());
 	}
 }

--- a/streamelements/StreamElementsOutputManager.hpp
+++ b/streamelements/StreamElementsOutputManager.hpp
@@ -47,6 +47,9 @@ public:
 	void TriggerSplitRecordingOutputById(CefRefPtr<CefValue> input,
 					     CefRefPtr<CefValue> &output);
 
+	void TriggerSaveReplayBufferById(CefRefPtr<CefValue> input,
+					 CefRefPtr<CefValue> &output);
+
 	void Reset();
 
 private:

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -558,17 +558,31 @@ protected:
 	}
 
 	virtual obs_encoder_t* GetRecordingVideoEncoder() {
-		if (!obs_frontend_recording_active())
-			return nullptr;
+		obs_encoder_t *result = nullptr;
 
-		auto output = obs_frontend_get_recording_output();
+		if (!result && obs_frontend_recording_active()) {
+			auto output = obs_frontend_get_recording_output();
 
-		if (!output)
-			return nullptr;
+			if (output) {
+				result = obs_output_get_video_encoder(output);
 
-		auto result = obs_output_get_video_encoder(output);
+				obs_output_release(output);
+			}
+		}
 
-		obs_output_release(output);
+		if (!result && obs_frontend_replay_buffer_active()) {
+			auto output = obs_frontend_get_replay_buffer_output();
+
+			if (output) {
+				result = obs_output_get_video_encoder(output);
+
+				obs_output_release(output);
+			}
+		}
+
+		if (!result && obs_frontend_streaming_active()) {
+			result = GetStreamingVideoEncoder();
+		}
 
 		return result;
 	}


### PR DESCRIPTION
Add API Methods:

- getAllReplayBufferOutputs
- addReplayBufferOutput
- removeReplayBufferOutputsByIds
- enableReplayBufferOutputsByIds
- disableReplayBufferOutputsByIds
- triggerReplayBufferOutputSaveById

Add Events:

- hostReplayBufferOutputListChanged
- hostReplayBufferOutputStarted
- hostReplayBufferOutputError
- hostReplayBufferOutputStopped
- hostReplayBufferOutputPaused
- hostReplayBufferOutputUnpaused
- hostReplayBufferOutputStarting
- hostReplayBufferOutputStopping
- hostReplayBufferOutputActivated
- hostReplayBufferOutputDeactivated
- hostReplayBufferOutputReconnecting
- hostReplayBufferOutputReconnected 
- hostReplayBufferOutputSavedToLocalFile

This PR adds a fallback from Recording / Replay Buffer
encoders to Streaming encoders in case the former do not exist
(this may be the case with OBS native encoders).

This PR also fixes a couple of deadlocks most likely introduced
by https://github.com/StreamElements/obs-streamelements-core/commit/5cc4617adf6fc51b8bbc22e3fb4cd330e0c800c4

In addition, this PR shuts down outputs at the correct OBS shutdown
stage, so outputs no longer hang on exit.