### PR TITLE
Lazy video encoder creation

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -2646,7 +2646,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		StreamElementsGlobalStateManager::GetInstance()
 			->GetOutputManager()
 			->SerializeAllOutputs(
-				StreamElementsOutputBase::StreamingOutput,
+				StreamingOutput,
 				result);
 	}
 	API_HANDLER_END();
@@ -2657,7 +2657,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->DeserializeOutput(
-					StreamElementsOutputBase::StreamingOutput,
+					StreamingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2669,7 +2669,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->RemoveOutputsByIds(
-					StreamElementsOutputBase::StreamingOutput,
+					StreamingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2681,7 +2681,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->EnableOutputsByIds(
-					StreamElementsOutputBase::StreamingOutput,
+					StreamingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2693,7 +2693,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->DisableOutputsByIds(
-					StreamElementsOutputBase::StreamingOutput,
+					StreamingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2704,7 +2704,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		StreamElementsGlobalStateManager::GetInstance()
 			->GetOutputManager()
 			->SerializeAllOutputs(
-				StreamElementsOutputBase::RecordingOutput,
+				RecordingOutput,
 				result);
 	}
 	API_HANDLER_END();
@@ -2715,7 +2715,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->DeserializeOutput(
-					StreamElementsOutputBase::RecordingOutput,
+					RecordingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2727,7 +2727,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->RemoveOutputsByIds(
-					StreamElementsOutputBase::RecordingOutput,
+					RecordingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2739,7 +2739,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->EnableOutputsByIds(
-					StreamElementsOutputBase::RecordingOutput,
+					RecordingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2751,7 +2751,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
 				->DisableOutputsByIds(
-					StreamElementsOutputBase::RecordingOutput,
+					RecordingOutput,
 					args->GetValue(0), result);
 		}
 	}
@@ -2773,7 +2773,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		StreamElementsGlobalStateManager::GetInstance()
 			->GetOutputManager()
 			->SerializeAllOutputs(
-				StreamElementsOutputBase::ReplayBufferOutput,
+				ReplayBufferOutput,
 				result);
 	}
 	API_HANDLER_END();
@@ -2783,8 +2783,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
-				->DeserializeOutput(StreamElementsOutputBase::
-							    ReplayBufferOutput,
+				->DeserializeOutput(ReplayBufferOutput,
 						    args->GetValue(0), result);
 		}
 	}
@@ -2795,8 +2794,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
-				->RemoveOutputsByIds(StreamElementsOutputBase::
-							     ReplayBufferOutput,
+				->RemoveOutputsByIds(ReplayBufferOutput,
 						     args->GetValue(0), result);
 		}
 	}
@@ -2807,8 +2805,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
-				->EnableOutputsByIds(StreamElementsOutputBase::
-							     ReplayBufferOutput,
+				->EnableOutputsByIds(ReplayBufferOutput,
 						     args->GetValue(0), result);
 		}
 	}
@@ -2819,10 +2816,9 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		if (args->GetSize()) {
 			StreamElementsGlobalStateManager::GetInstance()
 				->GetOutputManager()
-				->DisableOutputsByIds(
-					StreamElementsOutputBase::
-						ReplayBufferOutput,
-					args->GetValue(0), result);
+				->DisableOutputsByIds(ReplayBufferOutput,
+						      args->GetValue(0),
+						      result);
 		}
 	}
 	API_HANDLER_END();

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -38,10 +38,10 @@ static std::string getRecordingsFolderPath()
 	return std::string(path);
 }
 
-static std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+static std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 GetVideoEncodersFromOutput(obs_output_t *output)
 {
-	std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+	std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 		result;
 
 	if (output) {
@@ -56,13 +56,13 @@ GetVideoEncodersFromOutput(obs_output_t *output)
 
 			result.push_back(
 				std::make_shared <
-				StreamElementsOutputBase::VideoEncoder>(idx));
+				StreamElementsOutputBase::VideoEncoderTemplate>(idx));
 		}
 	}
 
 	if (!result.size()) {
 		result.push_back(std::make_shared <
-				 StreamElementsOutputBase::VideoEncoder>(0));
+				 StreamElementsOutputBase::VideoEncoderTemplate>(0));
 	}
 
 	return result;
@@ -152,10 +152,10 @@ DeserializeAudioTracks(CefRefPtr<CefDictionaryValue> rootDict)
 	return DeserializeTracks(rootDict, "audioTracks", MAX_AUDIO_MIXES);
 }
 
-static std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+static std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
 {
-	std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+	std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 		result;
 
 
@@ -179,7 +179,7 @@ DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
 
 				result.push_back(std::make_shared<
 						 StreamElementsOutputBase::
-							 VideoEncoder>(value));
+							 VideoEncoderTemplate>(value));
 
 			} else if (list->GetType(i) == VTYPE_INT) {
 				auto trackIndex = uint32_t(list->GetInt(i));
@@ -200,7 +200,7 @@ DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
 						result.push_back(
 							std::make_shared<
 								StreamElementsOutputBase::
-									VideoEncoder>(
+									VideoEncoderTemplate>(
 								trackIndex));
 					}
 				}
@@ -210,7 +210,7 @@ DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
 
 	if (!result.size()) {
 		result.push_back(
-			std::make_shared<StreamElementsOutputBase::VideoEncoder>(0));
+			std::make_shared<StreamElementsOutputBase::VideoEncoderTemplate>(0));
 	}
 
 	return result;
@@ -218,9 +218,9 @@ DeserializeVideoEncoders(CefRefPtr<CefDictionaryValue> rootDict)
 
 static void dispatch_list_change_event(StreamElementsOutputBase *output)
 {
-	if (output->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (output->GetOutputType() == StreamingOutput)
 		DispatchJSEventGlobal("hostStreamingOutputListChanged", "null");
-	else if (output->GetOutputType() == StreamElementsOutputBase::RecordingOutput)
+	else if (output->GetOutputType() == RecordingOutput)
 		DispatchJSEventGlobal("hostRecordingOutputListChanged", "null");
 	else
 		DispatchJSEventGlobal("hostReplayBufferOutputListChanged", "null");
@@ -247,10 +247,9 @@ void StreamElementsOutputBase::handle_output_start(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStarted");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStarted");
 	else
 		dispatch_event(self, "hostReplayBufferOutputStarted");
@@ -315,20 +314,17 @@ void StreamElementsOutputBase::handle_output_stop(void *my_data,
 
 		self->SetError(args->GetString("reason"));
 
-		if (self->GetOutputType() ==
-		    StreamElementsOutputBase::StreamingOutput)
+		if (self->GetOutputType() == StreamingOutput)
 			dispatch_event(self, "hostStreamingOutputError", args);
-		else if (self->GetOutputType() ==
-			 StreamElementsOutputBase::RecordingOutput)
+		else if (self->GetOutputType() == RecordingOutput)
 			dispatch_event(self, "hostRecordingOutputError", args);
 		else
 			dispatch_event(self, "hostReplayBufferOutputError", args);
 	}
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStopped");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStopped");
 	else
 		dispatch_event(self, "hostReplayBufferOutputStopped");
@@ -343,10 +339,9 @@ void StreamElementsOutputBase::handle_output_pause(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputPaused");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputPaused");
 	else
 		dispatch_event(self, "hostReplayBufferOutputPaused");
@@ -361,10 +356,9 @@ void StreamElementsOutputBase::handle_output_unpause(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputUnpaused");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputUnpaused");
 	else
 		dispatch_event(self, "hostReplayBufferOutputUnpaused");
@@ -379,10 +373,9 @@ void StreamElementsOutputBase::handle_output_starting(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStarting");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStarting");
 	else
 		dispatch_event(self, "hostReplayBufferOutputStarting");
@@ -397,10 +390,9 @@ void StreamElementsOutputBase::handle_output_stopping(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputStopping");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputStopping");
 	else
 		dispatch_event(self, "hostReplayBufferOutputStopping");
@@ -415,10 +407,9 @@ void StreamElementsOutputBase::handle_output_activate(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputActivated");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputActivated");
 	else
 		dispatch_event(self, "hostReplayBufferOutputActivated");
@@ -433,10 +424,9 @@ void StreamElementsOutputBase::handle_output_deactivate(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputDeactivated");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputDeactivated");
 	else
 		dispatch_event(self, "hostReplayBufferOutputDeactivated");
@@ -451,10 +441,9 @@ void StreamElementsOutputBase::handle_output_reconnect(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputReconnecting");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputReconnecting");
 	else
 		dispatch_event(self, "hostReplayBufferOutputReconnecting");
@@ -470,10 +459,9 @@ StreamElementsOutputBase::handle_output_reconnect_success(void *my_data,
 
 	auto self = (StreamElementsOutputBase *)my_data;
 
-	if (self->GetOutputType() == StreamElementsOutputBase::StreamingOutput)
+	if (self->GetOutputType() == StreamingOutput)
 		dispatch_event(self, "hostStreamingOutputReconnected");
-	else if (self->GetOutputType() ==
-		 StreamElementsOutputBase::RecordingOutput)
+	else if (self->GetOutputType() == RecordingOutput)
 		dispatch_event(self, "hostRecordingOutputReconnected");
 	else
 		dispatch_event(self, "hostReplayBufferOutputReconnected");
@@ -870,20 +858,27 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	std::vector<obs_encoder_t*> streamingVideoEncoders;
+	m_videoEncoders.clear();
+	m_videoEncoderProviders.clear();
 
-	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
-		obs_encoder_t* streamingVideoEncoder =
-			m_videoEncoders[i]->GetStreamingEncoderRef(
-				videoCompositionInfo);
+	for (size_t i = 0; i < m_videoEncoderTemplates.size(); ++i) {
 
-		if (!streamingVideoEncoder)
+		auto provider = m_videoEncoderTemplates[i]
+					->CreateStreamingEncoderProvider(
+						videoCompositionInfo);
+
+		if (!provider)
 			break;
 
-		streamingVideoEncoders.push_back(streamingVideoEncoder);
+		auto encoder = provider->GetLazyObjectReference();
+
+		if (!encoder)
+			break;
+
+		m_videoEncoders.push_back(encoder);
 	}
 
-	if (!streamingVideoEncoders.size() && videoCompositionInfo->IsObsNative()) {
+	if (!m_videoEncoders.size() && videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
 		     "obs-streamelements-core: OBS Native streaming video encoders do not exist yet on streaming output '%s'",
 		     GetId().c_str());
@@ -899,6 +894,9 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 		dispatch_event(this, "hostStreamingOutputError", args);
 		dispatch_event(this, "hostStreamingOutputStopped");
 		dispatch_list_change_event(this);
+
+		m_videoEncoders.clear();
+		m_videoEncoderProviders.clear();
 
 		return false;
 	}
@@ -924,11 +922,11 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 
 	if (m_output) {
 		obs_output_set_video_encoder(m_output,
-					     streamingVideoEncoders[0]);
+					     m_videoEncoders[0]->Get());
 
-		for (size_t i = 1; i < streamingVideoEncoders.size(); ++i) {
+		for (size_t i = 1; i < m_videoEncoders.size(); ++i) {
 			obs_output_set_video_encoder2(
-				m_output, streamingVideoEncoders[i], i);
+				m_output, m_videoEncoders[i]->Get(), i);
 		}
 
 		size_t audioEncodersCount = 0;
@@ -994,10 +992,6 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 			"Failed to create output");
 	}
 
-	for (const auto &encoder : streamingVideoEncoders) {
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
-
 	return result;
 }
 
@@ -1014,6 +1008,9 @@ void StreamElementsCustomStreamingOutput::StopInternal()
 
 	obs_output_release(SETRACE_DECREF(m_output));
 	m_output = nullptr;
+
+	m_videoEncoders.clear();
+	m_videoEncoderProviders.clear();
 }
 
 void StreamElementsCustomStreamingOutput::SerializeOutputSettings(
@@ -1274,7 +1271,7 @@ std::vector<uint32_t> StreamElementsObsNativeStreamingOutput::GetAudioTracks()
 	return result;
 }
 
-std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 StreamElementsObsNativeStreamingOutput::GetVideoEncoders()
 {
 	OBSOutputAutoRelease output = SETRACE_AUTODECREF(GetOutput());
@@ -1348,7 +1345,7 @@ std::vector<uint32_t> StreamElementsObsNativeRecordingOutput::GetAudioTracks()
 	return result;
 }
 
-std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 StreamElementsObsNativeRecordingOutput::GetVideoEncoders()
 {
 	OBSOutputAutoRelease output = SETRACE_AUTODECREF(GetOutput());
@@ -1412,20 +1409,27 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	std::vector<obs_encoder_t*> recordingVideoEncoders;
+	m_videoEncoders.clear();
+	m_videoEncoderProviders.clear();
 
-	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
-		obs_encoder_t* recordingVideoEncoder =
-			m_videoEncoders[i]
-				->GetRecordingEncoderRef(videoCompositionInfo);
+	for (size_t i = 0; i < m_videoEncoderTemplates.size(); ++i) {
 
-		if (!recordingVideoEncoder)
+		auto provider = m_videoEncoderTemplates[i]
+					->CreateRecordingEncoderProvider(
+						videoCompositionInfo);
+
+		if (!provider)
 			break;
 
-		recordingVideoEncoders.push_back(recordingVideoEncoder);
+		auto encoder = provider->GetLazyObjectReference();
+
+		if (!encoder)
+			break;
+
+		m_videoEncoders.push_back(encoder);
 	}
 
-	if (!recordingVideoEncoders.size() &&
+	if (!m_videoEncoders.size() &&
 	    videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
 		     "obs-streamelements-core: OBS Native recording video encoders do not exist yet on recording output '%s'",
@@ -1442,6 +1446,10 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 		dispatch_event(this, "hostRecordingOutputError", args);
 		dispatch_event(this, "hostRecordingOutputStopped");
 		dispatch_list_change_event(this);
+
+
+		m_videoEncoders.clear();
+		m_videoEncoderProviders.clear();
 
 		return false;
 	}
@@ -1597,12 +1605,12 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 
 	if (m_output) {
 		obs_output_set_video_encoder(m_output,
-					     recordingVideoEncoders[0]);
+					     m_videoEncoders[0]->Get());
 
-		for (size_t i = 1; i < recordingVideoEncoders.size(); ++i) {
+		for (size_t i = 1; i < m_videoEncoders.size(); ++i) {
 			// TODO: Find by request
-			obs_output_set_video_encoder2(
-				m_output, recordingVideoEncoders[i], i);
+			obs_output_set_video_encoder2(m_output,
+						      m_videoEncoders[i]->Get(), i);
 		}
 
 		size_t audioEncodersCount = 0;
@@ -1663,10 +1671,6 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 		     GetId().c_str(), output_type);
 
 		SetError("Failed to create output");
-	}
-
-	for (const auto &encoder : recordingVideoEncoders) {
-		obs_encoder_release(SETRACE_DECREF(encoder));
 	}
 
 	return result;
@@ -1873,7 +1877,7 @@ StreamElementsObsNativeReplayBufferOutput::GetAudioTracks()
 	return result;
 }
 
-std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoder>>
+std::vector<std::shared_ptr<StreamElementsOutputBase::VideoEncoderTemplate>>
 StreamElementsObsNativeReplayBufferOutput::GetVideoEncoders()
 {
 	OBSOutputAutoRelease output = SETRACE_AUTODECREF(GetOutput());
@@ -1902,20 +1906,27 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 	if (!videoCompositionInfo)
 		return false;
 
-	std::vector<obs_encoder_t*> recordingVideoEncoders;
+	m_videoEncoders.clear();
+	m_videoEncoderProviders.clear();
 
-	for (size_t i = 0; i < m_videoEncoders.size(); ++i) {
-		obs_encoder_t* recordingVideoEncoder =
-			m_videoEncoders[i]->GetRecordingEncoderRef(
+	for (size_t i = 0; i < m_videoEncoderTemplates.size(); ++i) {
+		
+		auto provider =
+			m_videoEncoderTemplates[i]->CreateRecordingEncoderProvider(
 				videoCompositionInfo);
 
-		if (!recordingVideoEncoder)
+		if (!provider)
 			break;
 
-		recordingVideoEncoders.push_back(recordingVideoEncoder);
+		auto encoder = provider->GetLazyObjectReference();
+
+		if (!encoder)
+			break;
+
+		m_videoEncoders.push_back(encoder);
 	}
 
-	if (!recordingVideoEncoders.size() && videoCompositionInfo->IsObsNative()) {
+	if (!m_videoEncoders.size() && videoCompositionInfo->IsObsNative()) {
 		blog(LOG_WARNING,
 		     "obs-streamelements-core: OBS Native recording video encoders do not exist yet on replay buffer output '%s'",
 		     GetId().c_str());
@@ -1931,6 +1942,9 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 		dispatch_event(this, "hostReplayBufferOutputError", args);
 		dispatch_event(this, "hostReplayBufferOutputStopped");
 		dispatch_list_change_event(this);
+
+		m_videoEncoders.clear();
+		m_videoEncoderProviders.clear();
 
 		return false;
 	}
@@ -2080,12 +2094,12 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 
 	if (m_output) {
 		obs_output_set_video_encoder(m_output,
-					     recordingVideoEncoders[0]);
+					     m_videoEncoders[0]->Get());
 
-		for (size_t i = 1; i < recordingVideoEncoders.size(); ++i) {
+		for (size_t i = 1; i < m_videoEncoders.size(); ++i) {
 			// TODO: Find by request
-			obs_output_set_video_encoder2(
-				m_output, recordingVideoEncoders[i], i);
+			obs_output_set_video_encoder2(m_output,
+						      m_videoEncoders[i]->Get(), i);
 		}
 
 		size_t audioEncodersCount = 0;
@@ -2148,10 +2162,6 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 		SetError("Failed to create output");
 	}
 
-	for (const auto &encoder : recordingVideoEncoders) {
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
-
 	return result;
 }
 
@@ -2169,6 +2179,9 @@ void StreamElementsCustomReplayBufferOutput::StopInternal()
 
 	obs_output_release(SETRACE_DECREF(m_output));
 	m_output = nullptr;
+
+	m_videoEncoders.clear();
+	m_videoEncoderProviders.clear();
 }
 
 void StreamElementsCustomReplayBufferOutput::SerializeOutputSettings(

--- a/streamelements/StreamElementsOutput.cpp
+++ b/streamelements/StreamElementsOutput.cpp
@@ -875,6 +875,7 @@ bool StreamElementsCustomStreamingOutput::StartInternal(
 		if (!encoder)
 			break;
 
+		m_videoEncoderProviders.push_back(provider);
 		m_videoEncoders.push_back(encoder);
 	}
 
@@ -1426,6 +1427,7 @@ bool StreamElementsCustomRecordingOutput::StartInternal(
 		if (!encoder)
 			break;
 
+		m_videoEncoderProviders.push_back(provider);
 		m_videoEncoders.push_back(encoder);
 	}
 
@@ -1923,6 +1925,7 @@ bool StreamElementsCustomReplayBufferOutput::StartInternal(
 		if (!encoder)
 			break;
 
+		m_videoEncoderProviders.push_back(provider);
 		m_videoEncoders.push_back(encoder);
 	}
 

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -19,6 +19,11 @@ private:
 	CefRefPtr<CefValue> m_obsEncoderInfo;
 	ObsOutputType m_outputType;
 
+	std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
+		m_encoderProviderRef = nullptr;
+	std::shared_ptr<SELazyObjectReference<obs_encoder_t>> m_encoderRef =
+		nullptr;
+
 public:
 	SEVideoCompositionVideoEncoderProvider(
 		std::shared_ptr<
@@ -39,6 +44,10 @@ protected:
 	virtual obs_encoder_t *AllocRef() override
 	{
 		obs_encoder_t *result = nullptr;
+
+		// Release previously held resources if any
+		m_encoderRef = nullptr;
+		m_encoderProviderRef = nullptr;
 
 		if (m_obsEncoderInfo.get()) {
 			result = DeserializeObsVideoEncoder(
@@ -72,27 +81,42 @@ protected:
 				obs_encoder_set_video(
 					result, m_videoCompositionBase
 							->GetVideo());
+
+				return result;
 			}
 		}
 
-		std::shared_ptr<SELazyObjectReference<obs_encoder_t>> ref =
-			nullptr;
-
 		if (m_outputType != StreamingOutput)
 		{
-			ref = m_videoCompositionBase
-				      ->GetRecordingVideoEncoderRef(m_index);
+			m_encoderProviderRef =
+				m_videoCompositionBase
+					->GetRecordingVideoEncoderProvider(m_index);
 
+			if (m_encoderProviderRef) {
+				m_encoderRef =
+					m_encoderProviderRef
+						->GetLazyObjectReference();
+			}
 		}
 
-		if (!ref) {
-			ref = m_videoCompositionBase
-				      ->GetStreamingVideoEncoderRef(m_index);
+		if (!m_encoderRef) {
+			m_encoderProviderRef =
+				m_videoCompositionBase
+					->GetStreamingVideoEncoderProvider(
+						m_index);
+
+			if (m_encoderProviderRef) {
+				m_encoderRef =
+					m_encoderProviderRef
+						->GetLazyObjectReference();
+			}
 		}
 
-		if (ref) {
+		if (m_encoderRef) {
 			result = SETRACE_ADDREF(
-				obs_encoder_get_ref(ref->Get()));
+				obs_encoder_get_ref(m_encoderRef->Get()));
+		} else {
+			m_encoderProviderRef = nullptr;
 		}
 
 		return result;
@@ -106,6 +130,13 @@ protected:
 	virtual void ReleaseRef(obs_encoder_t *encoder) override
 	{
 		return obs_encoder_release(SETRACE_DECREF(encoder));
+	}
+
+	virtual void ReleaseAuxiliaryResources() override
+	{
+		// When last reference to the encoder is released, we want to release the internal reference as well
+		m_encoderRef = nullptr;
+		m_encoderProviderRef = nullptr;
 	}
 };
 

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -88,8 +88,13 @@ public:
 				}
 			}
 
-			result = videoCompositionBase
-					 ->GetStreamingVideoEncoderRef(m_index);
+			auto ref =
+				videoCompositionBase
+					->GetStreamingVideoEncoderRef(m_index);
+
+			if (ref) {
+				result = SETRACE_ADDREF(obs_encoder_get_ref(ref->Get()));
+			}
 
 			return result;
 		}
@@ -114,8 +119,13 @@ public:
 				}
 			}
 
-			result = videoCompositionBase
-					 ->GetRecordingVideoEncoderRef(m_index);
+			auto ref =
+				videoCompositionBase
+					->GetRecordingVideoEncoderRef(m_index);
+
+			if (ref) {
+				result = SETRACE_ADDREF(obs_encoder_get_ref(ref->Get()));
+			}
 
 			return result;
 		}

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -6,6 +6,109 @@
 
 #include <shared_mutex>
 
+
+enum ObsOutputType { StreamingOutput, RecordingOutput, ReplayBufferOutput };
+
+class SEVideoCompositionVideoEncoderProvider
+	: public SELazyObjectProviderBase<obs_encoder_t> {
+private:
+	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
+		m_videoCompositionBase;
+
+	size_t m_index;
+	CefRefPtr<CefValue> m_obsEncoderInfo;
+	ObsOutputType m_outputType;
+
+public:
+	SEVideoCompositionVideoEncoderProvider(
+		std::shared_ptr<
+			StreamElementsVideoCompositionBase::CompositionInfo>
+			videoCompositionBase,
+		size_t index,
+		CefRefPtr<CefValue> obsEncoderInfo, ObsOutputType outputType)
+	{
+		m_index = index;
+		m_videoCompositionBase = videoCompositionBase;
+		m_obsEncoderInfo = obsEncoderInfo;
+		m_outputType = outputType;
+	}
+
+	~SEVideoCompositionVideoEncoderProvider() {}
+
+protected:
+	virtual obs_encoder_t *AllocRef() override
+	{
+		obs_encoder_t *result = nullptr;
+
+		if (m_obsEncoderInfo.get()) {
+			result = DeserializeObsVideoEncoder(
+				m_obsEncoderInfo);
+
+			if (result) {
+				switch (video_output_get_format(
+					obs_get_video())) {
+				case VIDEO_FORMAT_I420:
+				case VIDEO_FORMAT_NV12:
+				case VIDEO_FORMAT_I010:
+				case VIDEO_FORMAT_P010:
+					break;
+				default:
+					obs_encoder_set_preferred_video_format(
+						result,
+						VIDEO_FORMAT_NV12);
+				}
+
+				uint32_t width, height;
+				m_videoCompositionBase->GetVideoBaseDimensions(
+					&width, &height);
+
+				//
+				// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
+				// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
+				//
+				obs_encoder_set_scaled_size(result,
+							    width, height);
+
+				obs_encoder_set_video(
+					result, m_videoCompositionBase
+							->GetVideo());
+			}
+		}
+
+		std::shared_ptr<SELazyObjectReference<obs_encoder_t>> ref =
+			nullptr;
+
+		if (m_outputType != StreamingOutput)
+		{
+			ref = m_videoCompositionBase
+				      ->GetRecordingVideoEncoderRef(m_index);
+
+		}
+
+		if (!ref) {
+			ref = m_videoCompositionBase
+				      ->GetStreamingVideoEncoderRef(m_index);
+		}
+
+		if (ref) {
+			result = SETRACE_ADDREF(
+				obs_encoder_get_ref(ref->Get()));
+		}
+
+		return result;
+	}
+
+	virtual obs_encoder_t *AddRef(obs_encoder_t *encoder) override
+	{
+		return SETRACE_ADDREF(obs_encoder_get_ref(encoder));
+	}
+
+	virtual void ReleaseRef(obs_encoder_t *encoder) override
+	{
+		return obs_encoder_release(SETRACE_DECREF(encoder));
+	}
+};
+
 class StreamElementsOutputBase
 	: public StreamElementsVideoCompositionEventListener,
 	  public StreamElementsAudioCompositionEventListener {
@@ -17,35 +120,29 @@ public:
 		None
 	};
 
-	enum ObsOutputType {
-		StreamingOutput,
-		RecordingOutput,
-		ReplayBufferOutput
-	};
-
-	class VideoEncoder {
+	class VideoEncoderTemplate {
 	public:
 		size_t m_index;
 		CefRefPtr<CefValue> m_obsEncoderInfo;
 
 	public:
-		VideoEncoder(size_t index)
+		VideoEncoderTemplate(size_t index)
 			: m_index(index), m_obsEncoderInfo(CefValue::Create())
 		{
 			m_obsEncoderInfo->SetNull();
 		}
 
-		VideoEncoder(CefRefPtr<CefValue> obsEncoderInfo)
+		VideoEncoderTemplate(CefRefPtr<CefValue> obsEncoderInfo)
 			: m_index(0), m_obsEncoderInfo(obsEncoderInfo->Copy())
 		{
 		}
 
-		VideoEncoder(VideoEncoder &other)
+		VideoEncoderTemplate(VideoEncoderTemplate &other)
 			: m_index(other.m_index), m_obsEncoderInfo(other.m_obsEncoderInfo->Copy())
 		{
 		}
 
-		~VideoEncoder() {}
+		~VideoEncoderTemplate() {}
 
 		bool IsMatchingIndex(size_t index) {
 			if (m_obsEncoderInfo.get() &&
@@ -69,65 +166,26 @@ public:
 		}
 
 	public:
-		obs_encoder_t *GetStreamingEncoderRef(
+		std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
+		CreateStreamingEncoderProvider(
 			std::shared_ptr<StreamElementsVideoCompositionBase::
 						CompositionInfo> videoCompositionBase)
 		{
-			obs_encoder_t *result = nullptr;
-
-			if (m_obsEncoderInfo.get()) {
-				result = DeserializeObsVideoEncoder(
-					m_obsEncoderInfo);
-
-				if (result) {
-					obs_encoder_set_video(
-						result, videoCompositionBase
-								->GetVideo());
-
-					return result;
-				}
-			}
-
-			auto ref =
-				videoCompositionBase
-					->GetStreamingVideoEncoderRef(m_index);
-
-			if (ref) {
-				result = SETRACE_ADDREF(obs_encoder_get_ref(ref->Get()));
-			}
-
-			return result;
+			return std::make_shared<SEVideoCompositionVideoEncoderProvider>(
+				videoCompositionBase, m_index, m_obsEncoderInfo,
+				StreamingOutput);
 		}
 
-		obs_encoder_t *GetRecordingEncoderRef(
+		std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
+		CreateRecordingEncoderProvider(
 			std::shared_ptr<StreamElementsVideoCompositionBase::
 						CompositionInfo>
 				videoCompositionBase)
 		{
-			obs_encoder_t *result = nullptr;
-
-			if (m_obsEncoderInfo.get()) {
-				result = DeserializeObsVideoEncoder(
-					m_obsEncoderInfo);
-
-				if (result) {
-					obs_encoder_set_video(
-						result, videoCompositionBase
-								->GetVideo());
-
-					return result;
-				}
-			}
-
-			auto ref =
-				videoCompositionBase
-					->GetRecordingVideoEncoderRef(m_index);
-
-			if (ref) {
-				result = SETRACE_ADDREF(obs_encoder_get_ref(ref->Get()));
-			}
-
-			return result;
+			return std::make_shared<
+				SEVideoCompositionVideoEncoderProvider>(
+				videoCompositionBase, m_index, m_obsEncoderInfo,
+				RecordingOutput);
 		}
 	};
 
@@ -189,7 +247,7 @@ public:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) = 0;
 
 	virtual std::vector<uint32_t> GetAudioTracks() = 0;
-	virtual std::vector<std::shared_ptr<VideoEncoder>> GetVideoEncoders() = 0;
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>> GetVideoEncoders() = 0;
 
 	virtual bool CanSplitRecordingOutput() { return false; }
 	virtual bool TriggerSplitRecordingOutput() { return false; }
@@ -255,8 +313,13 @@ private:
 	std::string m_bindToIP;
 
 	std::vector<uint32_t> m_audioTracks = {0};
-	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0)};
+	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
+		std::make_shared<VideoEncoderTemplate>(0)};
+
+	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+		m_videoEncoderProviders;
+	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>> m_videoEncoders;
+
 
 public:
 	StreamElementsCustomStreamingOutput(
@@ -266,14 +329,14 @@ public:
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
 		std::vector<uint32_t> audioTracks,
-		std::vector<std::shared_ptr<VideoEncoder>> videoEncoders, obs_service_t *service,
+		std::vector<std::shared_ptr<VideoEncoderTemplate>> videoEncoders, obs_service_t *service,
 		const char *bindToIP, CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, StreamingOutput, Streaming,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_service(service),
 		  m_audioTracks(audioTracks),
-		  m_videoEncoders(videoEncoders)
+		  m_videoEncoderTemplates(videoEncoders)
 	{
 		if (bindToIP) {
 			m_bindToIP = bindToIP;
@@ -312,9 +375,9 @@ public:
 		return m_audioTracks;
 	}
 
-	virtual std::vector<std::shared_ptr<VideoEncoder>> GetVideoEncoders() override
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>> GetVideoEncoders() override
 	{
-		return m_videoEncoders;
+		return m_videoEncoderTemplates;
 	}
 
 	static std::shared_ptr<StreamElementsCustomStreamingOutput>
@@ -377,7 +440,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
-	virtual std::vector<std::shared_ptr<VideoEncoder>> GetVideoEncoders() override;
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>> GetVideoEncoders() override;
 };
 
 class StreamElementsObsNativeRecordingOutput : public StreamElementsOutputBase {
@@ -423,7 +486,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
-	virtual std::vector<std::shared_ptr<VideoEncoder>>
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>>
 	GetVideoEncoders() override;
 };
 
@@ -439,8 +502,13 @@ private:
 	CefRefPtr<CefDictionaryValue> m_recordingSettings = CefDictionaryValue::Create();
 
 	std::vector<uint32_t> m_audioTracks;
-	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0)};
+	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
+		std::make_shared<VideoEncoderTemplate>(0)};
+
+	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+		m_videoEncoderProviders;
+	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>>
+		m_videoEncoders;
 
 public:
 	StreamElementsCustomRecordingOutput(
@@ -451,14 +519,14 @@ public:
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
 		std::vector<uint32_t> audioTracks,
-		std::vector<std::shared_ptr<VideoEncoder>> videoEncoders,
+		std::vector<std::shared_ptr<VideoEncoderTemplate>> videoEncoders,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, RecordingOutput, None,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_recordingSettings(recordingSettings),
 		  m_audioTracks(audioTracks),
-		  m_videoEncoders(videoEncoders)
+		  m_videoEncoderTemplates(videoEncoders)
 	{
 	}
 
@@ -477,9 +545,9 @@ public:
 		return m_audioTracks;
 	}
 
-	virtual std::vector<std::shared_ptr<VideoEncoder>> GetVideoEncoders() override
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>> GetVideoEncoders() override
 	{
-		return m_videoEncoders;
+		return m_videoEncoderTemplates;
 	}
 
 	static std::shared_ptr<StreamElementsCustomRecordingOutput>
@@ -555,7 +623,7 @@ protected:
 	SerializeOutputSettings(CefRefPtr<CefValue> &output) override;
 
 	virtual std::vector<uint32_t> GetAudioTracks() override;
-	virtual std::vector<std::shared_ptr<VideoEncoder>>
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>>
 	GetVideoEncoders() override;
 };
 
@@ -572,8 +640,13 @@ private:
 		CefDictionaryValue::Create();
 
 	std::vector<uint32_t> m_audioTracks = {0};
-	std::vector<std::shared_ptr<VideoEncoder>> m_videoEncoders = {
-		std::make_shared<VideoEncoder>(0)};
+	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
+		std::make_shared<VideoEncoderTemplate>(0)};
+
+	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+		m_videoEncoderProviders;
+	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>>
+		m_videoEncoders;
 
 public:
 	StreamElementsCustomReplayBufferOutput(
@@ -584,14 +657,14 @@ public:
 		std::shared_ptr<StreamElementsAudioCompositionBase>
 			audioComposition,
 		std::vector<uint32_t> audioTracks,
-		std::vector<std::shared_ptr<VideoEncoder>> videoEncoders,
+		std::vector<std::shared_ptr<VideoEncoderTemplate>> videoEncoders,
 		CefRefPtr<CefDictionaryValue> auxData)
 		: StreamElementsOutputBase(id, name, ReplayBufferOutput, Streaming,
 					   videoComposition, audioComposition,
 					   auxData),
 		  m_recordingSettings(recordingSettings),
 		  m_audioTracks(audioTracks),
-		  m_videoEncoders(videoEncoders)
+		  m_videoEncoderTemplates(videoEncoders)
 	{
 	}
 
@@ -609,9 +682,9 @@ public:
 		return m_audioTracks;
 	}
 
-	virtual std::vector<std::shared_ptr<VideoEncoder>> GetVideoEncoders() override
+	virtual std::vector<std::shared_ptr<VideoEncoderTemplate>> GetVideoEncoders() override
 	{
-		return m_videoEncoders;
+		return m_videoEncoderTemplates;
 	}
 
 	static std::shared_ptr<StreamElementsCustomReplayBufferOutput>

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -192,6 +192,22 @@ public:
 					auto d = m_obsEncoderInfo
 							 ->GetDictionary();
 
+					CefRefPtr<CefValue> settingsInfo;
+
+					if (d->HasKey("settings") &&
+					    d->GetType("settings") ==
+						    VTYPE_DICTIONARY) {
+						obs_data_t* data =
+							obs_data_create();
+
+						if (DeserializeObsData(d->GetValue("settings"), data)) {
+							return data;
+						}
+						else {
+							obs_data_release(data);
+						}
+					}
+
 					if (d->HasKey("class") &&
 					    d->GetType("class") ==
 						    VTYPE_STRING) {

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -178,13 +178,24 @@ public:
 			virtual obs_data_t *GetSettingsRef() override
 			{
 				if (m_encoderProviderRef) {
-					m_encoderProviderRef->GetSettingsRef();
+					return m_encoderProviderRef->GetSettingsRef();
 				}
 
 				if (m_customEncoder) {
-					return obs_encoder_get_settings(
+					obs_data_t* data =
+						obs_encoder_get_defaults(
+							m_customEncoder);
+
+					OBSDataAutoRelease settings =
+						obs_encoder_get_settings(
 						m_customEncoder);
+
+					obs_data_apply(data, settings);
+
+					return data;
 				}
+
+				obs_data_t *result = obs_data_create();
 
 				if (m_obsEncoderInfo &&
 				    m_obsEncoderInfo->GetType() ==
@@ -194,20 +205,6 @@ public:
 
 					CefRefPtr<CefValue> settingsInfo;
 
-					if (d->HasKey("settings") &&
-					    d->GetType("settings") ==
-						    VTYPE_DICTIONARY) {
-						obs_data_t* data =
-							obs_data_create();
-
-						if (DeserializeObsData(d->GetValue("settings"), data)) {
-							return data;
-						}
-						else {
-							obs_data_release(data);
-						}
-					}
-
 					if (d->HasKey("class") &&
 					    d->GetType("class") ==
 						    VTYPE_STRING) {
@@ -215,13 +212,31 @@ public:
 							d->GetString("class")
 								.ToString();
 
-						if (id.size() > 0)
-							return obs_encoder_defaults(
-								id.c_str());
+						if (id.size() > 0) {
+							OBSDataAutoRelease defaults =
+								obs_encoder_defaults(
+									id.c_str());
+
+							obs_data_apply(
+								result,
+								defaults);
+						}
+					}
+
+					if (d->HasKey("settings") &&
+					    d->GetType("settings") ==
+						    VTYPE_DICTIONARY) {
+						OBSDataAutoRelease data =
+							obs_data_create();
+
+						if (DeserializeObsData(d->GetValue("settings"), data)) {
+							obs_data_apply(result,
+								       data);
+						}
 					}
 				}
 
-				return obs_data_create();
+				return result;
 			}
 
 			virtual std::string GetId() const override

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -334,6 +334,7 @@ public:
 						CompositionInfo> videoCompositionBase)
 		{
 			return std::make_shared<SELazyOBSVideoEncoderProvider>(
+				"StreamElementsOutputBase::VideoEncoderTemplate::CreateStreamingEncoderProvider()",
 				VideoCompositionEncoderAllocator::Create(
 					videoCompositionBase, m_index,
 					m_obsEncoderInfo, StreamingOutput));
@@ -346,7 +347,7 @@ public:
 				videoCompositionBase)
 		{
 			return std::make_shared<SELazyOBSVideoEncoderProvider>(
-
+				"StreamElementsOutputBase::VideoEncoderTemplate::CreateRecordingEncoderProvider()",
 				VideoCompositionEncoderAllocator::Create(
 					videoCompositionBase, m_index,
 					m_obsEncoderInfo, RecordingOutput));

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -9,137 +9,6 @@
 
 enum ObsOutputType { StreamingOutput, RecordingOutput, ReplayBufferOutput };
 
-class SEVideoCompositionVideoEncoderProvider
-	: public SELazyObjectProviderBase<obs_encoder_t> {
-private:
-	std::shared_ptr<StreamElementsVideoCompositionBase::CompositionInfo>
-		m_videoCompositionBase;
-
-	size_t m_index;
-	CefRefPtr<CefValue> m_obsEncoderInfo;
-	ObsOutputType m_outputType;
-
-	std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
-		m_encoderProviderRef = nullptr;
-	std::shared_ptr<SELazyObjectReference<obs_encoder_t>> m_encoderRef =
-		nullptr;
-
-public:
-	SEVideoCompositionVideoEncoderProvider(
-		std::shared_ptr<
-			StreamElementsVideoCompositionBase::CompositionInfo>
-			videoCompositionBase,
-		size_t index,
-		CefRefPtr<CefValue> obsEncoderInfo, ObsOutputType outputType)
-	{
-		m_index = index;
-		m_videoCompositionBase = videoCompositionBase;
-		m_obsEncoderInfo = obsEncoderInfo;
-		m_outputType = outputType;
-	}
-
-	~SEVideoCompositionVideoEncoderProvider() {}
-
-protected:
-	virtual obs_encoder_t *AllocRef() override
-	{
-		obs_encoder_t *result = nullptr;
-
-		// Release previously held resources if any
-		m_encoderRef = nullptr;
-		m_encoderProviderRef = nullptr;
-
-		if (m_obsEncoderInfo.get()) {
-			result = DeserializeObsVideoEncoder(
-				m_obsEncoderInfo);
-
-			if (result) {
-				switch (video_output_get_format(
-					obs_get_video())) {
-				case VIDEO_FORMAT_I420:
-				case VIDEO_FORMAT_NV12:
-				case VIDEO_FORMAT_I010:
-				case VIDEO_FORMAT_P010:
-					break;
-				default:
-					obs_encoder_set_preferred_video_format(
-						result,
-						VIDEO_FORMAT_NV12);
-				}
-
-				uint32_t width, height;
-				m_videoCompositionBase->GetVideoBaseDimensions(
-					&width, &height);
-
-				//
-				// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-				// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-				//
-				obs_encoder_set_scaled_size(result,
-							    width, height);
-
-				obs_encoder_set_video(
-					result, m_videoCompositionBase
-							->GetVideo());
-
-				return result;
-			}
-		}
-
-		if (m_outputType != StreamingOutput)
-		{
-			m_encoderProviderRef =
-				m_videoCompositionBase
-					->GetRecordingVideoEncoderProvider(m_index);
-
-			if (m_encoderProviderRef) {
-				m_encoderRef =
-					m_encoderProviderRef
-						->GetLazyObjectReference();
-			}
-		}
-
-		if (!m_encoderRef) {
-			m_encoderProviderRef =
-				m_videoCompositionBase
-					->GetStreamingVideoEncoderProvider(
-						m_index);
-
-			if (m_encoderProviderRef) {
-				m_encoderRef =
-					m_encoderProviderRef
-						->GetLazyObjectReference();
-			}
-		}
-
-		if (m_encoderRef) {
-			result = SETRACE_ADDREF(
-				obs_encoder_get_ref(m_encoderRef->Get()));
-		} else {
-			m_encoderProviderRef = nullptr;
-		}
-
-		return result;
-	}
-
-	virtual obs_encoder_t *AddRef(obs_encoder_t *encoder) override
-	{
-		return SETRACE_ADDREF(obs_encoder_get_ref(encoder));
-	}
-
-	virtual void ReleaseRef(obs_encoder_t *encoder) override
-	{
-		return obs_encoder_release(SETRACE_DECREF(encoder));
-	}
-
-	virtual void ReleaseAuxiliaryResources() override
-	{
-		// When last reference to the encoder is released, we want to release the internal reference as well
-		m_encoderRef = nullptr;
-		m_encoderProviderRef = nullptr;
-	}
-};
-
 class StreamElementsOutputBase
 	: public StreamElementsVideoCompositionEventListener,
 	  public StreamElementsAudioCompositionEventListener {
@@ -152,6 +21,256 @@ public:
 	};
 
 	class VideoEncoderTemplate {
+	private:
+		class VideoCompositionEncoderAllocator
+			: public SELazyOBSVideoEncoderAllocatorBase {
+		private:
+			struct Private {};
+
+		private:
+			std::shared_ptr<StreamElementsVideoCompositionBase::
+						CompositionInfo>
+				m_videoCompositionBase;
+
+			size_t m_index;
+			CefRefPtr<CefValue> m_obsEncoderInfo;
+			ObsOutputType m_outputType;
+
+			std::shared_ptr<SELazyOBSVideoEncoderProvider>
+				m_encoderProviderRef = nullptr;
+			std::shared_ptr<
+				SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>
+				m_encoderRef =
+				nullptr;
+			obs_encoder_t *m_customEncoder = nullptr;
+
+		public:
+			static std::shared_ptr<VideoCompositionEncoderAllocator>
+			Create(std::shared_ptr<
+				       StreamElementsVideoCompositionBase::
+					       CompositionInfo>
+				       videoCompositionBase,
+			       size_t index, CefRefPtr<CefValue> obsEncoderInfo,
+			       ObsOutputType outputType)
+			{
+				return std::make_shared<
+					VideoCompositionEncoderAllocator>(
+					Private{}, videoCompositionBase, index,
+					obsEncoderInfo, outputType);
+			}
+
+			VideoCompositionEncoderAllocator(
+				Private,
+				std::shared_ptr<
+					StreamElementsVideoCompositionBase::
+						CompositionInfo>
+					videoCompositionBase,
+				size_t index,
+				CefRefPtr<CefValue> obsEncoderInfo,
+				ObsOutputType outputType)
+			{
+				m_index = index;
+				m_videoCompositionBase = videoCompositionBase;
+				m_obsEncoderInfo = obsEncoderInfo;
+				m_outputType = outputType;
+			}
+
+			virtual ~VideoCompositionEncoderAllocator() {}
+
+			virtual obs_encoder_t *AllocRef() override
+			{
+				obs_encoder_t *result = nullptr;
+
+				// Release previously held resources if any
+				Reset();
+
+				if (m_obsEncoderInfo.get()) {
+					result = DeserializeObsVideoEncoder(
+						m_obsEncoderInfo);
+
+					if (result) {
+						switch (video_output_get_format(
+							obs_get_video())) {
+						case VIDEO_FORMAT_I420:
+						case VIDEO_FORMAT_NV12:
+						case VIDEO_FORMAT_I010:
+						case VIDEO_FORMAT_P010:
+							break;
+						default:
+							obs_encoder_set_preferred_video_format(
+								result,
+								VIDEO_FORMAT_NV12);
+						}
+
+						uint32_t width, height;
+						m_videoCompositionBase
+							->GetVideoBaseDimensions(
+								&width,
+								&height);
+
+						//
+						// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
+						// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
+						//
+						obs_encoder_set_scaled_size(
+							result, width, height);
+
+						obs_encoder_set_video(
+							result,
+							m_videoCompositionBase
+								->GetVideo());
+
+						m_customEncoder = SETRACE_ADDREF(
+							obs_encoder_get_ref(
+								result));
+
+						return result;
+					}
+				}
+
+				if (!m_encoderProviderRef) {
+					m_encoderProviderRef =
+						GetVideoEncoderProvider();
+				}
+
+				if (m_encoderProviderRef) {
+					m_encoderRef =
+						m_encoderProviderRef
+							->GetLazyObjectReference();
+				}
+
+				if (m_encoderRef) {
+					result = SETRACE_ADDREF(
+						obs_encoder_get_ref(
+							m_encoderRef->Get()));
+				} else {
+					m_encoderProviderRef = nullptr;
+				}
+
+				return result;
+			}
+
+			virtual void Reset() override
+			{
+				m_encoderRef = nullptr;
+				m_encoderProviderRef = nullptr;
+
+				if (m_customEncoder) {
+					obs_encoder_release(SETRACE_DECREF(
+						m_customEncoder));
+
+					m_customEncoder = nullptr;
+				}
+			}
+
+			virtual obs_data_t *GetSettingsRef() override
+			{
+				if (m_encoderProviderRef) {
+					m_encoderProviderRef->GetSettingsRef();
+				}
+
+				if (m_customEncoder) {
+					return obs_encoder_get_settings(
+						m_customEncoder);
+				}
+
+				if (m_obsEncoderInfo &&
+				    m_obsEncoderInfo->GetType() ==
+					    VTYPE_DICTIONARY) {
+					auto d = m_obsEncoderInfo
+							 ->GetDictionary();
+
+					if (d->HasKey("class") &&
+					    d->GetType("class") ==
+						    VTYPE_STRING) {
+						std::string id =
+							d->GetString("class")
+								.ToString();
+
+						if (id.size() > 0)
+							return obs_encoder_defaults(
+								id.c_str());
+					}
+				}
+
+				return obs_data_create();
+			}
+
+			virtual std::string GetId() const override
+			{
+				if (m_encoderProviderRef)
+					return m_encoderProviderRef->GetId();
+
+				if (m_customEncoder)
+					return obs_encoder_get_id(
+						m_customEncoder);
+
+				if (m_obsEncoderInfo &&
+				    m_obsEncoderInfo->GetType() ==
+					    VTYPE_DICTIONARY) {
+					auto d = m_obsEncoderInfo
+							 ->GetDictionary();
+
+					if (d->HasKey("class") &&
+					    d->GetType("class") ==
+						    VTYPE_STRING) {
+						return d->GetString("class")
+							.ToString();
+					}
+				}
+
+				return "";
+			}
+
+			virtual std::string GetName() const override
+			{
+				if (m_encoderProviderRef)
+					return m_encoderProviderRef->GetName();
+
+				if (m_customEncoder)
+					return obs_encoder_get_name(
+						m_customEncoder);
+
+				if (m_obsEncoderInfo &&
+				    m_obsEncoderInfo->GetType() ==
+					    VTYPE_DICTIONARY) {
+					auto d = m_obsEncoderInfo
+							 ->GetDictionary();
+
+					if (d->HasKey("name") &&
+					    d->GetType("name") ==
+						    VTYPE_STRING) {
+						return d->GetString("name")
+							.ToString();
+					}
+				}
+
+				return GetId();
+			}
+
+
+		private:
+			std::shared_ptr<SELazyOBSVideoEncoderProvider>
+			GetVideoEncoderProvider()
+			{
+				if (m_encoderProviderRef)
+					return m_encoderProviderRef;
+
+				if (m_outputType != StreamingOutput) {
+					m_encoderProviderRef =
+						m_videoCompositionBase
+							->GetRecordingVideoEncoderProvider(
+								m_index);
+				} else {
+					m_encoderProviderRef =
+						m_videoCompositionBase
+							->GetStreamingVideoEncoderProvider(
+								m_index);
+				}
+				return m_encoderProviderRef;
+			}
+		};
+
 	public:
 		size_t m_index;
 		CefRefPtr<CefValue> m_obsEncoderInfo;
@@ -197,26 +316,28 @@ public:
 		}
 
 	public:
-		std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
+		std::shared_ptr<SELazyOBSVideoEncoderProvider>
 		CreateStreamingEncoderProvider(
 			std::shared_ptr<StreamElementsVideoCompositionBase::
 						CompositionInfo> videoCompositionBase)
 		{
-			return std::make_shared<SEVideoCompositionVideoEncoderProvider>(
-				videoCompositionBase, m_index, m_obsEncoderInfo,
-				StreamingOutput);
+			return std::make_shared<SELazyOBSVideoEncoderProvider>(
+				VideoCompositionEncoderAllocator::Create(
+					videoCompositionBase, m_index,
+					m_obsEncoderInfo, StreamingOutput));
 		}
 
-		std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>
+		std::shared_ptr<SELazyOBSVideoEncoderProvider>
 		CreateRecordingEncoderProvider(
 			std::shared_ptr<StreamElementsVideoCompositionBase::
 						CompositionInfo>
 				videoCompositionBase)
 		{
-			return std::make_shared<
-				SEVideoCompositionVideoEncoderProvider>(
-				videoCompositionBase, m_index, m_obsEncoderInfo,
-				RecordingOutput);
+			return std::make_shared<SELazyOBSVideoEncoderProvider>(
+
+				VideoCompositionEncoderAllocator::Create(
+					videoCompositionBase, m_index,
+					m_obsEncoderInfo, RecordingOutput));
 		}
 	};
 
@@ -347,9 +468,9 @@ private:
 	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
 		std::make_shared<VideoEncoderTemplate>(0)};
 
-	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
 		m_videoEncoderProviders;
-	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>> m_videoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>> m_videoEncoders;
 
 
 public:
@@ -536,9 +657,9 @@ private:
 	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
 		std::make_shared<VideoEncoderTemplate>(0)};
 
-	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
 		m_videoEncoderProviders;
-	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>>
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>>
 		m_videoEncoders;
 
 public:
@@ -674,9 +795,10 @@ private:
 	std::vector<std::shared_ptr<VideoEncoderTemplate>> m_videoEncoderTemplates = {
 		std::make_shared<VideoEncoderTemplate>(0)};
 
-	std::vector<std::shared_ptr<SELazyObjectProviderBase<obs_encoder_t>>>
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
 		m_videoEncoderProviders;
-	std::vector<std::shared_ptr<SELazyObjectReference<obs_encoder_t>>>
+	std::vector<std::shared_ptr<
+		SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>>
 		m_videoEncoders;
 
 public:

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -68,6 +68,18 @@ public:
 				size_t index,
 				CefRefPtr<CefValue> obsEncoderInfo,
 				ObsOutputType outputType)
+				: SELazyOBSVideoEncoderAllocatorBase(FormatString(
+					  "VideoCompositionEncoderAllocator: [index: %d] [outputType: %s] %s - %s",
+					  index,
+					  outputType == StreamingOutput
+						  ? "StreamingOutput"
+						  : (outputType == RecordingOutput
+							     ? "RecordingOutput"
+							     : "ReplayBufferOutput"),
+					  videoCompositionBase->GetComposition()->GetId().c_str(),
+					  videoCompositionBase->GetComposition()
+						  ->GetName()
+						  .c_str()))
 			{
 				m_index = index;
 				m_videoCompositionBase = videoCompositionBase;
@@ -85,8 +97,9 @@ public:
 				Reset();
 
 				if (m_obsEncoderInfo.get()) {
-					result = DeserializeObsVideoEncoder(
-						m_obsEncoderInfo);
+					result =
+						SETRACE_AUTODECREF(DeserializeObsVideoEncoder(
+						m_obsEncoderInfo));
 
 					if (result) {
 						switch (video_output_get_format(
@@ -140,9 +153,8 @@ public:
 				}
 
 				if (m_encoderRef) {
-					result = SETRACE_ADDREF(
-						obs_encoder_get_ref(
-							m_encoderRef->Get()));
+					result = obs_encoder_get_ref(
+							m_encoderRef->Get());
 				} else {
 					m_encoderProviderRef = nullptr;
 				}

--- a/streamelements/StreamElementsOutputManager.cpp
+++ b/streamelements/StreamElementsOutputManager.cpp
@@ -1,10 +1,6 @@
 #include "StreamElementsOutputManager.hpp"
 #include "StreamElementsUtils.hpp"
 
-#define StreamingOutput StreamElementsOutputBase::StreamingOutput
-#define RecordingOutput StreamElementsOutputBase::RecordingOutput
-#define ReplayBufferOutput StreamElementsOutputBase::ReplayBufferOutput
-
 StreamElementsOutputManager::StreamElementsOutputManager(
 	std::shared_ptr<StreamElementsVideoCompositionManager>
 		videoCompositionManager,
@@ -72,8 +68,7 @@ void StreamElementsOutputManager::Reset()
 	}
 }
 
-void StreamElementsOutputManager::DeserializeOutput(
-	StreamElementsOutputBase::ObsOutputType outputType,
+void StreamElementsOutputManager::DeserializeOutput(ObsOutputType outputType,
 	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
 {
 	std::unique_lock<decltype(m_mutex)> lock(m_mutex);
@@ -139,7 +134,7 @@ void StreamElementsOutputManager::DeserializeOutput(
 }
 
 void StreamElementsOutputManager::SerializeAllOutputs(
-	StreamElementsOutputBase::ObsOutputType outputType,
+	ObsOutputType outputType,
 	CefRefPtr<CefValue> &output)
 {
 	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
@@ -157,8 +152,7 @@ void StreamElementsOutputManager::SerializeAllOutputs(
 	output->SetDictionary(d);
 }
 
-void StreamElementsOutputManager::RemoveOutputsByIds(
-	StreamElementsOutputBase::ObsOutputType outputType,
+void StreamElementsOutputManager::RemoveOutputsByIds(ObsOutputType outputType,
 	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
 {
 	std::unique_lock<decltype(m_mutex)> lock(m_mutex);
@@ -178,8 +172,7 @@ void StreamElementsOutputManager::RemoveOutputsByIds(
 	output->SetBool(true);
 }
 
-void StreamElementsOutputManager::EnableOutputsByIds(
-	StreamElementsOutputBase::ObsOutputType outputType,
+void StreamElementsOutputManager::EnableOutputsByIds(ObsOutputType outputType,
 	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
 {
 	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
@@ -200,7 +193,7 @@ void StreamElementsOutputManager::EnableOutputsByIds(
 }
 
 void StreamElementsOutputManager::DisableOutputsByIds(
-	StreamElementsOutputBase::ObsOutputType outputType,
+	ObsOutputType outputType,
 	CefRefPtr<CefValue> input, CefRefPtr<CefValue> &output)
 {
 	std::shared_lock<decltype(m_mutex)> lock(m_mutex);
@@ -258,7 +251,7 @@ void StreamElementsOutputManager::TriggerSaveReplayBufferById(
 }
 
 bool StreamElementsOutputManager::GetValidIds(
-	StreamElementsOutputBase::ObsOutputType outputType, CefRefPtr<CefValue> input,
+	ObsOutputType outputType, CefRefPtr<CefValue> input,
 	std::map<std::string, bool>& output, bool testRemove, bool testDisable)
 {
 	if (input->GetType() != VTYPE_LIST)

--- a/streamelements/StreamElementsOutputManager.hpp
+++ b/streamelements/StreamElementsOutputManager.hpp
@@ -9,7 +9,7 @@
 class StreamElementsOutputManager {
 private:
 	std::shared_mutex m_mutex;
-	std::map<StreamElementsOutputBase::ObsOutputType,
+	std::map<ObsOutputType,
 		 std::shared_ptr<std::map<std::string, std::shared_ptr<StreamElementsOutputBase>>>>
 		m_map;
 	std::shared_ptr<StreamElementsVideoCompositionManager>
@@ -26,21 +26,18 @@ public:
 	~StreamElementsOutputManager();
 
 public:
-	void
-	DeserializeOutput(StreamElementsOutputBase::ObsOutputType outputType,
+	void DeserializeOutput(ObsOutputType outputType,
 			  CefRefPtr<CefValue> input,
 			  CefRefPtr<CefValue> &output);
-	void SerializeAllOutputs(StreamElementsOutputBase::ObsOutputType outputType, CefRefPtr<CefValue> &output);
-	void
-	RemoveOutputsByIds(StreamElementsOutputBase::ObsOutputType outputType,
+	void SerializeAllOutputs(ObsOutputType outputType,
+				 CefRefPtr<CefValue> &output);
+	void RemoveOutputsByIds(ObsOutputType outputType,
 			   CefRefPtr<CefValue> input,
 			   CefRefPtr<CefValue> &output);
-	void
-	EnableOutputsByIds(StreamElementsOutputBase::ObsOutputType outputType,
+	void EnableOutputsByIds(ObsOutputType outputType,
 			   CefRefPtr<CefValue> input,
 			   CefRefPtr<CefValue> &output);
-	void
-	DisableOutputsByIds(StreamElementsOutputBase::ObsOutputType outputType,
+	void DisableOutputsByIds(ObsOutputType outputType,
 			    CefRefPtr<CefValue> input,
 			    CefRefPtr<CefValue> &output);
 
@@ -53,7 +50,7 @@ public:
 	void Reset();
 
 private:
-	bool GetValidIds(StreamElementsOutputBase::ObsOutputType outputType,
+	bool GetValidIds(ObsOutputType outputType,
 			 CefRefPtr<CefValue> input,
 			 std::map<std::string, bool> &output, bool testRemove,
 			 bool testDisable);

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -3923,7 +3923,8 @@ CefRefPtr<CefValue> SerializeObsData(obs_data_t *data)
 
 		std::unique_lock guard(mutex); // obs_data_get_json is not thread_safe for the same data container
 
-		const char *json = SETRACE_NOREF(obs_data_get_json(data));
+		const char *json =
+			SETRACE_NOREF(obs_data_get_json_with_defaults(data));
 
 		if (json) {
 			return CefParseJSON(json,
@@ -4215,9 +4216,7 @@ CefRefPtr<CefDictionaryValue> SerializeObsEncoder(obs_encoder_t *e)
 
 	auto settings = SETRACE_ADDREF(obs_encoder_get_settings(e));
 
-	result->SetValue("settings",
-			 CefParseJSON(obs_data_get_json(settings),
-				      JSON_PARSER_ALLOW_TRAILING_COMMAS));
+	result->SetValue("settings", SerializeObsData(settings));
 
 	result->SetValue("properties",
 			 SerializeObsEncoderProperties(obs_encoder_get_id(e),

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -559,8 +559,13 @@ private:
 	int m_refCount = 0;
 	T *m_object = nullptr;
 
+	T *m_externallyAllocatedObject = nullptr;
+
 public:
-	SELazyObjectProviderBase() {}
+	SELazyObjectProviderBase(T *externallyAllocatedObject = nullptr) : m_externallyAllocatedObject(externallyAllocatedObject)
+	{
+	}
+
 	~SELazyObjectProviderBase()
 	{
 		std::shared_lock lock(m_mutex);
@@ -576,6 +581,14 @@ public:
 		return std::make_shared<SELazyObjectReference<T>>(this);
 	}
 
+	std::shared_ptr<SELazyObjectReference<T>> TryGetLazyObjectReference()
+	{
+		if (!m_object && !m_externallyAllocatedObject)
+			return nullptr;
+
+		return GetLazyObjectReference();
+	}
+
 protected:
 	inline T *GetPtr() const { return m_object; }
 
@@ -584,7 +597,11 @@ protected:
 		std::unique_lock lock(m_mutex);
 
 		if (!m_object) {
-			m_object = SETRACE_ADDREF(AllocRef());
+			if (m_externallyAllocatedObject) {
+				m_object = AddRef(m_externallyAllocatedObject);
+			} else {
+				m_object = SETRACE_ADDREF(AllocRef());
+			}
 			++m_refCount;
 		}
 

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -565,7 +565,7 @@ public:
 	virtual std::string GetName() const = 0;
 
 public:
-	std::string slug() { return m_slug; }
+	std::string slug() const { return m_slug; }
 };
 
 class SELazyOBSVideoEncoderProvider
@@ -799,6 +799,8 @@ public:
 	};
 
 private:
+	std::string m_slug;
+
 	std::shared_mutex m_mutex;
 	int m_refCount = 0;
 	obs_encoder_t *m_object = nullptr;
@@ -806,9 +808,11 @@ private:
 	std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> m_allocator = nullptr;
 
 public:
-	SELazyOBSVideoEncoderProvider(std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> allocator)
+	SELazyOBSVideoEncoderProvider(
+		std::string slug,
+		std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> allocator)
+		: m_slug(slug), m_allocator(allocator)
 	{
-		m_allocator = allocator;
 	}
 
 	virtual ~SELazyOBSVideoEncoderProvider()
@@ -816,8 +820,16 @@ public:
 		if (m_refCount > 0) {
 			blog(LOG_ERROR,
 			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object: %s",
-			     m_allocator->slug().c_str());
+			     slug().c_str());
 		}
+	}
+
+	std::string slug() const
+	{
+		if (m_slug.size())
+			return m_slug + ": " + m_allocator->slug();
+		else
+			return m_allocator->slug();
 	}
 
 	obs_data_t *GetSettingsRef()
@@ -920,7 +932,7 @@ private:
 			blog(LOG_INFO,
 			     "[obs-streamelements-core]: SELazyOBSVideoEncoderProvider::AddConsumer called allocator->AllocRef(): (refCount: %d, object: %s): %s",
 			     m_refCount, GetIdFromPointer(m_object).c_str(),
-			     m_allocator->slug().c_str());
+			     slug().c_str());
 		}
 	}
 
@@ -935,7 +947,7 @@ private:
 			blog(LOG_INFO,
 			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider::RemoveConsumer calling allocator->Reset(): (refCount: %d, object: %s): %s",
 			     m_refCount, GetIdFromPointer(m_object).c_str(),
-			     m_allocator->slug().c_str());
+			     slug().c_str());
 
 			m_allocator->Reset();
 
@@ -945,7 +957,7 @@ private:
 		if (m_refCount < 0) {
 			blog(LOG_ERROR,
 			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider::RemoveConsumer call results in negative reference count (%d): %s",
-			     m_refCount, m_allocator->slug().c_str());
+			     m_refCount, slug().c_str());
 		}
 	}
 

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -549,107 +549,354 @@ void DeserializeRevealFileInGraphicalShell(CefRefPtr<CefValue> input,
 
 /* ========================================================= */
 
-template<typename T> class SELazyObjectReference;
+class SELazyOBSVideoEncoderAllocatorBase {
+public:
+	SELazyOBSVideoEncoderAllocatorBase() {}
+	virtual ~SELazyOBSVideoEncoderAllocatorBase() {}
 
-template<typename T> class SELazyObjectProviderBase {
-	friend class SELazyObjectReference<T>;
+	virtual obs_encoder_t *AllocRef() = 0;
+	virtual void Reset() = 0;
+	virtual obs_data_t *GetSettingsRef() = 0;
+
+	virtual std::string GetId() const = 0;
+	virtual std::string GetName() const = 0;
+};
+
+class SELazyOBSVideoEncoderProvider
+	: public std::enable_shared_from_this<SELazyOBSVideoEncoderProvider> {
+public:
+	class SELazyOBSEncoderReference {
+	private:
+		std::shared_ptr<SELazyOBSVideoEncoderProvider> m_provider =
+			nullptr;
+
+	public:
+		SELazyOBSEncoderReference(
+			std::shared_ptr<SELazyOBSVideoEncoderProvider> provider)
+			: m_provider(provider)
+		{
+			m_provider->AddConsumer();
+		}
+
+		~SELazyOBSEncoderReference() { m_provider->RemoveConsumer(); }
+
+		inline operator obs_encoder_t *() const
+		{
+			return m_provider->GetPtr();
+		}
+		obs_encoder_t *Get() const { return m_provider->GetPtr(); }
+
+		inline bool operator==(obs_encoder_t *p) const
+		{
+			return m_provider->GetPtr() == p;
+		}
+		inline bool operator!=(obs_encoder_t *p) const
+		{
+			return m_provider->GetPtr() != p;
+		}
+	};
+
+public:
+	class ExternallyAllocatedEncoderAllocator : public SELazyOBSVideoEncoderAllocatorBase {
+	private:
+		struct Private {};
+
+	private:
+		obs_encoder_t *m_externallyAllocatedObject;
+
+	public:
+		static std::shared_ptr<ExternallyAllocatedEncoderAllocator>
+		Create(obs_encoder_t* externallyAllocatedObject)
+		{
+			if (!externallyAllocatedObject)
+				return nullptr;
+			return std::make_shared<ExternallyAllocatedEncoderAllocator>(
+				Private{}, externallyAllocatedObject);
+		}
+
+		ExternallyAllocatedEncoderAllocator(
+			Private,
+			obs_encoder_t *externallyAllocatedObject)
+		{
+			m_externallyAllocatedObject = SETRACE_ADDREF(
+				obs_encoder_get_ref(externallyAllocatedObject));
+		}
+
+		virtual ~ExternallyAllocatedEncoderAllocator()
+		{
+			if (m_externallyAllocatedObject) {
+				obs_encoder_release(SETRACE_DECREF(
+					m_externallyAllocatedObject));
+
+				m_externallyAllocatedObject = nullptr;
+			}
+		}
+
+		virtual obs_encoder_t* AllocRef() override {
+			return SETRACE_ADDREF(
+				obs_encoder_get_ref(m_externallyAllocatedObject));
+		}
+
+		virtual void Reset() override {}
+
+		virtual obs_data_t* GetSettingsRef() override
+		{
+			return obs_encoder_get_settings(
+				m_externallyAllocatedObject);
+		}
+
+		virtual std::string GetId() const override
+		{
+			const auto id = obs_encoder_get_id(m_externallyAllocatedObject);
+
+			if (id)
+				return id;
+			else
+				return "";
+		}
+
+		virtual std::string GetName() const
+		{
+			const auto name = obs_encoder_get_name(m_externallyAllocatedObject);
+
+			if (name)
+				return name;
+			else
+				return GetId();
+		}
+	};
+
+	class CreateEncoderAllocator : public SELazyOBSVideoEncoderAllocatorBase {
+	private:
+		struct Private {};
+
+	private:
+		std::string m_id;
+		std::string m_name;
+		obs_data_t *m_settings = nullptr;
+		obs_data_t *m_hotkeys = nullptr;
+		uint32_t m_width;
+		uint32_t m_height;
+		video_t *m_video;
+
+	public:
+		static std::shared_ptr<CreateEncoderAllocator>
+		Create(std::string id, std::string name, obs_data_t *settings,
+		       obs_data_t *hotkeys, uint32_t width, uint32_t height,
+		       video_t *video)
+		{
+			return std::make_shared<CreateEncoderAllocator>(
+				Private{}, id, name, settings, hotkeys, width, height, video);
+		}
+
+ 		CreateEncoderAllocator(Private, std::string id,
+				       std::string name,
+				       obs_data_t *settings,
+				       obs_data_t *hotkeys, uint32_t width,
+				       uint32_t height, video_t *video)
+		{
+			m_id = id;
+			m_name = name;
+			m_width = width;
+			m_height = height;
+			m_video = video;
+
+			if (settings) {
+				obs_data_addref(SETRACE_ADDREF(settings));
+
+				m_settings = settings;
+			}
+
+			if (hotkeys) {
+				obs_data_addref(SETRACE_ADDREF(hotkeys));
+
+				m_hotkeys = hotkeys;
+			}
+		}
+
+		virtual ~CreateEncoderAllocator()
+		{
+			if (m_settings) {
+				obs_data_release(SETRACE_DECREF(m_settings));
+				m_settings = nullptr;
+			}
+			if (m_hotkeys) {
+				obs_data_release(SETRACE_DECREF(m_hotkeys));
+				m_hotkeys = nullptr;
+			}
+		}
+
+		virtual obs_encoder_t *AllocRef() override
+		{
+			auto created_encoder =
+				SETRACE_ADDREF(obs_video_encoder_create(
+					m_id.c_str(), m_name.c_str(),
+					m_settings, m_hotkeys));
+
+			if (!created_encoder) {
+				blog(LOG_ERROR,
+				     "[obs-streamelements-core]: failed lazy-creating video encoder: %s (%s)",
+				     m_id.c_str(), m_name.c_str());
+
+				return nullptr;
+			}
+
+			switch (video_output_get_format(obs_get_video())) {
+			case VIDEO_FORMAT_I420:
+			case VIDEO_FORMAT_NV12:
+			case VIDEO_FORMAT_I010:
+			case VIDEO_FORMAT_P010:
+				break;
+			default:
+				obs_encoder_set_preferred_video_format(
+					created_encoder, VIDEO_FORMAT_NV12);
+			}
+
+			//
+			// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
+			// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
+			//
+			obs_encoder_set_scaled_size(created_encoder, m_width,
+						    m_height);
+
+			obs_encoder_set_video(created_encoder, m_video);
+
+			return created_encoder;
+		}
+
+		virtual void Reset() override {}
+
+		virtual obs_data_t *GetSettingsRef() override
+		{
+			if (m_settings) {
+				obs_data_addref(m_settings);
+
+				return m_settings;
+			}
+
+			if (m_id.size() > 0) {
+				return obs_encoder_defaults(m_id.c_str());
+			}
+
+			return obs_data_create();
+		}
+
+		virtual std::string GetId() const override
+		{
+			return m_id;
+		}
+
+		virtual std::string GetName() const
+		{
+			return m_name;
+		}
+	};
 
 private:
 	std::shared_mutex m_mutex;
 	int m_refCount = 0;
-	T *m_object = nullptr;
+	obs_encoder_t *m_object = nullptr;
 
-	T *m_externallyAllocatedObject = nullptr;
+	std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> m_allocator = nullptr;
 
 public:
-	SELazyObjectProviderBase(T *externallyAllocatedObject = nullptr) : m_externallyAllocatedObject(externallyAllocatedObject)
+	SELazyOBSVideoEncoderProvider(std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> allocator)
 	{
+		m_allocator = allocator;
 	}
 
-	~SELazyObjectProviderBase()
+	virtual ~SELazyOBSVideoEncoderProvider()
 	{
-		std::shared_lock lock(m_mutex);
-
 		if (m_refCount > 0) {
 			blog(LOG_ERROR,
-			     "[obs-streamelements-core]: SEObjectProvider is destroyed while there are active references to the underlying object");
+			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object");
 		}
 	}
 
-	std::shared_ptr<SELazyObjectReference<T>> GetLazyObjectReference()
+	obs_data_t *GetSettingsRef()
 	{
-		return std::make_shared<SELazyObjectReference<T>>(this);
+		auto ref = TryGetLazyObjectReference();
+
+		if (ref && ref->Get()) {
+			return obs_encoder_get_settings(ref->Get());
+		}
+
+		return m_allocator->GetSettingsRef();
 	}
 
-	std::shared_ptr<SELazyObjectReference<T>> TryGetLazyObjectReference()
+	std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>
+	GetLazyObjectReference()
 	{
-		if (!m_object && !m_externallyAllocatedObject)
+		auto shared = this->shared_from_this();
+
+		return std::make_shared<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>(
+			shared);
+	}
+
+	std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>
+	TryGetLazyObjectReference()
+	{
+		if (!m_object)
 			return nullptr;
 
 		return GetLazyObjectReference();
 	}
 
-protected:
-	inline T *GetPtr() const { return m_object; }
+	std::string GetId() const { return m_allocator->GetId(); }
 
+	std::string GetName() const { return m_allocator->GetName(); }
+
+protected:
+	inline obs_encoder_t *GetPtr() const {
+		return m_object;
+	}
+
+private:
 	void AddConsumer()
 	{
 		std::unique_lock lock(m_mutex);
 
 		if (!m_object) {
-			if (m_externallyAllocatedObject) {
-				m_object = AddRef(m_externallyAllocatedObject);
-			} else {
-				m_object = SETRACE_ADDREF(AllocRef());
-			}
+			m_object = SETRACE_ADDREF(m_allocator->AllocRef());
+
 			++m_refCount;
 		}
-
-		m_object = SETRACE_ADDREF(AddRef(m_object));
-		++m_refCount;
 	}
 
 	void RemoveConsumer()
 	{
 		std::unique_lock lock(m_mutex);
 
-		ReleaseRef(SETRACE_DECREF(m_object));
+		ReleaseRef(m_object);
 		--m_refCount;
 
-		if (m_refCount <= 1 && m_object) {
-			ReleaseRef(SETRACE_DECREF(m_object));
-			m_refCount = 0;
+		if (m_refCount <= 0 && m_object) {
+			m_object = nullptr;
 
-			ReleaseAuxiliaryResources();
+			m_allocator->Reset();
+		}
+
+		if (m_refCount < 0) {
+			blog(LOG_ERROR,
+			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider::RemoveConsumer call results in negative reference count");
 		}
 	}
 
 protected:
-	virtual T *AllocRef() = 0;
-	virtual T *AddRef(T *object) = 0;
-	virtual void ReleaseRef(T *object) = 0;
-	virtual void ReleaseAuxiliaryResources() {}
-};
-
-template<typename T> class SELazyObjectReference {
-	friend class SELazyObjectProviderBase<T>;
-
-private:
-	SELazyObjectProviderBase<T> *m_provider;
-
-public:
-	SELazyObjectReference(SELazyObjectProviderBase<T> *provider) : m_provider(provider)
+	obs_encoder_t* AddRef(obs_encoder_t* object)
 	{
-		m_provider->AddConsumer();
+		return SETRACE_ADDREF(obs_encoder_get_ref(object));
 	}
 
-	~SELazyObjectReference() { m_provider->RemoveConsumer(); }
+	void ReleaseRef(obs_encoder_t* object)
+	{
+		obs_encoder_release(SETRACE_DECREF(object));
+	}
 
-	inline operator T() const { return m_provider->GetPtr(); }
-	inline T *Get() const { return m_provider->GetPtr(); }
+	void ReleaseAuxiliaryResources()
+	{
 
-	inline bool operator==(T p) const { return m_provider->GetPtr() == p; }
-	inline bool operator!=(T p) const { return m_provider->GetPtr() != p; }
+	}
 };
 
 /* ========================================================= */

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -619,6 +619,8 @@ protected:
 		if (m_refCount <= 1 && m_object) {
 			ReleaseRef(SETRACE_DECREF(m_object));
 			m_refCount = 0;
+
+			ReleaseAuxiliaryResources();
 		}
 	}
 
@@ -626,6 +628,7 @@ protected:
 	virtual T *AllocRef() = 0;
 	virtual T *AddRef(T *object) = 0;
 	virtual void ReleaseRef(T *object) = 0;
+	virtual void ReleaseAuxiliaryResources() {}
 };
 
 template<typename T> class SELazyObjectReference {

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -730,35 +730,18 @@ public:
 					obs_data_get_defaults(
 						defaultsContainer);
 
-				blog(LOG_INFO,
-				     "------- %s: ctor(): defaults json: %s",
-				     slug().c_str(),
-				     obs_data_get_json_with_defaults(defaults));
-
 				obs_data_apply(m_settings, defaults);
 
 				OBSDataAutoRelease settingsData =
 					obs_encoder_get_settings(encoder);
 
-				blog(LOG_INFO,
-				     "------- %s: ctor(): settings data json: %s",
-				     slug().c_str(),
-				     obs_data_get_json_with_defaults(settingsData));
-
 				obs_data_apply(m_settings, settingsData);
 			} else if (settings) {
-				blog(LOG_INFO,
-				     "------- %s: ctor(): args settings json: %s",
-				     slug().c_str(),
-				     obs_data_get_json_with_defaults(settings));
+				OBSDataAutoRelease defaults =
+					obs_data_get_defaults(settings);
 
 				obs_data_apply(m_settings, settings);
 			}
-
-			blog(LOG_INFO,
-			     "------- %s: ctor(): final settings json: %s",
-			     slug().c_str(),
-			     obs_data_get_json_with_defaults(m_settings));
 		}
 
 		virtual ~CreateEncoderAllocator()
@@ -941,14 +924,6 @@ public:
 		// Settings & properties
 
 		obs_data_t *settings = SETRACE_ADDREF(GetSettingsRef());
-
-		std::string json =
-			settings ? obs_data_get_json_with_defaults(settings)
-					    : "null";
-
-		blog(LOG_INFO,
-		     "[obs-streamelements-core]: encoder settings: %s: %s",
-		     slug().c_str(), json.c_str());
 
 		result->SetValue("settings", SerializeObsData(settings));
 

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -772,7 +772,8 @@ public:
 
 		virtual void Reset() override {}
 
-		virtual obs_data_t *GetSettingsRef() override
+		virtual obs_data_t *
+		GetSettingsRef() override
 		{
 			if (m_settings) {
 				obs_data_addref(m_settings);
@@ -834,10 +835,10 @@ public:
 
 	obs_data_t *GetSettingsRef()
 	{
-		auto ref = TryGetLazyObjectReference();
+		std::shared_lock lock(m_mutex);
 
-		if (ref && ref->Get()) {
-			return obs_encoder_get_settings(ref->Get());
+		if (m_object) {
+			return obs_encoder_get_settings(m_object);
 		}
 
 		return m_allocator->GetSettingsRef();

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -661,7 +661,7 @@ public:
 				return "";
 		}
 
-		virtual std::string GetName() const
+		virtual std::string GetName() const override
 		{
 			const auto name = obs_encoder_get_name(m_externallyAllocatedObject);
 
@@ -819,7 +819,7 @@ public:
 			return m_id;
 		}
 
-		virtual std::string GetName() const
+		virtual std::string GetName() const override
 		{
 			return m_name;
 		}

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -723,13 +723,17 @@ public:
 					settings, nullptr);
 
 			if (encoder) {
-				OBSDataAutoRelease defaults =
+				OBSDataAutoRelease defaultsContainer =
 					obs_encoder_get_defaults(encoder);
+
+				OBSDataAutoRelease defaults =
+					obs_data_get_defaults(
+						defaultsContainer);
 
 				blog(LOG_INFO,
 				     "------- %s: ctor(): defaults json: %s",
 				     slug().c_str(),
-				     obs_data_get_json(defaults));
+				     obs_data_get_json_with_defaults(defaults));
 
 				obs_data_apply(m_settings, defaults);
 
@@ -739,21 +743,22 @@ public:
 				blog(LOG_INFO,
 				     "------- %s: ctor(): settings data json: %s",
 				     slug().c_str(),
-				     obs_data_get_json(settingsData));
+				     obs_data_get_json_with_defaults(settingsData));
 
 				obs_data_apply(m_settings, settingsData);
 			} else if (settings) {
 				blog(LOG_INFO,
 				     "------- %s: ctor(): args settings json: %s",
 				     slug().c_str(),
-				     obs_data_get_json(settings));
+				     obs_data_get_json_with_defaults(settings));
 
 				obs_data_apply(m_settings, settings);
 			}
 
 			blog(LOG_INFO,
 			     "------- %s: ctor(): final settings json: %s",
-			     slug().c_str(), obs_data_get_json(m_settings));
+			     slug().c_str(),
+			     obs_data_get_json_with_defaults(m_settings));
 		}
 
 		virtual ~CreateEncoderAllocator()
@@ -937,17 +942,15 @@ public:
 
 		obs_data_t *settings = SETRACE_ADDREF(GetSettingsRef());
 
-		std::string json = settings ? obs_data_get_json(settings)
+		std::string json =
+			settings ? obs_data_get_json_with_defaults(settings)
 					    : "null";
 
 		blog(LOG_INFO,
 		     "[obs-streamelements-core]: encoder settings: %s: %s",
 		     slug().c_str(), json.c_str());
 
-		result->SetValue(
-			"settings",
-			CefParseJSON(json,
-				     JSON_PARSER_ALLOW_TRAILING_COMMAS));
+		result->SetValue("settings", SerializeObsData(settings));
 
 		result->SetValue("properties", SerializeObsEncoderProperties(
 						       GetId(), settings));

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -4,6 +4,7 @@
 
 #include <cef-headers.hpp>
 #include <obs.h>
+#include <obs.hpp>
 #include <obs-module.h>
 
 #include <memory>
@@ -707,17 +708,52 @@ public:
 			m_height = height;
 			m_video = video;
 
-			if (settings) {
-				obs_data_addref(SETRACE_ADDREF(settings));
-
-				m_settings = settings;
-			}
-
 			if (hotkeys) {
 				obs_data_addref(SETRACE_ADDREF(hotkeys));
 
 				m_hotkeys = hotkeys;
 			}
+
+			m_settings = SETRACE_ADDREF(obs_data_create());
+
+			OBSEncoderAutoRelease encoder =
+				obs_video_encoder_create(
+					m_id.c_str(),
+					CreateGloballyUniqueIdString().c_str(),
+					settings, nullptr);
+
+			if (encoder) {
+				OBSDataAutoRelease defaults =
+					obs_encoder_get_defaults(encoder);
+
+				blog(LOG_INFO,
+				     "------- %s: ctor(): defaults json: %s",
+				     slug().c_str(),
+				     obs_data_get_json(defaults));
+
+				obs_data_apply(m_settings, defaults);
+
+				OBSDataAutoRelease settingsData =
+					obs_encoder_get_settings(encoder);
+
+				blog(LOG_INFO,
+				     "------- %s: ctor(): settings data json: %s",
+				     slug().c_str(),
+				     obs_data_get_json(settingsData));
+
+				obs_data_apply(m_settings, settingsData);
+			} else if (settings) {
+				blog(LOG_INFO,
+				     "------- %s: ctor(): args settings json: %s",
+				     slug().c_str(),
+				     obs_data_get_json(settings));
+
+				obs_data_apply(m_settings, settings);
+			}
+
+			blog(LOG_INFO,
+			     "------- %s: ctor(): final settings json: %s",
+			     slug().c_str(), obs_data_get_json(m_settings));
 		}
 
 		virtual ~CreateEncoderAllocator()
@@ -775,17 +811,19 @@ public:
 		virtual obs_data_t *
 		GetSettingsRef() override
 		{
-			if (m_settings) {
-				obs_data_addref(m_settings);
-
-				return m_settings;
-			}
+			obs_data_t *result = obs_data_create();
 
 			if (m_id.size() > 0) {
-				return obs_encoder_defaults(m_id.c_str());
+				OBSDataAutoRelease defaults = obs_encoder_defaults(m_id.c_str());
+
+				obs_data_apply(result, defaults);
 			}
 
-			return obs_data_create();
+			if (m_settings) {
+				obs_data_apply(result, m_settings);
+			}
+
+			return result;
 		}
 
 		virtual std::string GetId() const override
@@ -820,7 +858,7 @@ public:
 	{
 		if (m_refCount > 0) {
 			blog(LOG_ERROR,
-			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object: %s",
+			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object: %s",
 			     slug().c_str());
 		}
 	}
@@ -899,10 +937,16 @@ public:
 
 		obs_data_t *settings = SETRACE_ADDREF(GetSettingsRef());
 
+		std::string json = settings ? obs_data_get_json(settings)
+					    : "null";
+
+		blog(LOG_INFO,
+		     "[obs-streamelements-core]: encoder settings: %s: %s",
+		     slug().c_str(), json.c_str());
+
 		result->SetValue(
 			"settings",
-			CefParseJSON(settings ? obs_data_get_json(settings)
-					      : "null",
+			CefParseJSON(json,
 				     JSON_PARSER_ALLOW_TRAILING_COMMAS));
 
 		result->SetValue("properties", SerializeObsEncoderProperties(

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -18,6 +18,8 @@
 #include <functional>
 #include <future>
 
+#include <shared_mutex>
+
 #include <util/threading.h>
 #include <util/platform.h>
 #include <curl/curl.h>
@@ -544,3 +546,90 @@ obs_encoder_t *DeserializeObsAudioEncoder(CefRefPtr<CefValue> input,
 void SerializeLoadedObsModules(CefRefPtr<CefValue> &output);
 void DeserializeRevealFileInGraphicalShell(CefRefPtr<CefValue> input,
 					   CefRefPtr<CefValue> &output);
+
+/* ========================================================= */
+
+template<typename T> class SELazyObjectReference;
+
+template<typename T> class SELazyObjectProviderBase {
+	friend class SELazyObjectReference<T>;
+
+private:
+	std::shared_mutex m_mutex;
+	int m_refCount = 0;
+	T *m_object = nullptr;
+
+public:
+	SELazyObjectProviderBase() {}
+	~SELazyObjectProviderBase()
+	{
+		std::shared_lock lock(m_mutex);
+
+		if (m_refCount > 0) {
+			blog(LOG_ERROR,
+			     "[obs-streamelements-core]: SEObjectProvider is destroyed while there are active references to the underlying object");
+		}
+	}
+
+	std::shared_ptr<SELazyObjectReference<T>> GetLazyObjectReference()
+	{
+		return std::make_shared<SELazyObjectReference<T>>(this);
+	}
+
+protected:
+	inline T *GetPtr() const { return m_object; }
+
+	void AddConsumer()
+	{
+		std::unique_lock lock(m_mutex);
+
+		if (!m_object) {
+			m_object = SETRACE_ADDREF(AllocRef());
+			++m_refCount;
+		}
+
+		m_object = SETRACE_ADDREF(AddRef(m_object));
+		++m_refCount;
+	}
+
+	void RemoveConsumer()
+	{
+		std::unique_lock lock(m_mutex);
+
+		ReleaseRef(SETRACE_DECREF(m_object));
+		--m_refCount;
+
+		if (m_refCount <= 1 && m_object) {
+			ReleaseRef(SETRACE_DECREF(m_object));
+			m_refCount = 0;
+		}
+	}
+
+protected:
+	virtual T *AllocRef() = 0;
+	virtual T *AddRef(T *object) = 0;
+	virtual void ReleaseRef(T *object) = 0;
+};
+
+template<typename T> class SELazyObjectReference {
+	friend class SELazyObjectProviderBase<T>;
+
+private:
+	SELazyObjectProviderBase<T> *m_provider;
+
+public:
+	SELazyObjectReference(SELazyObjectProviderBase<T> *provider) : m_provider(provider)
+	{
+		m_provider->AddConsumer();
+	}
+
+	~SELazyObjectReference() { m_provider->RemoveConsumer(); }
+
+	inline operator T() const { return m_provider->GetPtr(); }
+	inline T *Get() const { return m_provider->GetPtr(); }
+
+	inline bool operator==(T p) const { return m_provider->GetPtr() == p; }
+	inline bool operator!=(T p) const { return m_provider->GetPtr() != p; }
+};
+
+/* ========================================================= */

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -550,8 +550,11 @@ void DeserializeRevealFileInGraphicalShell(CefRefPtr<CefValue> input,
 /* ========================================================= */
 
 class SELazyOBSVideoEncoderAllocatorBase {
+private:
+	std::string m_slug;
+
 public:
-	SELazyOBSVideoEncoderAllocatorBase() {}
+	SELazyOBSVideoEncoderAllocatorBase(std::string slug): m_slug(slug) {}
 	virtual ~SELazyOBSVideoEncoderAllocatorBase() {}
 
 	virtual obs_encoder_t *AllocRef() = 0;
@@ -560,6 +563,9 @@ public:
 
 	virtual std::string GetId() const = 0;
 	virtual std::string GetName() const = 0;
+
+public:
+	std::string slug() { return m_slug; }
 };
 
 class SELazyOBSVideoEncoderProvider
@@ -615,8 +621,8 @@ public:
 		}
 
 		ExternallyAllocatedEncoderAllocator(
-			Private,
-			obs_encoder_t *externallyAllocatedObject)
+			Private, obs_encoder_t *externallyAllocatedObject)
+			: SELazyOBSVideoEncoderAllocatorBase(FormatString("externallyAllocatedObject: %s", GetIdFromPointer(externallyAllocatedObject).c_str()))
 		{
 			m_externallyAllocatedObject = SETRACE_ADDREF(
 				obs_encoder_get_ref(externallyAllocatedObject));
@@ -633,8 +639,7 @@ public:
 		}
 
 		virtual obs_encoder_t* AllocRef() override {
-			return SETRACE_ADDREF(
-				obs_encoder_get_ref(m_externallyAllocatedObject));
+			return obs_encoder_get_ref(m_externallyAllocatedObject);
 		}
 
 		virtual void Reset() override {}
@@ -690,10 +695,11 @@ public:
 		}
 
  		CreateEncoderAllocator(Private, std::string id,
-				       std::string name,
-				       obs_data_t *settings,
+				       std::string name, obs_data_t *settings,
 				       obs_data_t *hotkeys, uint32_t width,
 				       uint32_t height, video_t *video)
+			: SELazyOBSVideoEncoderAllocatorBase(
+				  FormatString("CreateEncoderAllocator: [%d x %d] %s - %s", width, height, id.c_str(), name.c_str()))
 		{
 			m_id = id;
 			m_name = name;
@@ -729,14 +735,14 @@ public:
 		virtual obs_encoder_t *AllocRef() override
 		{
 			auto created_encoder =
-				SETRACE_ADDREF(obs_video_encoder_create(
+				obs_video_encoder_create(
 					m_id.c_str(), m_name.c_str(),
-					m_settings, m_hotkeys));
+					m_settings, m_hotkeys);
 
 			if (!created_encoder) {
 				blog(LOG_ERROR,
-				     "[obs-streamelements-core]: failed lazy-creating video encoder: %s (%s)",
-				     m_id.c_str(), m_name.c_str());
+				     "[obs-streamelements-core]: failed lazy-creating video encoder: %s",
+				     slug().c_str());
 
 				return nullptr;
 			}
@@ -809,7 +815,8 @@ public:
 	{
 		if (m_refCount > 0) {
 			blog(LOG_ERROR,
-			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object");
+			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider is destroyed while there are active references to the underlying object: %s",
+			     m_allocator->slug().c_str());
 		}
 	}
 
@@ -846,6 +853,55 @@ public:
 
 	std::string GetName() const { return m_allocator->GetName(); }
 
+	CefRefPtr<CefDictionaryValue> SerializeEncoder()
+	{
+		std::shared_lock lock(m_mutex);
+
+		if (m_object) {
+			return SerializeObsEncoder(m_object);
+		}
+
+		auto result = CefDictionaryValue::Create();
+
+		result->SetString("class", GetId());
+		result->SetString("name", GetName());
+		result->SetString("label", GetName());
+
+		auto codec = obs_get_encoder_codec(GetId().c_str());
+
+		if (codec)
+			result->SetString("codec", codec);
+		else
+			result->SetNull("codec");
+
+		auto encoder_type = obs_get_encoder_type(GetId().c_str());
+
+		if (encoder_type == OBS_ENCODER_VIDEO) {
+			result->SetString("type", "video");
+		} else if (encoder_type == OBS_ENCODER_AUDIO) {
+			result->SetString("type", "audio");
+		}
+
+		// Settings & properties
+
+		obs_data_t *settings = SETRACE_ADDREF(GetSettingsRef());
+
+		result->SetValue(
+			"settings",
+			CefParseJSON(settings ? obs_data_get_json(settings)
+					      : "null",
+				     JSON_PARSER_ALLOW_TRAILING_COMMAS));
+
+		result->SetValue("properties", SerializeObsEncoderProperties(
+						       GetId(), settings));
+
+		if (settings) {
+			obs_data_release(SETRACE_DECREF(settings));
+		}
+
+		return result;
+	}
+
 protected:
 	inline obs_encoder_t *GetPtr() const {
 		return m_object;
@@ -856,10 +912,15 @@ private:
 	{
 		std::unique_lock lock(m_mutex);
 
+		++m_refCount;
+
 		if (!m_object) {
 			m_object = SETRACE_ADDREF(m_allocator->AllocRef());
 
-			++m_refCount;
+			blog(LOG_INFO,
+			     "[obs-streamelements-core]: SELazyOBSVideoEncoderProvider::AddConsumer called allocator->AllocRef(): (refCount: %d, object: %s): %s",
+			     m_refCount, GetIdFromPointer(m_object).c_str(),
+			     m_allocator->slug().c_str());
 		}
 	}
 
@@ -871,14 +932,20 @@ private:
 		--m_refCount;
 
 		if (m_refCount <= 0 && m_object) {
-			m_object = nullptr;
+			blog(LOG_INFO,
+			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider::RemoveConsumer calling allocator->Reset(): (refCount: %d, object: %s): %s",
+			     m_refCount, GetIdFromPointer(m_object).c_str(),
+			     m_allocator->slug().c_str());
 
 			m_allocator->Reset();
+
+			m_object = nullptr;
 		}
 
 		if (m_refCount < 0) {
 			blog(LOG_ERROR,
-			     "[obs-streamelements-core]: warning: SELazyOBSVideoEncoderProvider::RemoveConsumer call results in negative reference count");
+			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider::RemoveConsumer call results in negative reference count (%d): %s",
+			     m_refCount, m_allocator->slug().c_str());
 		}
 	}
 
@@ -891,11 +958,6 @@ protected:
 	void ReleaseRef(obs_encoder_t* object)
 	{
 		obs_encoder_release(SETRACE_DECREF(object));
-	}
-
-	void ReleaseAuxiliaryResources()
-	{
-
 	}
 };
 

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -262,6 +262,48 @@ ParseEncodersList(CefRefPtr<CefValue> encodersList,
 	return encoderIds.size() > 0;
 }
 
+static CefRefPtr<CefDictionaryValue> SerializeObsEncoder(std::shared_ptr<SELazyOBSVideoEncoderProvider> e)
+{
+	auto existing = e->TryGetLazyObjectReference();
+
+	if (existing) {
+		return SerializeObsEncoder(existing->Get());
+	}
+
+	auto result = CefDictionaryValue::Create();
+
+	OBSDataAutoRelease settings = SETRACE_SCOPEREF(e->GetSettingsRef());
+
+	result->SetString("class", e->GetId());
+	result->SetString("name", e->GetName());
+	result->SetString("label", e->GetName());
+
+	auto codec = obs_get_encoder_codec(e->GetId().c_str());
+
+	if (codec)
+		result->SetString("codec", codec);
+	else
+		result->SetNull("codec");
+
+	auto encoder_type = obs_get_encoder_type(e->GetId().c_str());
+
+	if (encoder_type == OBS_ENCODER_VIDEO) {
+		result->SetString("type", "video");
+	} else if (encoder_type == OBS_ENCODER_AUDIO) {
+		result->SetString("type", "audio");
+	}
+
+	result->SetValue("settings",
+			 CefParseJSON(obs_data_get_json(settings),
+				      JSON_PARSER_ALLOW_TRAILING_COMMAS));
+
+	result->SetValue("properties",
+			 SerializeObsEncoderProperties(e->GetId(),
+						       settings));
+
+	return result;
+}
+
 static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* composition, CefRefPtr<CefDictionaryValue>& root)
 {
 	auto info = composition->GetCompositionInfo(nullptr, "SerializeObsVideoEncoders");
@@ -269,8 +311,8 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 	auto streamingVideoEncoders = CefListValue::Create();
 
 	for (size_t idx = 0;; ++idx) {
-		OBSEncoderAutoRelease streamingVideoEncoder =
-			info->GetStreamingVideoEncoderRef(idx);
+		auto streamingVideoEncoder =
+			info->GetStreamingVideoEncoderProvider(idx);
 
 		// OBS Native composition doesn't have an encoder until we start streaming
 		if (!streamingVideoEncoder)
@@ -279,8 +321,6 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 		streamingVideoEncoders->SetDictionary(
 			streamingVideoEncoders->GetSize(),
 			SerializeObsEncoder(streamingVideoEncoder));
-
-		SETRACE_DECREF(streamingVideoEncoder.Get());
 	}
 
 	if (streamingVideoEncoders->GetSize() == 0)
@@ -295,20 +335,18 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 	auto recordingVideoEncoders = CefListValue::Create();
 
 	for (size_t idx = 0;; ++idx) {
-		OBSEncoderAutoRelease recordingVideoEncoder =
-			info->GetRecordingVideoEncoderRef(idx);
-		SETRACE_DECREF(recordingVideoEncoder.Get());
+		auto recordingVideoEncoder =
+			info->GetRecordingVideoEncoderProvider(idx);
 
 		if (!recordingVideoEncoder)
 			break;
 
-		OBSEncoderAutoRelease streamingVideoEncoder =
-			info->GetRecordingVideoEncoderRef(idx);
-		SETRACE_DECREF(streamingVideoEncoder.Get());
+		auto streamingVideoEncoder =
+			info->GetStreamingVideoEncoderProvider(idx);
 
 		if (!streamingVideoEncoder ||
-		    streamingVideoEncoder.Get() !=
-			    recordingVideoEncoder.Get()) {
+		    streamingVideoEncoder !=
+			    recordingVideoEncoder) {
 			allEqual = false;
 		}
 
@@ -800,8 +838,9 @@ public:
 
 	virtual ~StreamElementsDefaultVideoCompositionInfo() {}
 
-protected:
-	virtual obs_encoder_t *GetStreamingVideoEncoder(size_t index)
+public:
+	virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+	GetStreamingVideoEncoderProvider(size_t index)
 	{
 		if (!obs_frontend_streaming_active())
 			return nullptr;
@@ -822,10 +861,11 @@ protected:
 			result = obs_output_get_video_encoder2(output, index);
 		}
 
-		return result;
+		return std::make_shared<SELazyOBSVideoEncoderProvider>(result);
 	}
 
-	virtual obs_encoder_t *GetRecordingVideoEncoder(size_t index)
+	virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+	GetRecordingVideoEncoderProvider(size_t index)
 	{
 		obs_encoder_t *result = nullptr;
 
@@ -864,10 +904,12 @@ protected:
 		}
 
 		if (!result && obs_frontend_streaming_active()) {
-			result = GetStreamingVideoEncoder(index);
+			return GetStreamingVideoEncoderProvider(
+				index);
+		} else {
+			return std::make_shared<SELazyOBSVideoEncoderProvider>(
+				result);
 		}
-
-		return result;
 	}
 
 public:
@@ -1109,8 +1151,9 @@ private:
 	video_t *m_video = nullptr;
 	//obs_view_t *m_view = nullptr;
 	obs_canvas_t *m_canvas = nullptr;
-	std::vector<obs_encoder_t *> m_streamingVideoEncoders;
-	std::vector<obs_encoder_t *> m_recordingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>> m_streamingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
+		m_recordingVideoEncoders;
 	uint32_t m_baseWidth = 1920;
 	uint32_t m_baseHeight = 1080;
 
@@ -1123,8 +1166,10 @@ public:
 		StreamElementsVideoCompositionEventListener *listener,
 		std::string holder,
 		video_t *video, uint32_t baseWidth, uint32_t baseHeight,
-		std::vector<obs_encoder_t *> streamingVideoEncoders,
-		std::vector<obs_encoder_t *> recordingVideoEncoders,
+		std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
+			streamingVideoEncoders,
+		std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>>
+			recordingVideoEncoders,
 		obs_canvas_t* canvas
 		/* obs_view_t *view*/)
 		: StreamElementsVideoCompositionBase::CompositionInfo(
@@ -1138,29 +1183,23 @@ public:
 		  //m_view(view)
 	{
 		for (auto encoder : streamingVideoEncoders) {
-			m_streamingVideoEncoders.push_back(
-				SETRACE_ADDREF(obs_encoder_get_ref(encoder)));
+			m_streamingVideoEncoders.push_back(encoder);
 		}
 
 		for (auto encoder : recordingVideoEncoders) {
-			m_recordingVideoEncoders.push_back(
-				SETRACE_ADDREF(obs_encoder_get_ref(encoder)));
+			m_recordingVideoEncoders.push_back(encoder);
 		}
 	}
 
 	virtual ~StreamElementsCustomVideoCompositionInfo()
 	{
-		for (const auto &encoder : m_streamingVideoEncoders) {
-			obs_encoder_release(SETRACE_DECREF(encoder));
-		}
-
-		for (const auto &encoder : m_recordingVideoEncoders) {
-			obs_encoder_release(SETRACE_DECREF(encoder));
-		}
+		m_streamingVideoEncoders.clear();
+		m_recordingVideoEncoders.clear();
 	}
 
-protected:
-	virtual obs_encoder_t *GetStreamingVideoEncoder(size_t index)
+public:
+	virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+	GetStreamingVideoEncoderProvider(size_t index)
 	{
 		if (index >= 0 && index < m_streamingVideoEncoders.size())
 			return m_streamingVideoEncoders[index];
@@ -1168,12 +1207,13 @@ protected:
 			return nullptr;
 	}
 
-	virtual obs_encoder_t *GetRecordingVideoEncoder(size_t index)
+	virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+	GetRecordingVideoEncoderProvider(size_t index)
 	{
 		if (index >= 0 && index < m_recordingVideoEncoders.size())
 			return m_recordingVideoEncoders[index];
 		else
-			return GetStreamingVideoEncoder(index);
+			return GetStreamingVideoEncoderProvider(index);
 	}
 
 public:
@@ -1219,6 +1259,10 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 		throw std::runtime_error(
 			"mismatch between sizes of passed in vectors");
 
+	if (!streamingVideoEncoderIds.size()) {
+		throw std::runtime_error("Must specify at least one streamingVideoEncoder");
+	}
+
 	/* align to multiple-of-two and SSE alignment sizes */
 	m_baseWidth &= 0xFFFFFFFC;
 	m_baseHeight &= 0xFFFFFFFE;
@@ -1227,58 +1271,6 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 
 	if (!obs_get_video_info(&ovi))
 		throw std::runtime_error("obs_get_video_info() failed");
-
-	for (size_t idx = 0; idx < streamingVideoEncoderSettings.size(); ++idx) {
-		obs_data_t *settings =
-			SETRACE_NOREF(streamingVideoEncoderSettings[idx]);
-
-		char buf[32];
-		sprintf(buf, "%d", (int)idx + 1);
-
-		auto created_encoder = SETRACE_ADDREF(obs_video_encoder_create(
-			streamingVideoEncoderIds[idx].c_str(),
-			(name + ": streaming video encoder " + std::string(buf))
-				.c_str(),
-			settings, streamingVideoEncoderHotkeyData[idx]));
-
-		if (!created_encoder) {
-			for (auto encoder : m_streamingVideoEncoders) {
-				obs_encoder_release(SETRACE_DECREF(encoder));
-			}
-
-			throw std::runtime_error(
-				"obs_video_encoder_create() failed");
-		}
-
-		if (m_canvas) {
-			switch (video_output_get_format(
-				obs_canvas_get_video(m_canvas)))
-			{
-			case VIDEO_FORMAT_I420:
-			case VIDEO_FORMAT_NV12:
-			case VIDEO_FORMAT_I010:
-			case VIDEO_FORMAT_P010:
-				break;
-			default:
-				obs_encoder_set_preferred_video_format(
-					created_encoder, VIDEO_FORMAT_NV12);
-			}
-		}
-
-		m_streamingVideoEncoders.push_back(created_encoder);
-	}
-
-	if (!m_streamingVideoEncoders.size()) {
-		throw std::runtime_error("no encoders were created");
-	}
-
-	//
-	// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-	// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-	//
-	for (auto encoder : m_streamingVideoEncoders) {
-		obs_encoder_set_scaled_size(encoder, m_baseWidth, m_baseHeight);
-	}
 
 	m_rootSource = SETRACE_ADDREF(obs_source_create_private(
 		"cut_transition", (name + ": root source").c_str(), nullptr));
@@ -1293,9 +1285,7 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 		if (m_rootSource)
 			obs_source_release(SETRACE_DECREF(m_rootSource));
 
-		for (auto encoder : m_streamingVideoEncoders) {
-			obs_encoder_release(SETRACE_DECREF(encoder));
-		}
+		m_streamingVideoEncoders.clear();
 
 		throw std::runtime_error("obs_source_create_private(cut_transition) failed");
 	}
@@ -1310,18 +1300,10 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 
 	m_video = obs_canvas_get_video(m_canvas);
 
-	//m_view = SETRACE_ADDREF(obs_view_create());
-
-	//m_video = obs_view_add2(m_view, &ovi);
-
 	obs_transition_set(m_rootSource, m_transition);
 
 	//obs_view_set_source(m_view, 0, m_rootSource);
 	obs_canvas_set_channel(m_canvas, 0, m_rootSource);
-
-	for (auto encoder : m_streamingVideoEncoders) {
-		obs_encoder_set_video(encoder, m_video);
-	}
 
 	auto currentScene = scene_create_private_with_custom_size(
 		GetUniqueSceneName("Scene").c_str(), m_baseWidth, m_baseHeight, m_canvas);
@@ -1378,6 +1360,24 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 		}
 	}
 
+	for (size_t idx = 0; idx < streamingVideoEncoderSettings.size();
+	     ++idx) {
+		obs_data_t *settings =
+			SETRACE_NOREF(streamingVideoEncoderSettings[idx]);
+
+		char buf[32];
+		sprintf(buf, "%d", (int)idx + 1);
+
+		auto encoderProvider =
+			std::make_shared<SELazyOBSVideoEncoderProvider>(
+				streamingVideoEncoderIds[idx],
+				(name + ": streaming video encoder " +
+				 std::string(buf)),
+				settings, streamingVideoEncoderHotkeyData[idx], m_baseWidth, m_baseHeight, m_video);
+
+		m_streamingVideoEncoders.push_back(encoderProvider);
+	}
+
 	ConnectTransitionEvents(m_transition);
 }
 
@@ -1400,65 +1400,22 @@ void StreamElementsCustomVideoComposition::SetRecordingEncoders(
 		char buf[32];
 		sprintf(buf, "%d", (int)idx + 1);
 
-		auto created_encoder = SETRACE_ADDREF(obs_video_encoder_create(
-			recordingVideoEncoderIds[idx].c_str(),
-			(GetName() + ": recording video encoder " +
-			 std::string(buf))
-				.c_str(),
-			recordingVideoEncoderSettings[idx],
-			recordingVideoEncoderHotkeyData[idx]));
+		auto encoderProvider =
+			std::make_shared<SELazyOBSVideoEncoderProvider>(
+				recordingVideoEncoderIds[idx],
+				(GetName() + ": recording video encoder " +
+				 std::string(buf)),
+				recordingVideoEncoderSettings[idx],
+				recordingVideoEncoderHotkeyData[idx],
+				m_baseWidth, m_baseHeight, m_video);
 
-		if (!created_encoder) {
-			for (auto encoder : m_recordingVideoEncoders) {
-				obs_encoder_release(SETRACE_DECREF(encoder));
-			}
-
-			m_recordingVideoEncoders.clear();
-
-			return;
-		}
-
-		if (m_canvas) {
-			switch (video_output_get_format(
-				obs_canvas_get_video(m_canvas))) {
-			case VIDEO_FORMAT_I420:
-			case VIDEO_FORMAT_NV12:
-			case VIDEO_FORMAT_I010:
-			case VIDEO_FORMAT_P010:
-				break;
-			default:
-				obs_encoder_set_preferred_video_format(
-					created_encoder, VIDEO_FORMAT_NV12);
-			}
-		}
-
-		//
-		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-		//
-		obs_encoder_set_scaled_size(created_encoder, m_baseWidth,
-					    m_baseHeight);
-
-		obs_encoder_set_video(created_encoder, m_video);
-
-		m_recordingVideoEncoders.push_back(created_encoder);
+		m_recordingVideoEncoders.push_back(encoderProvider);
 	}
 }
 
 StreamElementsCustomVideoComposition::~StreamElementsCustomVideoComposition()
 {
-	for (auto encoder : m_streamingVideoEncoders) {
-		obs_encoder_set_video(encoder, nullptr);
-
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
 	m_streamingVideoEncoders.clear();
-
-	for (auto encoder : m_recordingVideoEncoders) {
-		obs_encoder_set_video(encoder, nullptr);
-
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
 	m_recordingVideoEncoders.clear();
 
 	m_video = nullptr;
@@ -2189,42 +2146,21 @@ StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 			char buf[32];
 			sprintf(buf, "%d", (int)idx + 1);
 
-			auto created_encoder =
-				SETRACE_ADDREF(obs_video_encoder_create(
-					streamingVideoEncoderIds[idx].c_str(),
+			auto encoderProvider =
+				std::make_shared<SELazyOBSVideoEncoderProvider>(
+					streamingVideoEncoderIds[idx],
 					(name + ": streaming video encoder " +
-					 std::string(buf))
-						.c_str(),
+					 std::string(buf)),
 					settings,
-					streamingVideoEncoderHotkeyData[idx]));
+					streamingVideoEncoderHotkeyData[idx],
+					ovi.base_width, ovi.base_height,
+					obs_get_video());
 
-			if (!created_encoder) {
-				for (auto encoder : m_streamingVideoEncoders) {
-					obs_encoder_release(SETRACE_DECREF(encoder));
-				}
-
-				throw std::runtime_error(
-					"obs_video_encoder_create() failed");
-			}
-
-			m_streamingVideoEncoders.push_back(created_encoder);
+			m_streamingVideoEncoders.push_back(encoderProvider);
 		}
 
 		if (!m_streamingVideoEncoders.size()) {
 			throw std::runtime_error("no encoders were created");
-		}
-
-		//
-		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-		//
-		for (auto encoder : m_streamingVideoEncoders) {
-			obs_encoder_set_scaled_size(encoder, ovi.base_width,
-						    ovi.base_height);
-		}
-
-		for (auto encoder : m_streamingVideoEncoders) {
-			obs_encoder_set_video(encoder, obs_get_video());
 		}
 
 		m_rootSource = SETRACE_ADDREF(obs_source_create_private(
@@ -2238,18 +2174,7 @@ StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 	~StreamElementsObsNativeVideoCompositionWithCustomEncoders()
 {
-	for (auto encoder : m_streamingVideoEncoders) {
-		obs_encoder_set_video(encoder, nullptr);
-
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
 	m_streamingVideoEncoders.clear();
-
-	for (auto encoder : m_recordingVideoEncoders) {
-		obs_encoder_set_video(encoder, nullptr);
-
-		obs_encoder_release(SETRACE_DECREF(encoder));
-	}
 	m_recordingVideoEncoders.clear();
 
 	std::unique_lock guard(m_mutex);
@@ -2295,45 +2220,17 @@ void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetRecordingEnco
 		char buf[32];
 		sprintf(buf, "%d", (int)idx + 1);
 
-		auto created_encoder = SETRACE_ADDREF(obs_video_encoder_create(
-			recordingVideoEncoderIds[idx].c_str(),
-			(GetName() + ": recording video encoder " +
-			 std::string(buf))
-				.c_str(),
-			recordingVideoEncoderSettings[idx],
-			recordingVideoEncoderHotkeyData[idx]));
+		auto encoderProvider =
+			std::make_shared<SELazyOBSVideoEncoderProvider>(
+				recordingVideoEncoderIds[idx],
+				(GetName() + ": recording video encoder " +
+				 std::string(buf)),
+				recordingVideoEncoderSettings[idx],
+				recordingVideoEncoderHotkeyData[idx],
+				ovi.base_width, ovi.base_height,
+				obs_get_video());
 
-		if (!created_encoder) {
-			for (auto encoder : m_recordingVideoEncoders) {
-				obs_encoder_release(SETRACE_DECREF(encoder));
-			}
-
-			m_recordingVideoEncoders.clear();
-
-			return;
-		}
-
-		switch (video_output_get_format(obs_get_video())) {
-		case VIDEO_FORMAT_I420:
-		case VIDEO_FORMAT_NV12:
-		case VIDEO_FORMAT_I010:
-		case VIDEO_FORMAT_P010:
-			break;
-		default:
-			obs_encoder_set_preferred_video_format(
-				created_encoder, VIDEO_FORMAT_NV12);
-		}
-
-		//
-		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-		//
-		obs_encoder_set_scaled_size(created_encoder, ovi.base_width,
-					    ovi.base_height);
-
-		obs_encoder_set_video(created_encoder, obs_get_video());
-
-		m_recordingVideoEncoders.push_back(created_encoder);
+		m_recordingVideoEncoders.push_back(encoderProvider);
 	}
 }
 

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -861,7 +861,13 @@ public:
 			result = obs_output_get_video_encoder2(output, index);
 		}
 
-		return std::make_shared<SELazyOBSVideoEncoderProvider>(result);
+		if (!result)
+			return nullptr;
+
+		return std::make_shared<SELazyOBSVideoEncoderProvider>(
+			SELazyOBSVideoEncoderProvider::
+				ExternallyAllocatedEncoderAllocator::Create(
+					result));
 	}
 
 	virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
@@ -907,8 +913,14 @@ public:
 			return GetStreamingVideoEncoderProvider(
 				index);
 		} else {
-			return std::make_shared<SELazyOBSVideoEncoderProvider>(
-				result);
+			if (!result)
+				return nullptr;
+			else
+				return std::make_shared<
+					SELazyOBSVideoEncoderProvider>(
+					SELazyOBSVideoEncoderProvider::
+						ExternallyAllocatedEncoderAllocator::
+							Create(result));
 		}
 	}
 
@@ -1368,12 +1380,15 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 		char buf[32];
 		sprintf(buf, "%d", (int)idx + 1);
 
-		auto encoderProvider =
-			std::make_shared<SELazyOBSVideoEncoderProvider>(
-				streamingVideoEncoderIds[idx],
-				(name + ": streaming video encoder " +
-				 std::string(buf)),
-				settings, streamingVideoEncoderHotkeyData[idx], m_baseWidth, m_baseHeight, m_video);
+		auto encoderProvider = std::make_shared<
+			SELazyOBSVideoEncoderProvider>(
+			SELazyOBSVideoEncoderProvider::CreateEncoderAllocator::
+				Create(streamingVideoEncoderIds[idx],
+				       (name + ": streaming video encoder " +
+					std::string(buf)),
+				       settings,
+				       streamingVideoEncoderHotkeyData[idx],
+				       m_baseWidth, m_baseHeight, m_video));
 
 		m_streamingVideoEncoders.push_back(encoderProvider);
 	}
@@ -1400,14 +1415,16 @@ void StreamElementsCustomVideoComposition::SetRecordingEncoders(
 		char buf[32];
 		sprintf(buf, "%d", (int)idx + 1);
 
-		auto encoderProvider =
-			std::make_shared<SELazyOBSVideoEncoderProvider>(
-				recordingVideoEncoderIds[idx],
-				(GetName() + ": recording video encoder " +
-				 std::string(buf)),
-				recordingVideoEncoderSettings[idx],
-				recordingVideoEncoderHotkeyData[idx],
-				m_baseWidth, m_baseHeight, m_video);
+		auto encoderProvider = std::make_shared<
+			SELazyOBSVideoEncoderProvider>(
+			SELazyOBSVideoEncoderProvider::CreateEncoderAllocator::
+				Create(recordingVideoEncoderIds[idx],
+				       (GetName() +
+					": recording video encoder " +
+					std::string(buf)),
+				       recordingVideoEncoderSettings[idx],
+				       recordingVideoEncoderHotkeyData[idx],
+				       m_baseWidth, m_baseHeight, m_video));
 
 		m_recordingVideoEncoders.push_back(encoderProvider);
 	}
@@ -2146,15 +2163,19 @@ StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 			char buf[32];
 			sprintf(buf, "%d", (int)idx + 1);
 
-			auto encoderProvider =
-				std::make_shared<SELazyOBSVideoEncoderProvider>(
-					streamingVideoEncoderIds[idx],
-					(name + ": streaming video encoder " +
-					 std::string(buf)),
-					settings,
-					streamingVideoEncoderHotkeyData[idx],
-					ovi.base_width, ovi.base_height,
-					obs_get_video());
+			auto encoderProvider = std::make_shared<
+				SELazyOBSVideoEncoderProvider>(
+				SELazyOBSVideoEncoderProvider::
+					CreateEncoderAllocator::Create(
+						streamingVideoEncoderIds[idx],
+						(name +
+						 ": streaming video encoder " +
+						 std::string(buf)),
+						settings,
+						streamingVideoEncoderHotkeyData
+							[idx],
+						ovi.base_width, ovi.base_height,
+						obs_get_video()));
 
 			m_streamingVideoEncoders.push_back(encoderProvider);
 		}
@@ -2222,13 +2243,16 @@ void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetRecordingEnco
 
 		auto encoderProvider =
 			std::make_shared<SELazyOBSVideoEncoderProvider>(
-				recordingVideoEncoderIds[idx],
-				(GetName() + ": recording video encoder " +
-				 std::string(buf)),
-				recordingVideoEncoderSettings[idx],
-				recordingVideoEncoderHotkeyData[idx],
-				ovi.base_width, ovi.base_height,
-				obs_get_video());
+				SELazyOBSVideoEncoderProvider::
+							 CreateEncoderAllocator::Create(
+					recordingVideoEncoderIds[idx],
+					(GetName() +
+					 ": recording video encoder " +
+					 std::string(buf)),
+					recordingVideoEncoderSettings[idx],
+					recordingVideoEncoderHotkeyData[idx],
+					ovi.base_width, ovi.base_height,
+					obs_get_video()));
 
 		m_recordingVideoEncoders.push_back(encoderProvider);
 	}

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -262,48 +262,6 @@ ParseEncodersList(CefRefPtr<CefValue> encodersList,
 	return encoderIds.size() > 0;
 }
 
-static CefRefPtr<CefDictionaryValue> SerializeObsEncoder(std::shared_ptr<SELazyOBSVideoEncoderProvider> e)
-{
-	auto existing = e->TryGetLazyObjectReference();
-
-	if (existing) {
-		return SerializeObsEncoder(existing->Get());
-	}
-
-	auto result = CefDictionaryValue::Create();
-
-	OBSDataAutoRelease settings = SETRACE_SCOPEREF(e->GetSettingsRef());
-
-	result->SetString("class", e->GetId());
-	result->SetString("name", e->GetName());
-	result->SetString("label", e->GetName());
-
-	auto codec = obs_get_encoder_codec(e->GetId().c_str());
-
-	if (codec)
-		result->SetString("codec", codec);
-	else
-		result->SetNull("codec");
-
-	auto encoder_type = obs_get_encoder_type(e->GetId().c_str());
-
-	if (encoder_type == OBS_ENCODER_VIDEO) {
-		result->SetString("type", "video");
-	} else if (encoder_type == OBS_ENCODER_AUDIO) {
-		result->SetString("type", "audio");
-	}
-
-	result->SetValue("settings",
-			 CefParseJSON(obs_data_get_json(settings),
-				      JSON_PARSER_ALLOW_TRAILING_COMMAS));
-
-	result->SetValue("properties",
-			 SerializeObsEncoderProperties(e->GetId(),
-						       settings));
-
-	return result;
-}
-
 static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* composition, CefRefPtr<CefDictionaryValue>& root)
 {
 	auto info = composition->GetCompositionInfo(nullptr, "SerializeObsVideoEncoders");
@@ -320,7 +278,7 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 
 		streamingVideoEncoders->SetDictionary(
 			streamingVideoEncoders->GetSize(),
-			SerializeObsEncoder(streamingVideoEncoder));
+			streamingVideoEncoder->SerializeEncoder());
 	}
 
 	if (streamingVideoEncoders->GetSize() == 0)
@@ -352,7 +310,7 @@ static void SerializeObsVideoEncoders(StreamElementsVideoCompositionBase* compos
 
 		recordingVideoEncoders->SetDictionary(
 			recordingVideoEncoders->GetSize(),
-			SerializeObsEncoder(recordingVideoEncoder));
+			recordingVideoEncoder->SerializeEncoder());
 	}
 
 	if (recordingVideoEncoders->GetSize() > 0 && !allEqual) {

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -823,6 +823,7 @@ public:
 			return nullptr;
 
 		return std::make_shared<SELazyOBSVideoEncoderProvider>(
+			FormatString("StreamElementsDefaultVideoCompositionInfo::GetStreamingVideoEncoderProvider(%d)", index),
 			SELazyOBSVideoEncoderProvider::
 				ExternallyAllocatedEncoderAllocator::Create(
 					result));
@@ -876,6 +877,9 @@ public:
 			else
 				return std::make_shared<
 					SELazyOBSVideoEncoderProvider>(
+					FormatString(
+						"StreamElementsDefaultVideoCompositionInfo::GetRecordingVideoEncoderProvider(%d)",
+						index),
 					SELazyOBSVideoEncoderProvider::
 						ExternallyAllocatedEncoderAllocator::
 							Create(result));
@@ -1335,15 +1339,16 @@ StreamElementsCustomVideoComposition::StreamElementsCustomVideoComposition(
 		obs_data_t *settings =
 			SETRACE_NOREF(streamingVideoEncoderSettings[idx]);
 
-		char buf[32];
-		sprintf(buf, "%d", (int)idx + 1);
-
 		auto encoderProvider = std::make_shared<
 			SELazyOBSVideoEncoderProvider>(
+			FormatString(
+				"StreamElementsCustomVideoComposition::ctor(streamingVideoEncoder[%d])",
+				idx),
 			SELazyOBSVideoEncoderProvider::CreateEncoderAllocator::
 				Create(streamingVideoEncoderIds[idx],
-				       (name + ": streaming video encoder " +
-					std::string(buf)),
+				       FormatString(
+					       "%s: streaming video encoder %d",
+					       name.c_str(), idx + 1),
 				       settings,
 				       streamingVideoEncoderHotkeyData[idx],
 				       m_baseWidth, m_baseHeight, m_video));
@@ -1375,11 +1380,13 @@ void StreamElementsCustomVideoComposition::SetRecordingEncoders(
 
 		auto encoderProvider = std::make_shared<
 			SELazyOBSVideoEncoderProvider>(
+			FormatString(
+				"StreamElementsCustomVideoComposition::SetRecordingEncoders(recordingVideoEncoder[%d])",
+				idx),
 			SELazyOBSVideoEncoderProvider::CreateEncoderAllocator::
 				Create(recordingVideoEncoderIds[idx],
-				       (GetName() +
-					": recording video encoder " +
-					std::string(buf)),
+				       FormatString("%s: recording video encoder %d",
+						    GetName().c_str(), idx + 1),
 				       recordingVideoEncoderSettings[idx],
 				       recordingVideoEncoderHotkeyData[idx],
 				       m_baseWidth, m_baseHeight, m_video));
@@ -2118,17 +2125,13 @@ StreamElementsObsNativeVideoCompositionWithCustomEncoders::
 			obs_data_t *settings =
 				streamingVideoEncoderSettings[idx];
 
-			char buf[32];
-			sprintf(buf, "%d", (int)idx + 1);
-
 			auto encoderProvider = std::make_shared<
 				SELazyOBSVideoEncoderProvider>(
+				FormatString("StreamElementsObsNativeVideoCompositionWithCustomEncoders::ctor(streamingVideoEncoders[%d])", idx),
 				SELazyOBSVideoEncoderProvider::
 					CreateEncoderAllocator::Create(
 						streamingVideoEncoderIds[idx],
-						(name +
-						 ": streaming video encoder " +
-						 std::string(buf)),
+						FormatString("%s: streaming video encoder %d", name.c_str(), idx + 1),
 						settings,
 						streamingVideoEncoderHotkeyData
 							[idx],
@@ -2196,17 +2199,15 @@ void StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetRecordingEnco
 
 	for (size_t idx = 0; idx < recordingVideoEncoderSettings.size();
 	     ++idx) {
-		char buf[32];
-		sprintf(buf, "%d", (int)idx + 1);
-
 		auto encoderProvider =
 			std::make_shared<SELazyOBSVideoEncoderProvider>(
+				FormatString("StreamElementsObsNativeVideoCompositionWithCustomEncoders::SetRecordingEncoders(recordingVideoEncoder[%d])", idx),
 				SELazyOBSVideoEncoderProvider::
 							 CreateEncoderAllocator::Create(
 					recordingVideoEncoderIds[idx],
-					(GetName() +
-					 ": recording video encoder " +
-					 std::string(buf)),
+				       FormatString(
+					       "%s: recoding video encoder %d",
+					       GetName().c_str(), idx + 1),
 					recordingVideoEncoderSettings[idx],
 					recordingVideoEncoderHotkeyData[idx],
 					ovi.base_width, ovi.base_height,

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -44,6 +44,12 @@ public:
 		m_width = width;
 		m_height = height;
 		m_video = video;
+
+		if (m_settings)
+			obs_data_addref(m_settings);
+
+		if (m_hotkeys)
+			obs_data_addref(m_hotkeys);
 	}
 
 	SELazyOBSVideoEncoderProvider(obs_encoder_t *externallyAllocatedObject)
@@ -67,7 +73,7 @@ public:
 	{
 		auto ref = TryGetLazyObjectReference();
 
-		if (ref) {
+		if (ref && ref->Get()) {
 			return obs_encoder_get_settings(ref->Get());
 		}
 
@@ -75,6 +81,10 @@ public:
 			obs_data_addref(m_settings);
 
 			return m_settings;
+		}
+
+		if (m_id.size() > 0) {
+			return obs_encoder_defaults(m_id.c_str());
 		}
 
 		return obs_data_create();

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -247,8 +247,6 @@ public:
 
 	std::string GetName()
 	{
-		std::shared_lock<decltype(m_mutex)> lock(m_mutex);
-
 		return m_name;
 	}
 

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -23,6 +23,38 @@ public:
 	//virtual void StopOutputRequested();
 };
 
+class SELazyOBSEncoderProvider
+	: public SELazyObjectProviderBase<obs_encoder_t> {
+private:
+	std::string m_id;
+	std::string m_name;
+	OBSDataAutoRelease m_settings;
+	OBSDataAutoRelease m_hotkeys;
+
+
+public:
+	SELazyOBSEncoderProvider(std::string id, std::string name, obs_data_t* settings, obs_data_t* hotkeys)
+	{
+		m_id = id;
+		m_name = name;
+		m_settings = settings;
+		m_hotkeys = hotkeys;
+	}
+
+protected:
+	virtual obs_encoder_t* AllocRef() override {
+		return SETRACE_ADDREF(obs_video_encoder_create(
+			m_id.c_str(), m_name.c_str(), m_settings, m_hotkeys));
+	}
+	virtual obs_encoder_t* AddRef(obs_encoder_t* encoder) override {
+		return SETRACE_ADDREF(obs_encoder_get_ref(encoder));
+	}
+
+	virtual void ReleaseRef(obs_encoder_t* encoder) override {
+		return obs_encoder_release(SETRACE_DECREF(encoder));
+	}
+};
+
 class StreamElementsVideoCompositionBase {
 public:
 	class scenes_t : public std::vector<obs_scene_t*> {

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -23,144 +23,6 @@ public:
 	//virtual void StopOutputRequested();
 };
 
-class SELazyOBSVideoEncoderProvider
-	: public SELazyObjectProviderBase<obs_encoder_t> {
-private:
-	std::string m_id;
-	std::string m_name;
-	OBSDataAutoRelease m_settings = nullptr;
-	OBSDataAutoRelease m_hotkeys = nullptr;
-	uint32_t m_width;
-	uint32_t m_height;
-	video_t *m_video;
-
-public:
-	SELazyOBSVideoEncoderProvider(std::string id, std::string name, obs_data_t* settings, obs_data_t* hotkeys, uint32_t width, uint32_t height, video_t* video)
-	{
-		m_id = id;
-		m_name = name;
-		m_settings = settings;
-		m_hotkeys = hotkeys;
-		m_width = width;
-		m_height = height;
-		m_video = video;
-
-		if (m_settings)
-			obs_data_addref(m_settings);
-
-		if (m_hotkeys)
-			obs_data_addref(m_hotkeys);
-	}
-
-	SELazyOBSVideoEncoderProvider(obs_encoder_t *externallyAllocatedObject)
-		: SELazyObjectProviderBase<obs_encoder_t>(externallyAllocatedObject)
-	{
-		if (!externallyAllocatedObject)
-			return;
-
-		m_id = obs_encoder_get_id(externallyAllocatedObject);
-		m_name = obs_encoder_get_name(externallyAllocatedObject);
-		m_settings =
-			obs_encoder_get_settings(externallyAllocatedObject);
-		m_hotkeys = nullptr;
-	}
-
-	~SELazyOBSVideoEncoderProvider() {
-		SetVideo(nullptr);
-	}
-
-	obs_data_t *GetSettingsRef()
-	{
-		auto ref = TryGetLazyObjectReference();
-
-		if (ref && ref->Get()) {
-			return obs_encoder_get_settings(ref->Get());
-		}
-
-		if (m_settings) {
-			obs_data_addref(m_settings);
-
-			return m_settings;
-		}
-
-		if (m_id.size() > 0) {
-			return obs_encoder_defaults(m_id.c_str());
-		}
-
-		return obs_data_create();
-	}
-
-	/*
-	obs_data_t *GetHotkeyDataRef()
-	{
-		if (m_hotkeys) {
-			obs_data_addref(m_hotkeys);
-
-			return m_hotkeys;
-		}
-
-		return obs_data_create();
-	}
-	*/
-
-	std::string GetId() const { return m_id; }
-	std::string GetName() const { return m_name; }
-
-	void SetVideo(video_t* video)
-	{
-		m_video = video;
-
-		auto ref = TryGetLazyObjectReference();
-
-		if (!ref)
-			return;
-
-		obs_encoder_set_video(ref->Get(), m_video);
-	}
-
-protected:
-	virtual obs_encoder_t* AllocRef() override {
-		auto created_encoder = SETRACE_ADDREF(obs_video_encoder_create(
-			m_id.c_str(), m_name.c_str(), m_settings, m_hotkeys));
-
-		if (!created_encoder) {
-			blog(LOG_ERROR,
-			     "[obs-streamelements-core]: failed lazy-creating video encoder: %s (%s)",
-			     m_id.c_str(), m_name.c_str());
-
-			return nullptr;
-		}
-		
-		switch (video_output_get_format(obs_get_video())) {
-		case VIDEO_FORMAT_I420:
-		case VIDEO_FORMAT_NV12:
-		case VIDEO_FORMAT_I010:
-		case VIDEO_FORMAT_P010:
-			break;
-		default:
-			obs_encoder_set_preferred_video_format(
-				created_encoder, VIDEO_FORMAT_NV12);
-		}
-
-		//
-		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
-		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
-		//
-		obs_encoder_set_scaled_size(created_encoder, m_width, m_height);
-
-		obs_encoder_set_video(created_encoder, m_video);
-
-		return created_encoder;
-	}
-	virtual obs_encoder_t* AddRef(obs_encoder_t* encoder) override {
-		return SETRACE_ADDREF(obs_encoder_get_ref(encoder));
-	}
-
-	virtual void ReleaseRef(obs_encoder_t* encoder) override {
-		return obs_encoder_release(SETRACE_DECREF(encoder));
-	}
-};
-
 class StreamElementsVideoCompositionBase {
 public:
 	class scenes_t : public std::vector<obs_scene_t*> {
@@ -237,7 +99,7 @@ public:
 		virtual void Render() = 0;
 
 		
-		std::shared_ptr<SELazyObjectReference<obs_encoder_t>>
+		std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>
 		GetStreamingVideoEncoderRef(size_t index)
 		{
 			auto prov = GetStreamingVideoEncoderProvider(index);
@@ -248,7 +110,7 @@ public:
 			return prov->GetLazyObjectReference();
 		}
 
-		std::shared_ptr<SELazyObjectReference<obs_encoder_t>> 
+		std::shared_ptr<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference> 
 		GetRecordingVideoEncoderRef(size_t index)
 		{
 			auto prov = GetRecordingVideoEncoderProvider(index);

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -23,28 +23,124 @@ public:
 	//virtual void StopOutputRequested();
 };
 
-class SELazyOBSEncoderProvider
+class SELazyOBSVideoEncoderProvider
 	: public SELazyObjectProviderBase<obs_encoder_t> {
 private:
 	std::string m_id;
 	std::string m_name;
-	OBSDataAutoRelease m_settings;
-	OBSDataAutoRelease m_hotkeys;
-
+	OBSDataAutoRelease m_settings = nullptr;
+	OBSDataAutoRelease m_hotkeys = nullptr;
+	uint32_t m_width;
+	uint32_t m_height;
+	video_t *m_video;
 
 public:
-	SELazyOBSEncoderProvider(std::string id, std::string name, obs_data_t* settings, obs_data_t* hotkeys)
+	SELazyOBSVideoEncoderProvider(std::string id, std::string name, obs_data_t* settings, obs_data_t* hotkeys, uint32_t width, uint32_t height, video_t* video)
 	{
 		m_id = id;
 		m_name = name;
 		m_settings = settings;
 		m_hotkeys = hotkeys;
+		m_width = width;
+		m_height = height;
+		m_video = video;
+	}
+
+	SELazyOBSVideoEncoderProvider(obs_encoder_t *externallyAllocatedObject)
+		: SELazyObjectProviderBase<obs_encoder_t>(externallyAllocatedObject)
+	{
+		if (!externallyAllocatedObject)
+			return;
+
+		m_id = obs_encoder_get_id(externallyAllocatedObject);
+		m_name = obs_encoder_get_name(externallyAllocatedObject);
+		m_settings =
+			obs_encoder_get_settings(externallyAllocatedObject);
+		m_hotkeys = nullptr;
+	}
+
+	~SELazyOBSVideoEncoderProvider() {
+		SetVideo(nullptr);
+	}
+
+	obs_data_t *GetSettingsRef()
+	{
+		auto ref = TryGetLazyObjectReference();
+
+		if (ref) {
+			return obs_encoder_get_settings(ref->Get());
+		}
+
+		if (m_settings) {
+			obs_data_addref(m_settings);
+
+			return m_settings;
+		}
+
+		return obs_data_create();
+	}
+
+	/*
+	obs_data_t *GetHotkeyDataRef()
+	{
+		if (m_hotkeys) {
+			obs_data_addref(m_hotkeys);
+
+			return m_hotkeys;
+		}
+
+		return obs_data_create();
+	}
+	*/
+
+	std::string GetId() const { return m_id; }
+	std::string GetName() const { return m_name; }
+
+	void SetVideo(video_t* video)
+	{
+		m_video = video;
+
+		auto ref = TryGetLazyObjectReference();
+
+		if (!ref)
+			return;
+
+		obs_encoder_set_video(ref->Get(), m_video);
 	}
 
 protected:
 	virtual obs_encoder_t* AllocRef() override {
-		return SETRACE_ADDREF(obs_video_encoder_create(
+		auto created_encoder = SETRACE_ADDREF(obs_video_encoder_create(
 			m_id.c_str(), m_name.c_str(), m_settings, m_hotkeys));
+
+		if (!created_encoder) {
+			blog(LOG_ERROR,
+			     "[obs-streamelements-core]: failed lazy-creating video encoder: %s (%s)",
+			     m_id.c_str(), m_name.c_str());
+
+			return nullptr;
+		}
+		
+		switch (video_output_get_format(obs_get_video())) {
+		case VIDEO_FORMAT_I420:
+		case VIDEO_FORMAT_NV12:
+		case VIDEO_FORMAT_I010:
+		case VIDEO_FORMAT_P010:
+			break;
+		default:
+			obs_encoder_set_preferred_video_format(
+				created_encoder, VIDEO_FORMAT_NV12);
+		}
+
+		//
+		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
+		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
+		//
+		obs_encoder_set_scaled_size(created_encoder, m_width, m_width);
+
+		obs_encoder_set_video(created_encoder, m_video);
+
+		return created_encoder;
 	}
 	virtual obs_encoder_t* AddRef(obs_encoder_t* encoder) override {
 		return SETRACE_ADDREF(obs_encoder_get_ref(encoder));
@@ -130,32 +226,34 @@ public:
 
 		virtual void Render() = 0;
 
-		obs_encoder_t* GetStreamingVideoEncoderRef(size_t index) {
-			auto result = GetStreamingVideoEncoder(index);
-
-			if (result) {
-				result = SETRACE_ADDREF(obs_encoder_get_ref(result));
-			}
-
-			return result;
-		}
-
-		obs_encoder_t *GetRecordingVideoEncoderRef(size_t index)
+		
+		std::shared_ptr<SELazyObjectReference<obs_encoder_t>>
+		GetStreamingVideoEncoderRef(size_t index)
 		{
-			auto result = GetRecordingVideoEncoder(index);
+			auto prov = GetStreamingVideoEncoderProvider(index);
 
-			if (result) {
-				result = SETRACE_ADDREF(obs_encoder_get_ref(result));
-			}
+			if (!prov)
+				return nullptr;
 
-			return result;
+			return prov->GetLazyObjectReference();
 		}
 
-	protected:
-		virtual obs_encoder_t *
-		GetStreamingVideoEncoder(size_t index) = 0;
-		virtual obs_encoder_t *
-		GetRecordingVideoEncoder(size_t index) = 0;
+		std::shared_ptr<SELazyObjectReference<obs_encoder_t>> 
+		GetRecordingVideoEncoderRef(size_t index)
+		{
+			auto prov = GetRecordingVideoEncoderProvider(index);
+
+			if (!prov)
+				return nullptr;
+
+			return prov->GetLazyObjectReference();
+		}
+
+		virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+		GetStreamingVideoEncoderProvider(size_t index) = 0;
+
+		virtual std::shared_ptr<SELazyOBSVideoEncoderProvider>
+		GetRecordingVideoEncoderProvider(size_t index) = 0;
 	};
 
 private:
@@ -701,8 +799,8 @@ private:
 			&recordingVideoEncoderHotkeyData);
 
 private:
-	std::vector<obs_encoder_t *> m_streamingVideoEncoders;
-	std::vector<obs_encoder_t *> m_recordingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>> m_streamingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>> m_recordingVideoEncoders;
 	video_t *m_video = nullptr;
 
 	obs_source_t* m_transition = nullptr;
@@ -768,8 +866,8 @@ private:
 private:
 	std::shared_mutex m_mutex;
 
-	std::vector<obs_encoder_t *> m_streamingVideoEncoders;
-	std::vector<obs_encoder_t *> m_recordingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>> m_streamingVideoEncoders;
+	std::vector<std::shared_ptr<SELazyOBSVideoEncoderProvider>> m_recordingVideoEncoders;
 
 	obs_source_t *m_rootSource = nullptr;
 

--- a/streamelements/StreamElementsVideoComposition.hpp
+++ b/streamelements/StreamElementsVideoComposition.hpp
@@ -146,7 +146,7 @@ protected:
 		// This will prevent obs_encoder_get_width & obs_encoder_get_height from crashing due to video output being improperly initialized for SOME REASON
 		// https://app.bugsplat.com/v2/crash?database=OBS_Live&id=1488897
 		//
-		obs_encoder_set_scaled_size(created_encoder, m_width, m_width);
+		obs_encoder_set_scaled_size(created_encoder, m_width, m_height);
 
 		obs_encoder_set_video(created_encoder, m_video);
 

--- a/streamelements/StreamElementsVideoCompositionManager.cpp
+++ b/streamelements/StreamElementsVideoCompositionManager.cpp
@@ -168,11 +168,6 @@ void StreamElementsVideoCompositionManager::DeserializeComposition(
 			    videoFrame->GetType("height") != VTYPE_INT)
 				return;
 
-			blog(LOG_INFO, "[obs-streamelements-core]: ----- StreamElementsVideoCompositionManager::DeserializeComposition(): streamingVideoEncoders: %s",
-			     CefWriteJSON(streamingVideoEncoders,
-					  JSON_WRITER_PRETTY_PRINT)
-				     .c_str());
-
 			composition =
 				StreamElementsCustomVideoComposition::Create(
 					id, name, videoFrame->GetInt("width"),

--- a/streamelements/StreamElementsVideoCompositionManager.cpp
+++ b/streamelements/StreamElementsVideoCompositionManager.cpp
@@ -168,6 +168,11 @@ void StreamElementsVideoCompositionManager::DeserializeComposition(
 			    videoFrame->GetType("height") != VTYPE_INT)
 				return;
 
+			blog(LOG_INFO, "[obs-streamelements-core]: ----- StreamElementsVideoCompositionManager::DeserializeComposition(): streamingVideoEncoders: %s",
+			     CefWriteJSON(streamingVideoEncoders,
+					  JSON_WRITER_PRETTY_PRINT)
+				     .c_str());
+
 			composition =
 				StreamElementsCustomVideoComposition::Create(
 					id, name, videoFrame->GetInt("width"),


### PR DESCRIPTION
Create video composition & output video encoders on-demand instead of creating them the moment a video composition is created

This may have positive impact on GPU resource usage