### PR TITLE
Replay Buffer: dependency on Streaming state and default minimum file time

### DIFF
--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -1983,6 +1983,11 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 		}
 	}
 
+	if (splitFileTime <= 0) {
+		// Safety. Without this, replay_buffer output will get stuck
+		splitFileTime = 20;
+	}
+
 	splitFile = splitFileSize > 0 || splitFileTime > 0;
 
 	////////////////////////////////////////////////

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -573,7 +573,7 @@ public:
 		std::vector<uint32_t> audioTracks,
 		std::vector<std::shared_ptr<VideoEncoder>> videoEncoders,
 		CefRefPtr<CefDictionaryValue> auxData)
-		: StreamElementsOutputBase(id, name, ReplayBufferOutput, None,
+		: StreamElementsOutputBase(id, name, ReplayBufferOutput, Streaming,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_recordingSettings(recordingSettings),


### PR DESCRIPTION
When a replay buffer is active, it reflects on the OBS frontend UI: i.e.
recording settings cannot be updated, while at least one replay buffer is active.
For this reason, we make sure our replay buffers can only be active when
OBS is streaming.

In addition, if replay buffer duration is zero or less than a keyframe interval,
attempt to save it to a file will result in OBS getting stuck in an infinite
loop trying to purge excess packets from the buffer forever.
If we detect that replay buffer duration is 0 or not specified, we'll set it
to 20 seconds.