### PR TITLE
API 6.6: Shared video compositions API tweaks

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -3045,6 +3045,19 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+	API_HANDLER_BEGIN("setSharedVideoCompositionProperties");
+	{
+		result->SetNull();
+
+		if (args->GetSize()) {
+			StreamElementsGlobalStateManager::GetInstance()
+				->GetSharedVideoCompositionManager()
+				->DeserializeSharedVideoCompositionProperties(
+					args->GetValue(0), result);
+		}
+	}
+	API_HANDLER_END();
+
 	API_HANDLER_BEGIN("removeSharedVideoCompositionsByIds");
 	{
 		result->SetNull();

--- a/streamelements/StreamElementsSharedVideoCompositionManager.hpp
+++ b/streamelements/StreamElementsSharedVideoCompositionManager.hpp
@@ -32,6 +32,9 @@ public:
 	void DeserializeSharedVideoComposition(CefRefPtr<CefValue> input,
 					       CefRefPtr<CefValue> &output);
 
+	void DeserializeSharedVideoCompositionProperties(
+		CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output);
+
 	void SerializeAllSharedVideoCompositions(CefRefPtr<CefValue> &output);
 
 	void RemoveSharedVideoCompositionsByIds(CefRefPtr<CefValue> input,

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -111,8 +111,11 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 
 	SaveDockWidgetsGeometry();
 
-	static_cast<StreamElementsBrowserWidget *>(m_nativeCentralWidget)
-		->RemoveVideoCompositionView();
+	auto currentCentralWisget = m_parent->centralWidget();
+	if (currentCentralWisget != m_nativeCentralWidget) {
+		static_cast<StreamElementsBrowserWidget *>(currentCentralWisget)
+			->RemoveVideoCompositionView();
+	}
 
 	QApplication::sendPostedEvents();
 	QSize currSize = mainWindow()->centralWidget()->size();


### PR DESCRIPTION
Add API Methods:

- setSharedVideoCompositionProperties

Modify Data Objects

- SharedVideoCompositionInfo: rename `sharedVideoCompositionId` to `id` to match convention
