### PR TITLE
New: API 6.7: Support for overriding output frame size at the encoder level

### DIFF
--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -59,8 +59,9 @@ public:
 			CefRefPtr<CefValue> result = CefValue::Create();
 
 			if (m_obsEncoderInfo.get() &&
-			    m_obsEncoderInfo->GetType() == VTYPE_DICTIONARY)
+			    m_obsEncoderInfo->GetType() == VTYPE_DICTIONARY) {
 				result->SetValue(m_obsEncoderInfo->Copy());
+			}
 			else
 				result->SetInt(m_index);
 

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -4204,9 +4204,26 @@ static obs_encoder_t *DeserializeObsEncoder(obs_encoder_type type,
 	if (mixer_idx < 0 || mixer_idx >= MAX_AUDIO_MIXES)
 		mixer_idx = 0;
 
-	if (type == OBS_ENCODER_VIDEO)
-		return obs_video_encoder_create(id.c_str(), name.c_str(),
+	if (type == OBS_ENCODER_VIDEO) {
+		auto encoder = obs_video_encoder_create(id.c_str(), name.c_str(),
 						settings, nullptr);
+
+		if (encoder && d->HasKey("width") &&
+		   d->GetType("width") == VTYPE_INT &&
+		   d->HasKey("height") && d->GetType("height") == VTYPE_INT)
+		{
+			int width = d->GetInt("width");
+			int height = d->GetInt("height");
+
+			if (width > 0 && height > 0) {
+				obs_encoder_set_scaled_size(encoder, width,
+							    height);
+			}
+		}
+
+		return encoder;
+	}
+
 	else if (type == OBS_ENCODER_AUDIO)
 		return obs_audio_encoder_create(id.c_str(), name.c_str(),
 						settings,

--- a/streamelements/Version.hpp
+++ b/streamelements/Version.hpp
@@ -15,7 +15,7 @@
  * of existing functionality).
  */
 #ifndef HOST_API_VERSION_MINOR
-#define HOST_API_VERSION_MINOR 6
+#define HOST_API_VERSION_MINOR 7
 #endif
 
 /* Numeric value in the YYYYMMDDHHmmss format, indicating the current


### PR DESCRIPTION
Modify Data Structures:

- ObsEncoderInfo - `width` and `height` are now writable (value above 0 = override)
