### PR TITLE
Bugfixes to issues reported by discord users

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2212,7 +2212,9 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 
 	API_HANDLER_BEGIN("requestStreamingStart");
 	{
-		obs_frontend_streaming_start();
+		StreamElementsGlobalStateManager::GetInstance()
+			->GetNativeOBSControlsManager()
+			->StartStreaming();
 
 		result->SetBool(true);
 	}

--- a/streamelements/StreamElementsBrowserDialog.cpp
+++ b/streamelements/StreamElementsBrowserDialog.cpp
@@ -1,5 +1,6 @@
 #include "StreamElementsBrowserDialog.hpp"
 #include "StreamElementsApiMessageHandler.hpp"
+#include "StreamElementsGlobalStateManager.hpp"
 
 #include <QVBoxLayout>
 
@@ -214,8 +215,12 @@ void StreamElementsBrowserDialog::DestroyBrowser(std::string reason)
 	layout()->removeWidget(m_browser);
 
 	m_browser->DestroyBrowser();
-	//m_browser->deleteLater();
-	delete m_browser;
+
+	if (StreamElementsGlobalStateManager::IsInstanceAvailable()) {
+		m_browser->deleteLater();
+	} else {
+		delete m_browser;
+	}
 
 	m_browser = nullptr;
 }

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -307,6 +307,8 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 std::shared_ptr<StreamElementsGlobalStateManager> StreamElementsGlobalStateManager::s_instance =
 	nullptr;
 
+/* ========================================================================= */
+
 StreamElementsGlobalStateManager::StreamElementsGlobalStateManager(
 	StreamElementsGlobalStateManager::Private)
 {
@@ -321,7 +323,8 @@ std::shared_ptr<StreamElementsGlobalStateManager>
 StreamElementsGlobalStateManager::GetInstance()
 {
 	if (!s_instance) {
-		s_instance = std::make_shared<StreamElementsGlobalStateManager>(
+		s_instance = std::make_shared<
+			StreamElementsGlobalStateManager>(
 			StreamElementsGlobalStateManager::Private());
 	}
 
@@ -340,7 +343,6 @@ bool StreamElementsGlobalStateManager::IsInstanceAvailable()
 
 	return s_instance->IsInitialized();
 }
-
 
 #include <QWindow>
 #include <QObjectList>

--- a/streamelements/StreamElementsNativeOBSControlsManager.cpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.cpp
@@ -1,4 +1,5 @@
 #include "StreamElementsNativeOBSControlsManager.hpp"
+#include "StreamElementsGlobalStateManager.hpp"
 #include "StreamElementsUtils.hpp"
 #include <QDockWidget>
 #include <QVBoxLayout>
@@ -342,6 +343,8 @@ void StreamElementsNativeOBSControlsManager::Reset()
 {
 	SetStartStreamingMode(StreamElementsNativeOBSControlsManager::start);
 
+	os_atomic_set_bool(&m_isStreamingTransitionState, false);
+
 	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	HidePreviewTitleBar();
 	HidePreviewFrame();
@@ -364,6 +367,8 @@ void StreamElementsNativeOBSControlsManager::SetStreamingActiveState()
 {
 	if (!m_startStopStreamingButton) return;
 
+	os_atomic_set_bool(&m_isStreamingTransitionState, false);
+
 	QtExecSync([&] {
 		m_startStopStreamingButton->setText(obs_module_text("StreamElements.Action.StopStreaming"));
 		m_startStopStreamingButton->setEnabled(true);
@@ -377,6 +382,8 @@ void StreamElementsNativeOBSControlsManager::SetStreamingActiveState()
 void StreamElementsNativeOBSControlsManager::SetStreamingStoppedState()
 {
 	if (!m_startStopStreamingButton) return;
+
+	os_atomic_set_bool(&m_isStreamingTransitionState, false);
 
 	StopTimeoutTracker();
 
@@ -394,6 +401,8 @@ void StreamElementsNativeOBSControlsManager::SetStreamingTransitionState()
 {
 	if (!m_startStopStreamingButton) return;
 
+	os_atomic_set_bool(&m_isStreamingTransitionState, true);
+
 	if (obs_frontend_streaming_active()) {
 		SetStreamingTransitionStoppingState();
 	}
@@ -405,6 +414,8 @@ void StreamElementsNativeOBSControlsManager::SetStreamingTransitionState()
 void StreamElementsNativeOBSControlsManager::SetStreamingTransitionStartingState()
 {
 	if (!m_startStopStreamingButton) return;
+
+	os_atomic_set_bool(&m_isStreamingTransitionState, true);
 
 	StopTimeoutTracker();
 
@@ -435,6 +446,8 @@ void StreamElementsNativeOBSControlsManager::SetStreamingRequestedState()
 void StreamElementsNativeOBSControlsManager::SetStreamingTransitionStoppingState()
 {
 	if (!m_startStopStreamingButton) return;
+
+	os_atomic_set_bool(&m_isStreamingTransitionState, true);
 
 	StopTimeoutTracker();
 
@@ -614,6 +627,30 @@ void StreamElementsNativeOBSControlsManager::BeginStartStreaming()
 		break;
 	}
 }
+
+void StreamElementsNativeOBSControlsManager::StartStreaming()
+{
+	SetStreamingInitialState();
+
+	m_startStopStreamingButton->setEnabled(false);
+
+	QtDelayTask(
+		[this]() {
+			if (!StreamElementsGlobalStateManager::
+				    IsInstanceAvailable())
+				return;
+
+			if (!os_atomic_load_bool(&m_isStreamingTransitionState))
+				m_startStopStreamingButton->setEnabled(true);
+		},
+		5000);
+
+	obs_frontend_streaming_start();
+
+	if (!m_startStopStreamingButton)
+		return;
+}
+
 
 bool StreamElementsNativeOBSControlsManager::DeserializeStartStreamingUIHandlerProperties(CefRefPtr<CefValue> input)
 {

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -127,6 +127,9 @@ public:
 
 	void Reset();
 
+public:
+	void StartStreaming();
+
 private:
 	void SetStreamingInitialState();
 	void SetStreamingActiveState();
@@ -171,6 +174,8 @@ private:
 	int m_startStreamingRequestAcknowledgeTimeoutSeconds = 5;
 	QTimer* m_timeoutTimer = nullptr;
 	std::recursive_mutex m_timeoutTimerMutex;
+
+	bool m_isStreamingTransitionState = false;
 
 	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
 	QFrame *m_previewFrame = nullptr;


### PR DESCRIPTION
- Revert to old CEF shutdown behavior when closing a dialog window while plugin is running
- Start streaming will no longer get stuck in "starting streaming" state when OBS detects validation issues before actually starting to stream