### PR TITLE
API 6.2: Support multiple encoders per canvas and output

### DIFF
--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -15,6 +15,29 @@ static std::string safe_string(const char* input)
 	return std::string(input);
 }
 
+static std::vector<uint32_t> GetVideoEncodersFromOutput(obs_output_t *output)
+{
+	std::vector<uint32_t> result;
+
+	if (output) {
+		for (size_t idx = 0;; ++idx) {
+			OBSEncoderAutoRelease encoder =
+				obs_output_get_video_encoder2(output, idx);
+
+			if (!encoder)
+				break;
+
+			result.push_back(idx);
+		}
+	}
+
+	if (!result.size()) {
+		result.push_back(0);
+	}
+
+	return result;
+}
+
 static void CleanStopObsOutput(obs_output_t *output, bool forceStop)
 {
 	if (!obs_output_active(output))
@@ -55,13 +78,12 @@ static void CleanStopObsOutput(obs_output_t *output, bool forceStop)
 	signal_handler_disconnect(handler, "error", handle_signal, &future);
 }
 
-static std::vector<uint32_t> DeserializeAudioTracks(CefRefPtr<CefDictionaryValue> rootDict)
+static std::vector<uint32_t> DeserializeTracks(CefRefPtr<CefDictionaryValue> rootDict, std::string key, uint32_t maxTrackIndex)
 {
 	std::vector<uint32_t> result;
 
-	if (rootDict->HasKey("audioTracks") &&
-	    rootDict->GetType("audioTracks") == VTYPE_LIST) {
-		auto list = rootDict->GetList("audioTracks");
+	if (rootDict->HasKey(key) && rootDict->GetType(key) == VTYPE_LIST) {
+		auto list = rootDict->GetList(key);
 
 		for (size_t i = 0; i < list->GetSize(); ++i) {
 			if (list->GetType(i) != VTYPE_INT)
@@ -69,7 +91,7 @@ static std::vector<uint32_t> DeserializeAudioTracks(CefRefPtr<CefDictionaryValue
 
 			auto trackIndex = uint32_t(list->GetInt(i));
 
-			if (trackIndex >= 0 && trackIndex < MAX_AUDIO_MIXES) {
+			if (trackIndex >= 0 && trackIndex < maxTrackIndex) {
 				bool hasValue = false;
 
 				for (auto it = result.cbegin();
@@ -92,6 +114,18 @@ static std::vector<uint32_t> DeserializeAudioTracks(CefRefPtr<CefDictionaryValue
 	}
 
 	return result;
+}
+
+static std::vector<uint32_t>
+DeserializeAudioTracks(CefRefPtr<CefDictionaryValue> rootDict)
+{
+	return DeserializeTracks(rootDict, "audioTracks", MAX_AUDIO_MIXES);
+}
+
+static std::vector<uint32_t>
+DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
+{
+	return DeserializeTracks(rootDict, "videoEncoders", 128);
 }
 
 static void dispatch_list_change_event(StreamElementsOutputBase *output)
@@ -511,6 +545,13 @@ void StreamElementsOutputBase::SerializeOutput(CefRefPtr<CefValue>& output)
 	}
 	d->SetList("audioTracks", audioTracks);
 
+	auto videoEncoders = CefListValue::Create();
+	for (auto videoEncoderIndex : GetVideoEncoders()) {
+		videoEncoders->SetInt(videoEncoders->GetSize(),
+				      videoEncoderIndex);
+	}
+	d->SetList("videoEncoders", videoEncoders);
+
 	auto outputSettings = CefValue::Create();
 
 	SerializeOutputSettings(outputSettings);
@@ -731,19 +772,33 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	OBSEncoderAutoRelease streamingVideoEncoder =
-		videoCompositionInfo->GetStreamingVideoEncoderRef();
+	std::vector<OBSEncoderAutoRelease> streamingVideoEncoders;
 
-	if (!streamingVideoEncoder && videoCompositionInfo->IsObsNative()) {
+	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
+		auto idx = m_videoEncoders[i];
+
+		OBSEncoderAutoRelease streamingVideoEncoder =
+			videoCompositionInfo->GetStreamingVideoEncoderRef(idx);
+
+		if (!streamingVideoEncoder)
+			break;
+
+		streamingVideoEncoders.push_back(
+			obs_encoder_get_ref(streamingVideoEncoder));
+	}
+
+	if (!streamingVideoEncoders.size() && videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
-		     "obs-streamelements-core: OBS Native streaming video encoder does not exist yet on streaming output '%s'",
+		     "obs-streamelements-core: OBS Native streaming video encoders do not exist yet on streaming output '%s'",
 		     GetId().c_str());
 
 		SetError(
-			"OBS Native streaming video encoder does not exist yet");
+			"OBS Native streaming video encoders do not exist yet");
 
 		auto args = CefDictionaryValue::Create();
-		args->SetString("reason", "OBS Native streaming video encoder does not exist yet");
+		args->SetString(
+			"reason",
+			"OBS Native streaming video encoders do not exist yet");
 
 		dispatch_event(this, "hostStreamingOutputError", args);
 		dispatch_event(this, "hostStreamingOutputStopped");
@@ -770,11 +825,10 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 	obs_data_release(output_settings);
 
 	if (m_output) {
-		OBSEncoderAutoRelease streamingVideoEncoder =
-			videoCompositionInfo->GetStreamingVideoEncoderRef();
-
-		obs_output_set_video_encoder(
-			m_output, streamingVideoEncoder);
+		for (size_t i = 0; i < streamingVideoEncoders.size(); ++i) {
+			obs_output_set_video_encoder2(
+				m_output, streamingVideoEncoders[i], i);
+		}
 
 		size_t audioEncodersCount = 0;
 
@@ -995,10 +1049,11 @@ std::shared_ptr <StreamElementsCustomStreamingOutput> StreamElementsCustomStream
 	auto bindToIP = "";
 
 	auto audioTracks = DeserializeAudioTracks(rootDict);
+	auto videoEncoders = DeserializeVideoEncoders(rootDict);
 
 	auto result = std::make_shared<StreamElementsCustomStreamingOutput>(
 		id, name, videoComposition, audioComposition, audioTracks,
-		service, bindToIP, auxData);
+		videoEncoders, service, bindToIP, auxData);
 
 	result->SetEnabled(isEnabled);
 
@@ -1087,6 +1142,13 @@ std::vector<uint32_t> StreamElementsObsNativeStreamingOutput::GetAudioTracks()
 	return result;
 }
 
+std::vector<uint32_t> StreamElementsObsNativeStreamingOutput::GetVideoEncoders()
+{
+	OBSOutputAutoRelease output = GetOutput();
+
+	return GetVideoEncodersFromOutput(output);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // StreamElementsObsNativeRecordingOutput
 ////////////////////////////////////////////////////////////////////////////////
@@ -1152,6 +1214,13 @@ std::vector<uint32_t> StreamElementsObsNativeRecordingOutput::GetAudioTracks()
 	return result;
 }
 
+std::vector<uint32_t> StreamElementsObsNativeRecordingOutput::GetVideoEncoders()
+{
+	OBSOutputAutoRelease output = GetOutput();
+
+	return GetVideoEncodersFromOutput(output);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // StreamElementsCustomRecordingOutput
 ////////////////////////////////////////////////////////////////////////////////
@@ -1208,22 +1277,34 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	OBSEncoderAutoRelease recordingVideoEncoder =
-		videoCompositionInfo->GetRecordingVideoEncoderRef();
+	std::vector<OBSEncoderAutoRelease> recordingVideoEncoders;
 
-	if (!recordingVideoEncoder &&
+	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
+		auto idx = m_videoEncoders[i];
+
+		OBSEncoderAutoRelease recordingVideoEncoder =
+			videoCompositionInfo->GetRecordingVideoEncoderRef(idx);
+
+		if (!recordingVideoEncoder)
+			break;
+
+		recordingVideoEncoders.push_back(
+			obs_encoder_get_ref(recordingVideoEncoder));
+	}
+
+	if (!recordingVideoEncoders.size() &&
 	    videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
-		     "obs-streamelements-core: OBS Native recording video encoder does not exist yet on recording output '%s'",
+		     "obs-streamelements-core: OBS Native recording video encoders do not exist yet on recording output '%s'",
 		     GetId().c_str());
 
 		SetError(
-			"OBS Native recording video encoder does not exist yet");
+			"OBS Native recording video encoders do not exist yet");
 
 		auto args = CefDictionaryValue::Create();
 		args->SetString(
 			"reason",
-			"OBS Native recording video encoder does not exist yet");
+			"OBS Native recording video encoders do not exist yet");
 
 		dispatch_event(this, "hostRecordingOutputError", args);
 		dispatch_event(this, "hostRecordingOutputStopped");
@@ -1384,11 +1465,11 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 				     hotkeyData);
 
 	if (m_output) {
-		OBSEncoderAutoRelease recordingVideoEncoder =
-			videoCompositionInfo->GetRecordingVideoEncoderRef();
-
-		obs_output_set_video_encoder(
-			m_output, recordingVideoEncoder);
+		for (size_t i = 0; i < recordingVideoEncoders.size(); ++i) {
+			// TODO: Find by request
+			obs_output_set_video_encoder2(
+				m_output, recordingVideoEncoders[i], i);
+		}
 
 		size_t audioEncodersCount = 0;
 
@@ -1553,11 +1634,11 @@ StreamElementsCustomRecordingOutput::Create(CefRefPtr<CefValue> input)
 	}
 
 	auto audioTracks = DeserializeAudioTracks(rootDict);
+	auto videoEncoders = DeserializeVideoEncoders(rootDict);
 
 	auto result = std::make_shared<StreamElementsCustomRecordingOutput>(
 		id, name, recordingSettings, videoComposition, audioComposition,
-		audioTracks,
-		auxData);
+		audioTracks, videoEncoders, auxData);
 
 	result->SetEnabled(isEnabled);
 
@@ -1644,6 +1725,14 @@ StreamElementsObsNativeReplayBufferOutput::GetAudioTracks()
 	return result;
 }
 
+std::vector<uint32_t>
+StreamElementsObsNativeReplayBufferOutput::GetVideoEncoders()
+{
+	OBSOutputAutoRelease output = GetOutput();
+
+	return GetVideoEncodersFromOutput(output);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // StreamElementsCustomReplayBufferOutput
 ////////////////////////////////////////////////////////////////////////////////
@@ -1665,21 +1754,33 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	OBSEncoderAutoRelease recordingVideoEncoder =
-		videoCompositionInfo->GetRecordingVideoEncoderRef();
+	std::vector<OBSEncoderAutoRelease> recordingVideoEncoders;
 
-	if (!recordingVideoEncoder && videoCompositionInfo->IsObsNative()) {
+	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
+		auto idx = m_videoEncoders[i];
+
+		OBSEncoderAutoRelease recordingVideoEncoder =
+			videoCompositionInfo->GetRecordingVideoEncoderRef(idx);
+
+		if (!recordingVideoEncoder)
+			break;
+
+		recordingVideoEncoders.push_back(
+			obs_encoder_get_ref(recordingVideoEncoder));
+	}
+
+	if (!recordingVideoEncoders.size() && videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
-		     "obs-streamelements-core: OBS Native recording video encoder does not exist yet on replay buffer output '%s'",
+		     "obs-streamelements-core: OBS Native recording video encoders do not exist yet on replay buffer output '%s'",
 		     GetId().c_str());
 
 		SetError(
-			"OBS Native recording video encoder does not exist yet");
+			"OBS Native recording video encoders do not exist yet");
 
 		auto args = CefDictionaryValue::Create();
 		args->SetString(
 			"reason",
-			"OBS Native recording video encoder does not exist yet");
+			"OBS Native recording video encoders do not exist yet");
 
 		dispatch_event(this, "hostReplayBufferOutputError", args);
 		dispatch_event(this, "hostReplayBufferOutputStopped");
@@ -1839,10 +1940,11 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 				     hotkeyData);
 
 	if (m_output) {
-		OBSEncoderAutoRelease recordingVideoEncoder =
-			videoCompositionInfo->GetRecordingVideoEncoderRef();
-
-		obs_output_set_video_encoder(m_output, recordingVideoEncoder);
+		for (size_t i = 0; i < recordingVideoEncoders.size(); ++i) {
+			// TODO: Find by request
+			obs_output_set_video_encoder2(
+				m_output, recordingVideoEncoders[i], i);
+		}
 
 		size_t audioEncodersCount = 0;
 
@@ -2005,10 +2107,11 @@ StreamElementsCustomReplayBufferOutput::Create(CefRefPtr<CefValue> input)
 	}
 
 	auto audioTracks = DeserializeAudioTracks(rootDict);
+	auto videoEncoders = DeserializeVideoEncoders(rootDict);
 
 	auto result = std::make_shared<StreamElementsCustomReplayBufferOutput>(
 		id, name, recordingSettings, videoComposition, audioComposition,
-		audioTracks, auxData);
+		audioTracks, videoEncoders, auxData);
 
 	result->SetEnabled(isEnabled);
 

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -910,7 +910,7 @@ void StreamElementsCustomStreamingOutput::SerializeOutputSettings(
 
 	obs_data_t *service_settings = obs_service_get_settings(m_service);
 
-	d->SetString("type", obs_service_get_type(m_service));
+	d->SetString("type", safe_string(obs_service_get_type(m_service)));
 
 	d->SetString("serverUrl",
 		     safe_string(obs_data_get_string(service_settings, "server")));
@@ -1093,7 +1093,7 @@ void StreamElementsObsNativeStreamingOutput::SerializeOutputSettings(
 
 	obs_data_t *service_settings = obs_service_get_settings(service);
 
-	d->SetString("type", obs_service_get_type(service));
+	d->SetString("type", safe_string(obs_service_get_type(service)));
 
 	d->SetString("serverUrl", safe_string(obs_data_get_string(
 					  service_settings, "server")));
@@ -1183,7 +1183,7 @@ void StreamElementsObsNativeRecordingOutput::SerializeOutputSettings(
 
 	obs_data_t *obs_output_settings = obs_output_get_settings(obs_output);
 
-	d->SetString("type", obs_output_get_id(obs_output));
+	d->SetString("type", safe_string(obs_output_get_id(obs_output)));
 	d->SetValue("settings", SerializeObsData(obs_output_settings));
 
 	obs_data_release(obs_output_settings);
@@ -1693,7 +1693,7 @@ void StreamElementsObsNativeReplayBufferOutput::SerializeOutputSettings(
 
 	obs_data_t *obs_output_settings = obs_output_get_settings(obs_output);
 
-	d->SetString("type", obs_output_get_id(obs_output));
+	d->SetString("type", safe_string(obs_output_get_id(obs_output)));
 	d->SetValue("settings", SerializeObsData(obs_output_settings));
 
 	obs_data_release(obs_output_settings);
@@ -2159,7 +2159,7 @@ void StreamElementsCustomReplayBufferOutput::handle_output_saved(
 
 	const char *path = nullptr;
 	if (calldata_get_string(proc_cd, "path", &path)) {
-		eventArgs->SetString("filePath", path);
+		eventArgs->SetString("filePath", safe_string(path));
 
 		dispatch_event(self, "hostReplayBufferOutputSavedToLocalFile", eventArgs);
 	}

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -81,6 +81,7 @@ public:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) = 0;
 
 	virtual std::vector<uint32_t> GetAudioTracks() = 0;
+	virtual std::vector<uint32_t> GetVideoEncoders() = 0;
 
 	virtual bool CanSplitRecordingOutput() { return false; }
 	virtual bool TriggerSplitRecordingOutput() { return false; }
@@ -146,6 +147,7 @@ private:
 	std::string m_bindToIP;
 
 	std::vector<uint32_t> m_audioTracks = {0};
+	std::vector<uint32_t> m_videoEncoders = {0};
 
 public:
 	StreamElementsCustomStreamingOutput(
@@ -154,13 +156,15 @@ public:
 			videoComposition,
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
-		std::vector<uint32_t> audioTracks, obs_service_t *service,
+		std::vector<uint32_t> audioTracks,
+		std::vector<uint32_t> videoEncoders, obs_service_t *service,
 		const char *bindToIP, CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_service(service),
-		  m_audioTracks(audioTracks)
+		  m_audioTracks(audioTracks),
+		  m_videoEncoders(videoEncoders)
 	{
 		if (bindToIP) {
 			m_bindToIP = bindToIP;
@@ -197,6 +201,11 @@ public:
 	virtual std::vector<uint32_t> GetAudioTracks() override
 	{
 		return m_audioTracks;
+	}
+
+	virtual std::vector<uint32_t> GetVideoEncoders() override
+	{
+		return m_videoEncoders;
 	}
 
 	static std::shared_ptr<StreamElementsCustomStreamingOutput>
@@ -259,6 +268,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
+	virtual std::vector<uint32_t> GetVideoEncoders() override;
 };
 
 class StreamElementsObsNativeRecordingOutput : public StreamElementsOutputBase {
@@ -304,6 +314,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
+	virtual std::vector<uint32_t> GetVideoEncoders() override;
 };
 
 class StreamElementsCustomRecordingOutput : public StreamElementsOutputBase {
@@ -318,6 +329,7 @@ private:
 	CefRefPtr<CefDictionaryValue> m_recordingSettings = CefDictionaryValue::Create();
 
 	std::vector<uint32_t> m_audioTracks;
+	std::vector<uint32_t> m_videoEncoders;
 
 public:
 	StreamElementsCustomRecordingOutput(
@@ -328,12 +340,14 @@ public:
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
 		std::vector<uint32_t> audioTracks,
+		std::vector<uint32_t> videoEncoders,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, RecordingOutput, None,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_recordingSettings(recordingSettings),
-		  m_audioTracks(audioTracks)
+		  m_audioTracks(audioTracks),
+		  m_videoEncoders(videoEncoders)
 	{
 	}
 
@@ -350,6 +364,11 @@ public:
 	virtual std::vector<uint32_t> GetAudioTracks() override
 	{
 		return m_audioTracks;
+	}
+
+	virtual std::vector<uint32_t> GetVideoEncoders() override
+	{
+		return m_videoEncoders;
 	}
 
 	static std::shared_ptr<StreamElementsCustomRecordingOutput>
@@ -423,6 +442,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
+	virtual std::vector<uint32_t> GetVideoEncoders() override;
 };
 
 class StreamElementsCustomReplayBufferOutput : public StreamElementsOutputBase {
@@ -437,7 +457,8 @@ private:
 	CefRefPtr<CefDictionaryValue> m_recordingSettings =
 		CefDictionaryValue::Create();
 
-	std::vector<uint32_t> m_audioTracks;
+	std::vector<uint32_t> m_audioTracks = {0};
+	std::vector<uint32_t> m_videoEncoders = {0};
 
 public:
 	StreamElementsCustomReplayBufferOutput(
@@ -448,12 +469,14 @@ public:
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
 		std::vector<uint32_t> audioTracks,
+		std::vector<uint32_t> videoEncoders,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, ReplayBufferOutput, None,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_recordingSettings(recordingSettings),
-		  m_audioTracks(audioTracks)
+		  m_audioTracks(audioTracks),
+		  m_videoEncoders(videoEncoders)
 	{
 	}
 
@@ -467,6 +490,11 @@ public:
 	virtual std::vector<uint32_t> GetAudioTracks() override
 	{
 		return m_audioTracks;
+	}
+
+	virtual std::vector<uint32_t> GetVideoEncoders() override
+	{
+		return m_videoEncoders;
 	}
 
 	static std::shared_ptr<StreamElementsCustomReplayBufferOutput>

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -837,6 +837,8 @@ void StreamElementsObsNativeVideoComposition::SerializeComposition(
 
 	root->SetDictionary("videoFrame", videoFrame);
 
+	root->SetString("view", "obs");
+
 	SerializeObsVideoEncoders(this, root);
 
 	output->SetDictionary(root);
@@ -1263,6 +1265,8 @@ void StreamElementsCustomVideoComposition::SerializeComposition(
 	videoFrame->SetInt("height", m_baseHeight);
 
 	root->SetDictionary("videoFrame", videoFrame);
+
+	root->SetString("view", "custom");
 
 	SerializeObsVideoEncoders(this, root);
 
@@ -1746,6 +1750,8 @@ void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SerializeComposi
 	videoFrame->SetInt("height", int(size.y));
 
 	root->SetDictionary("videoFrame", videoFrame);
+
+	root->SetString("view", "obs");
 
 	SerializeObsVideoEncoders(this, root);
 

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -1600,7 +1600,7 @@ void StreamElementsCustomVideoComposition::HandleObsSceneCollectionCleanup()
 ////////////////////////////////////////////////////////////////////////////////
 
 std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
-StreamElementsObsVirtualNativeVideoComposition::GetCompositionInfo(
+StreamElementsObsNativeVideoCompositionWithCustomEncoders::GetCompositionInfo(
 	StreamElementsVideoCompositionEventListener *listener,
 	std::string holder)
 {
@@ -1614,13 +1614,13 @@ StreamElementsObsVirtualNativeVideoComposition::GetCompositionInfo(
 		m_recordingVideoEncoders, nullptr /* render native OBS canvas */);
 }
 
-obs_scene_t *StreamElementsObsVirtualNativeVideoComposition::AddScene(
+obs_scene_t *StreamElementsObsNativeVideoCompositionWithCustomEncoders::AddScene(
 	std::string requestName)
 {
 	return obs_scene_create(GetUniqueSceneName(requestName).c_str());
 }
 
-bool StreamElementsObsVirtualNativeVideoComposition::RemoveScene(
+bool StreamElementsObsNativeVideoCompositionWithCustomEncoders::RemoveScene(
 	obs_scene_t *sceneToRemove)
 {
 	scenes_t scenes;
@@ -1638,7 +1638,7 @@ bool StreamElementsObsVirtualNativeVideoComposition::RemoveScene(
 	return false;
 }
 
-void StreamElementsObsVirtualNativeVideoComposition::SetTransition(
+void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetTransition(
 	obs_source_t *transition)
 {
 	obs_frontend_set_current_transition(transition);
@@ -1652,7 +1652,7 @@ void StreamElementsObsVirtualNativeVideoComposition::SetTransition(
 	dispatch_external_event("hostVideoCompositionChanged", json);
 }
 
-void StreamElementsObsVirtualNativeVideoComposition::
+void StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 	SetTransitionDurationMilliseconds(int duration)
 {
 	obs_frontend_set_transition_duration(duration);
@@ -1666,7 +1666,7 @@ void StreamElementsObsVirtualNativeVideoComposition::
 	dispatch_external_event("hostVideoCompositionChanged", json);
 }
 
-obs_source_t *StreamElementsObsVirtualNativeVideoComposition::GetTransition()
+obs_source_t *StreamElementsObsNativeVideoCompositionWithCustomEncoders::GetTransition()
 {
 	auto source = obs_frontend_get_current_transition();
 
@@ -1675,7 +1675,7 @@ obs_source_t *StreamElementsObsVirtualNativeVideoComposition::GetTransition()
 	return source;
 }
 
-bool StreamElementsObsVirtualNativeVideoComposition::SetCurrentScene(
+bool StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetCurrentScene(
 	obs_scene_t *scene)
 {
 	if (!scene)
@@ -1697,7 +1697,7 @@ bool StreamElementsObsVirtualNativeVideoComposition::SetCurrentScene(
 	return false;
 }
 
-void StreamElementsObsVirtualNativeVideoComposition::GetAllScenesInternal(
+void StreamElementsObsNativeVideoCompositionWithCustomEncoders::GetAllScenesInternal(
 	scenes_t &result)
 {
 	result.clear();
@@ -1720,7 +1720,7 @@ void StreamElementsObsVirtualNativeVideoComposition::GetAllScenesInternal(
 	obs_frontend_source_list_free(&frontendScenes);
 }
 
-void StreamElementsObsVirtualNativeVideoComposition::SerializeComposition(
+void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SerializeComposition(
 	CefRefPtr<CefValue> &output)
 {
 	obs_video_info ovi;
@@ -1752,7 +1752,7 @@ void StreamElementsObsVirtualNativeVideoComposition::SerializeComposition(
 	output->SetDictionary(root);
 }
 
-obs_scene_t *StreamElementsObsVirtualNativeVideoComposition::GetCurrentScene()
+obs_scene_t *StreamElementsObsNativeVideoCompositionWithCustomEncoders::GetCurrentScene()
 {
 	auto source = obs_frontend_get_current_scene();
 	auto scene = obs_scene_from_source(source);
@@ -1763,7 +1763,7 @@ obs_scene_t *StreamElementsObsVirtualNativeVideoComposition::GetCurrentScene()
 }
 
 obs_scene_t *
-StreamElementsObsVirtualNativeVideoComposition::GetCurrentSceneRef()
+StreamElementsObsNativeVideoCompositionWithCustomEncoders::GetCurrentSceneRef()
 {
 	auto source = obs_frontend_get_current_scene();
 	auto scene = obs_scene_from_source(source);
@@ -1771,9 +1771,9 @@ StreamElementsObsVirtualNativeVideoComposition::GetCurrentSceneRef()
 	return scene;
 }
 
-StreamElementsObsVirtualNativeVideoComposition::
-		StreamElementsObsVirtualNativeVideoComposition(
-			StreamElementsObsVirtualNativeVideoComposition::Private,
+StreamElementsObsNativeVideoCompositionWithCustomEncoders::
+		StreamElementsObsNativeVideoCompositionWithCustomEncoders(
+			StreamElementsObsNativeVideoCompositionWithCustomEncoders::Private,
 			std::string id,
 		std::string name,
 		std::vector<std::string> & streamingVideoEncoderIds,
@@ -1840,8 +1840,8 @@ StreamElementsObsVirtualNativeVideoComposition::
 		}
 }
 
-StreamElementsObsVirtualNativeVideoComposition::
-	~StreamElementsObsVirtualNativeVideoComposition()
+StreamElementsObsNativeVideoCompositionWithCustomEncoders::
+	~StreamElementsObsNativeVideoCompositionWithCustomEncoders()
 {
 	for (auto encoder : m_streamingVideoEncoders) {
 		obs_encoder_release(encoder);
@@ -1854,7 +1854,7 @@ StreamElementsObsVirtualNativeVideoComposition::
 	m_recordingVideoEncoders.clear();
 }
 
-void StreamElementsObsVirtualNativeVideoComposition::SetRecordingEncoders(
+void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetRecordingEncoders(
 	std::vector<std::string> &recordingVideoEncoderIds,
 	std::vector<OBSDataAutoRelease> &recordingVideoEncoderSettings,
 	std::vector<OBSDataAutoRelease> &recordingVideoEncoderHotkeyData)
@@ -1905,8 +1905,8 @@ void StreamElementsObsVirtualNativeVideoComposition::SetRecordingEncoders(
 	}
 }
 
-std::shared_ptr<StreamElementsObsVirtualNativeVideoComposition>
-StreamElementsObsVirtualNativeVideoComposition::Create(
+std::shared_ptr<StreamElementsObsNativeVideoCompositionWithCustomEncoders>
+StreamElementsObsNativeVideoCompositionWithCustomEncoders::Create(
 	std::string id, std::string name,
 	CefRefPtr<CefValue> streamingVideoEncoders,
 	CefRefPtr<CefValue> recordingVideoEncoders)
@@ -1921,7 +1921,7 @@ StreamElementsObsVirtualNativeVideoComposition::Create(
 			  streamingVideoEncoderHotkeyData);
 
 	std::exception_ptr exception = nullptr;
-	std::shared_ptr<StreamElementsObsVirtualNativeVideoComposition> result =
+	std::shared_ptr<StreamElementsObsNativeVideoCompositionWithCustomEncoders> result =
 		nullptr;
 
 	try {

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -72,8 +72,8 @@ public:
 
 		virtual void Render() = 0;
 
-		obs_encoder_t* GetStreamingVideoEncoderRef() {
-			auto result = GetStreamingVideoEncoder();
+		obs_encoder_t* GetStreamingVideoEncoderRef(size_t index) {
+			auto result = GetStreamingVideoEncoder(index);
 
 			if (result) {
 				result = obs_encoder_get_ref(result);
@@ -82,8 +82,9 @@ public:
 			return result;
 		}
 
-		obs_encoder_t* GetRecordingVideoEncoderRef() {
-			auto result = GetRecordingVideoEncoder();
+		obs_encoder_t *GetRecordingVideoEncoderRef(size_t index)
+		{
+			auto result = GetRecordingVideoEncoder(index);
 
 			if (result) {
 				result = obs_encoder_get_ref(result);
@@ -93,8 +94,10 @@ public:
 		}
 
 	protected:
-		virtual obs_encoder_t *GetStreamingVideoEncoder() = 0;
-		virtual obs_encoder_t *GetRecordingVideoEncoder() = 0;
+		virtual obs_encoder_t *
+		GetStreamingVideoEncoder(size_t index) = 0;
+		virtual obs_encoder_t *
+		GetRecordingVideoEncoder(size_t index) = 0;
 	};
 
 private:
@@ -530,19 +533,19 @@ public:
 	// ctor only usable by this class
 	StreamElementsCustomVideoComposition(
 		Private, std::string id, std::string name, uint32_t baseWidth,
-		uint32_t baseHeight, std::string streamingVideoEncoderId,
-		obs_data_t *streamingVideoEncoderSettings,
-		obs_data_t *streamingVideoEncoderHotkeyData);
+		uint32_t baseHeight, std::vector<std::string> streamingVideoEncoderIds,
+		std::vector<obs_data_t *> streamingVideoEncoderSettings,
+		std::vector<obs_data_t *> streamingVideoEncoderHotkeyData);
 
 	virtual ~StreamElementsCustomVideoComposition();
 
 public:
 	static std::shared_ptr<StreamElementsCustomVideoComposition>
 	Create(std::string id, std::string name, uint32_t width,
-	       uint32_t height, std::string streamingVideoEncoderId, obs_data_t* streamingVideoEncoderSettings, obs_data_t* streamingVideoEncoderHotkeyData)
+	       uint32_t height, std::vector<std::string> streamingVideoEncoderIds, std::vector<obs_data_t*> streamingVideoEncoderSettings, std::vector<obs_data_t*> streamingVideoEncoderHotkeyData)
 	{
 		return std::make_shared<StreamElementsCustomVideoComposition>(
-			Private(), id, name, width, height, streamingVideoEncoderId, streamingVideoEncoderSettings, streamingVideoEncoderHotkeyData);
+			Private(), id, name, width, height, streamingVideoEncoderIds, streamingVideoEncoderSettings, streamingVideoEncoderHotkeyData);
 	}
 
 	static std::shared_ptr<StreamElementsCustomVideoComposition>
@@ -551,13 +554,13 @@ public:
 	       CefRefPtr<CefValue> recordingVideoEncoders);
 
 private:
-	void SetRecordingEncoder(std::string recordingVideoEncoderId,
-				 obs_data_t *recordingVideoEncoderSettings,
-				 obs_data_t *recordingVideoEncoderHotkeyData);
+	void SetRecordingEncoders(std::vector<std::string> recordingVideoEncoderId,
+				 std::vector<obs_data_t *> recordingVideoEncoderSettings,
+				 std::vector<obs_data_t *> recordingVideoEncoderHotkeyData);
 
 private:
-	obs_encoder_t *m_streamingVideoEncoder = nullptr;
-	obs_encoder_t *m_recordingVideoEncoder = nullptr;
+	std::vector<obs_encoder_t *> m_streamingVideoEncoders;
+	std::vector<obs_encoder_t *> m_recordingVideoEncoders;
 	obs_view_t *m_view = nullptr;
 	video_t *m_video = nullptr;
 

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -619,7 +619,7 @@ public:
 };
 
 // Virtual main canvas WITH CUSTOM ENCODERS video composition
-class StreamElementsObsVirtualNativeVideoComposition
+class StreamElementsObsNativeVideoCompositionWithCustomEncoders
 	: public StreamElementsVideoCompositionBase,
 	  public std::enable_shared_from_this<
 		  StreamElementsVideoCompositionBase> {
@@ -634,31 +634,31 @@ private:
 
 public:
 	// ctor only usable by this class
-	StreamElementsObsVirtualNativeVideoComposition(
+	StreamElementsObsNativeVideoCompositionWithCustomEncoders(
 		Private, std::string id, std::string name,
 		std::vector<std::string> &streamingVideoEncoderIds,
 		std::vector<OBSDataAutoRelease> &streamingVideoEncoderSettings,
 		std::vector<OBSDataAutoRelease>
 			&streamingVideoEncoderHotkeyData);
 
-	virtual ~StreamElementsObsVirtualNativeVideoComposition();
+	virtual ~StreamElementsObsNativeVideoCompositionWithCustomEncoders();
 
 private:
-	static std::shared_ptr<StreamElementsObsVirtualNativeVideoComposition>
+	static std::shared_ptr<StreamElementsObsNativeVideoCompositionWithCustomEncoders>
 	Create(std::string id, std::string name,
 	       std::vector<std::string> &streamingVideoEncoderIds,
 	       std::vector<OBSDataAutoRelease> &streamingVideoEncoderSettings,
 	       std::vector<OBSDataAutoRelease> &streamingVideoEncoderHotkeyData)
 	{
 		return std::make_shared<
-			StreamElementsObsVirtualNativeVideoComposition>(
+			StreamElementsObsNativeVideoCompositionWithCustomEncoders>(
 			Private(), id, name,
 			streamingVideoEncoderIds, streamingVideoEncoderSettings,
 			streamingVideoEncoderHotkeyData);
 	}
 
 public:
-	static std::shared_ptr<StreamElementsObsVirtualNativeVideoComposition>
+	static std::shared_ptr<StreamElementsObsNativeVideoCompositionWithCustomEncoders>
 	Create(std::string id, std::string name, CefRefPtr<CefValue> streamingVideoEncoders,
 	       CefRefPtr<CefValue> recordingVideoEncoders);
 

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 1
+#define HOST_API_VERSION_MINOR 2
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Modify Data Structures:

- OutputInfo (add `videoEncoders` field)
- VideoCompositionInfo (add `view` field, support multiple video encoders)
