### PR TITLE
API 6.4: Support output video encoders override

### DIFF
--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -245,7 +245,7 @@ private:
 
 	std::vector<uint32_t> m_audioTracks = {0};
 	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0, nullptr)};
+		std::make_shared<VideoEncoder>(0)};
 
 public:
 	StreamElementsCustomStreamingOutput(
@@ -429,7 +429,7 @@ private:
 
 	std::vector<uint32_t> m_audioTracks;
 	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0, nullptr)};
+		std::make_shared<VideoEncoder>(0)};
 
 public:
 	StreamElementsCustomRecordingOutput(
@@ -560,7 +560,7 @@ private:
 
 	std::vector<uint32_t> m_audioTracks = {0};
 	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0, nullptr)};
+		std::make_shared<VideoEncoder>(0)};
 
 public:
 	StreamElementsCustomReplayBufferOutput(

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -527,4 +527,10 @@ obs_source_t *GetExistingObsTransition(std::string lookupId);
 bool DeserializeObsTransition(CefRefPtr<CefValue> input, obs_source_t **t,
 			      int *durationMilliseconds, bool useExisting);
 
+/* ========================================================= */
+
 CefRefPtr<CefDictionaryValue> SerializeObsEncoder(obs_encoder_t *e);
+
+obs_encoder_t *DeserializeObsVideoEncoder(CefRefPtr<CefValue> input);
+obs_encoder_t *DeserializeObsAudioEncoder(CefRefPtr<CefValue> input,
+					  int mixer_idx = -1);

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 3
+#define HOST_API_VERSION_MINOR 4
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Modify Data Structures:

- `ObsEncoderInfo` (add `audioMix` field to audio encoders)
- `OutputInfo` (`videoEncoders` array accepts `ObsEncoderInfo` in addition to `VideoComposition` encoder index)
