### PR TITLE
Fix five testable crash bugs; add standalone regression suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/
 /debug32/
 /debug64/
 /builds/
+tests/build/
 *.o.d
 *.ninja
 .ninja*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,3 +655,10 @@ if (ENABLE_ANGELSCRIPT)
 		set_target_properties_obs(obs-streamelements-core-streamelements-restore-script-host PROPERTIES FOLDER "plugins/streamelements" PREFIX "")
 	endif()
 endif()
+
+# Standalone regression tests. Off by default; they do not link libobs/Qt
+# and can be built without an obs-studio tree. See tests/CMakeLists.txt.
+option(SE_ENABLE_TESTS "Build standalone regression tests" OFF)
+if(SE_ENABLE_TESTS)
+	add_subdirectory(tests)
+endif()

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -85,6 +85,11 @@ bool StreamElementsApiMessageHandler::OnProcessMessageReceived(
 					args->GetString(i),
 					JSON_PARSER_ALLOW_TRAILING_COMMAS);
 
+				if (!parsedValue) {
+					parsedValue = CefValue::Create();
+					parsedValue->SetNull();
+				}
+
 				callArgs->SetValue(callArgs->GetSize(),
 						   parsedValue);
 			}
@@ -566,7 +571,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 			context->args = args;
 			context->result = result;
 			context->target = target;
-			context->cefClientId = context->cefClientId;
+			context->cefClientId = cefClientId;
 			context->complete_callback = complete_callback;
 
 			context->queueIndex->SetInt(0);
@@ -2385,18 +2390,6 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		StreamElementsGlobalStateManager::GetInstance()
 			->GetProfilesManager()
 			->SerializeCurrentProfile(result);
-	}
-	API_HANDLER_END();
-
-	API_HANDLER_BEGIN("setCurrentProfile");
-	{
-		if (args->GetSize()) {
-			result->SetBool(
-				StreamElementsGlobalStateManager::GetInstance()
-					->GetProfilesManager()
-					->DeserializeCurrentProfileById(
-						args->GetValue(0)));
-		}
 	}
 	API_HANDLER_END();
 

--- a/streamelements/StreamElementsAudioComposition.cpp
+++ b/streamelements/StreamElementsAudioComposition.cpp
@@ -322,7 +322,7 @@ public:
 protected:
 	virtual obs_encoder_t *GetStreamingAudioEncoder(size_t index)
 	{
-		if (index > MAX_AUDIO_MIXES)
+		if (index >= MAX_AUDIO_MIXES)
 			return nullptr;
 
 		return m_streamingAudioEncoders[index];
@@ -330,7 +330,7 @@ protected:
 
 	virtual obs_encoder_t *GetRecordingAudioEncoder(size_t index)
 	{
-		if (index > MAX_AUDIO_MIXES)
+		if (index >= MAX_AUDIO_MIXES)
 			return nullptr;
 
 		return m_recordingAudioEncoders[index];

--- a/streamelements/StreamElementsOutput.hpp
+++ b/streamelements/StreamElementsOutput.hpp
@@ -342,7 +342,7 @@ public:
 			    m_obsEncoderInfo->GetType() == VTYPE_DICTIONARY)
 				return false;
 
-			return m_index = index;
+			return m_index == index;
 		}
 
 		CefRefPtr<CefValue> Serialize() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Regression tests for crash-bug fixes.
+#
+# These tests are NOT part of the OBS plugin build. They are standalone
+# C++17 executables that do not link libobs or Qt. Two kinds of tests live
+# here:
+#
+#   1. Behavioural tests that reproduce a minimal mirror of the buggy code
+#      and assert it behaves correctly. (e.g. test_video_encoder_template_demo)
+#
+#   2. Source-invariant tests that open the real production source files
+#      and assert specific buggy patterns are absent. These act as a
+#      regression gate without requiring the OBS build to succeed.
+#
+# Build:
+#   cmake -S tests -B tests/build -DENABLE_TESTS=ON
+#   cmake --build tests/build
+#   ctest --test-dir tests/build --output-on-failure
+#
+# Or from the project root with ENABLE_TESTS=ON.
+
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT CMAKE_PROJECT_NAME)
+  project(obs-streamelements-core-tests CXX)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+set(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+# Configure the source-root path into the source-invariant test so it can
+# read production files at runtime regardless of where it is built from.
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/source_paths.hpp.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/source_paths.hpp"
+  @ONLY
+)
+
+set(GENERATED_INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+function(se_add_test name)
+  add_executable(${name} ${ARGN})
+  target_include_directories(${name} PRIVATE
+    "${GENERATED_INCLUDE}"
+    "${REPO_ROOT}"
+    "${REPO_ROOT}/deps"
+  )
+  target_compile_features(${name} PRIVATE cxx_std_17)
+  if(NOT MSVC)
+    target_compile_options(${name} PRIVATE -Wall -Wextra)
+  endif()
+  add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+# --- Behavioural test: C2 (VideoEncoderTemplate::IsMatchingIndex = vs ==) ---
+se_add_test(test_video_encoder_template_demo
+  test_video_encoder_template_demo.cpp)
+
+# --- Source-invariant test: catches re-introduction of any of the
+#     bug patterns this PR fixes. ---
+se_add_test(test_source_invariants
+  test_source_invariants.cpp)

--- a/tests/source_paths.hpp.in
+++ b/tests/source_paths.hpp.in
@@ -1,0 +1,8 @@
+#pragma once
+
+// Generated from source_paths.hpp.in — do not edit by hand.
+// Points the source-invariant tests at the production source tree.
+
+namespace se_tests {
+constexpr const char *kRepoRoot = "@REPO_ROOT@";
+}

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -1,0 +1,157 @@
+// Source-invariant regression gate.
+//
+// Reads production source files and asserts that specific buggy
+// patterns identified in the crash-bug review are absent. These checks
+// run in milliseconds and require no OBS / Qt / CEF dependencies.
+//
+// Each invariant references the bug it guards against; if a future edit
+// re-introduces the pattern, the test fails with a clear message.
+
+#include "source_paths.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+static int failures = 0;
+
+static std::string slurp(const std::string &relpath)
+{
+	std::string full = std::string(se_tests::kRepoRoot) + "/" + relpath;
+	std::ifstream in(full);
+	if (!in) {
+		std::fprintf(stderr, "FATAL: cannot open %s\n", full.c_str());
+		std::exit(2);
+	}
+	std::stringstream ss;
+	ss << in.rdbuf();
+	return ss.str();
+}
+
+static std::size_t count_matches(const std::string &haystack,
+				 const std::regex &re)
+{
+	auto begin = std::sregex_iterator(haystack.begin(), haystack.end(), re);
+	auto end = std::sregex_iterator();
+	return static_cast<std::size_t>(std::distance(begin, end));
+}
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+// --- C2: IsMatchingIndex must compare with ==, not assign with =.
+//
+// The original line was:  return m_index = index;
+// which assigns and returns truthy/falsy of the assigned value rather
+// than comparing. The fix is:  return m_index == index;
+static void check_c2_video_encoder_template_match()
+{
+	auto src = slurp("streamelements/StreamElementsOutput.hpp");
+
+	// The buggy assignment form must be gone. Match `m_index` followed
+	// by `=` with no neighbouring `=` (i.e. real assignment, not `==`).
+	std::regex bad(R"(return\s+m_index\s*=\s*[^=])");
+	check(count_matches(src, bad) == 0,
+	      "C2: StreamElementsOutput.hpp must not assign to m_index in IsMatchingIndex "
+	      "(should be `return m_index == index;`)");
+
+	// And the correct comparison form must be present.
+	std::regex good(R"(return\s+m_index\s*==\s*index\s*;)");
+	check(count_matches(src, good) >= 1,
+	      "C2: StreamElementsOutput.hpp must contain `return m_index == index;`");
+}
+
+// --- C4: self-assignment of cefClientId in batchInvokeSeries leaves
+// the field holding uninitialised heap memory which is then routed back
+// to CEF clients as a callback id.
+static void check_c4_no_self_assign_cefclientid()
+{
+	auto src = slurp("streamelements/StreamElementsApiMessageHandler.cpp");
+
+	std::regex bad(R"(context\s*->\s*cefClientId\s*=\s*context\s*->\s*cefClientId)");
+	check(count_matches(src, bad) == 0,
+	      "C4: StreamElementsApiMessageHandler.cpp must not contain "
+	      "`context->cefClientId = context->cefClientId` (self-assign)");
+}
+
+// --- C5: CefParseJSON returns null on malformed input. The result must
+// not be passed straight into CefListValue::SetValue without a null
+// check, because that dereferences a null CefRefPtr.
+static void check_c5_cefparsejson_null_guarded()
+{
+	auto src = slurp("streamelements/StreamElementsApiMessageHandler.cpp");
+
+	// The fix guards parsedValue against null before SetValue.
+	// We assert one of two acceptable patterns:
+	//   (a) an `if (!parsedValue ...) ...` near a CefParseJSON call, or
+	//   (b) the parsed value is replaced with a default null CefValue.
+	std::regex parseCall(R"(CefParseJSON\s*\()");
+	check(count_matches(src, parseCall) >= 1,
+	      "C5: expected at least one CefParseJSON call site to validate");
+
+	// Acceptable guard: a null check on parsedValue between the
+	// CefParseJSON call and the SetValue call.
+	std::regex guarded(
+		R"(CefParseJSON[\s\S]{0,400}?if\s*\(\s*!\s*parsedValue\b)");
+	check(count_matches(src, guarded) >= 1,
+	      "C5: CefParseJSON result must be null-checked before being passed to SetValue");
+}
+
+// --- C6: audio encoder bounds check must use `>=`, not `>`. The array
+// has MAX_AUDIO_MIXES slots, valid indices are [0, MAX_AUDIO_MIXES).
+static void check_c6_audio_encoder_bounds()
+{
+	auto src = slurp("streamelements/StreamElementsAudioComposition.cpp");
+
+	std::regex bad(R"(if\s*\(\s*index\s*>\s*MAX_AUDIO_MIXES\s*\))");
+	check(count_matches(src, bad) == 0,
+	      "C6: audio encoder bound check must use `>=`, not `>` "
+	      "(`if (index > MAX_AUDIO_MIXES)` allows one-past-end access)");
+
+	std::regex good(R"(if\s*\(\s*index\s*>=\s*MAX_AUDIO_MIXES\s*\))");
+	check(count_matches(src, good) >= 2,
+	      "C6: expected `if (index >= MAX_AUDIO_MIXES)` in both streaming "
+	      "and recording audio encoder accessors");
+}
+
+// --- C10: the `setCurrentProfile` API handler was registered twice, so
+// the first registration was silently overwritten. Assert it now
+// appears exactly once.
+static void check_c10_no_duplicate_handler_setcurrentprofile()
+{
+	auto src = slurp("streamelements/StreamElementsApiMessageHandler.cpp");
+
+	std::regex reg(R"(API_HANDLER_BEGIN\(\"setCurrentProfile\"\))");
+	std::size_t count = count_matches(src, reg);
+	if (count != 1) {
+		std::fprintf(stderr,
+			     "FAIL: C10: setCurrentProfile is registered %zu time(s); expected exactly 1\n",
+			     count);
+		++failures;
+	}
+}
+
+int main()
+{
+	check_c2_video_encoder_template_match();
+	check_c4_no_self_assign_cefclientid();
+	check_c5_cefparsejson_null_guarded();
+	check_c6_audio_encoder_bounds();
+	check_c10_no_duplicate_handler_setcurrentprofile();
+
+	if (failures) {
+		std::fprintf(stderr, "%d source invariant(s) violated\n",
+			     failures);
+		return 1;
+	}
+	std::puts("test_source_invariants: all invariants hold");
+	return 0;
+}

--- a/tests/test_video_encoder_template_demo.cpp
+++ b/tests/test_video_encoder_template_demo.cpp
@@ -1,0 +1,103 @@
+// Behavioural demonstration of the IsMatchingIndex bug in
+// streamelements/StreamElementsOutput.hpp.
+//
+// The production VideoEncoderTemplate class is nested inside
+// StreamElementsOutputBase and pulls in libobs/Qt transitively. To
+// exercise the matching-index logic without that build burden we mirror
+// the relevant slice of the class here and verify it behaves correctly.
+//
+// The source-invariant test in test_source_invariants.cpp asserts that
+// the real production file uses the same correct pattern.
+
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+
+namespace mirror {
+
+// Minimal mirror of the production logic. The real class also handles a
+// CefValue dictionary case (returning false when m_obsEncoderInfo is a
+// dict); we keep that branch but represent it with a plain bool here
+// since CefValue is not relevant to the index-matching logic.
+class VideoEncoderTemplate {
+public:
+	std::size_t m_index;
+	bool m_obsEncoderInfoIsDict;
+
+	VideoEncoderTemplate(std::size_t index)
+		: m_index(index), m_obsEncoderInfoIsDict(false)
+	{
+	}
+
+	// Faithfully reproduces the structure of the production method.
+	bool IsMatchingIndex(std::size_t index)
+	{
+		if (m_obsEncoderInfoIsDict)
+			return false;
+
+		return m_index == index;
+	}
+};
+
+} // namespace mirror
+
+static int failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+int main()
+{
+	// 1. A template for index 5 matches index 5, not index 3.
+	{
+		mirror::VideoEncoderTemplate t(5);
+		check(t.IsMatchingIndex(5) == true,
+		      "template(5) should match query 5");
+		check(t.IsMatchingIndex(3) == false,
+		      "template(5) should not match query 3");
+	}
+
+	// 2. Calling IsMatchingIndex must not mutate m_index. This is the
+	//    behaviour the original `return m_index = index;` violated:
+	//    every call rewrote m_index, silently corrupting the slot id.
+	{
+		mirror::VideoEncoderTemplate t(7);
+		(void)t.IsMatchingIndex(2);
+		check(t.m_index == 7,
+		      "IsMatchingIndex must not modify m_index");
+		(void)t.IsMatchingIndex(0);
+		check(t.m_index == 7,
+		      "IsMatchingIndex(0) must not modify m_index");
+	}
+
+	// 3. Index 0 must be matchable. With the buggy `=` form, querying
+	//    index 0 always returned false (assignment to 0 is falsy),
+	//    so a template for slot 0 could never be matched.
+	{
+		mirror::VideoEncoderTemplate t(0);
+		check(t.IsMatchingIndex(0) == true,
+		      "template(0) should match query 0 (regression check)");
+	}
+
+	// 4. The dictionary-encoder branch always returns false regardless
+	//    of index, and must also not mutate state.
+	{
+		mirror::VideoEncoderTemplate t(4);
+		t.m_obsEncoderInfoIsDict = true;
+		check(t.IsMatchingIndex(4) == false,
+		      "dict-encoder template must not match by index");
+		check(t.m_index == 4, "dict-encoder branch must not mutate m_index");
+	}
+
+	if (failures) {
+		std::fprintf(stderr, "%d assertion(s) failed\n", failures);
+		return 1;
+	}
+	std::puts("test_video_encoder_template_demo: all assertions passed");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Five concrete crash bugs from the recent crash-bug review, fixed and gated by a new standalone test suite. The tests build and run without libobs, Qt, or an obs-studio tree — they're pure C++17, finish in under a second, and are opt-in via `-DSE_ENABLE_TESTS=ON` so production builds are untouched.

I verified the bugs by running the suite against the unfixed code (all five invariants fail) and then against the fixed code (all green). Build/run:

```
cmake -S tests -B tests/build -DSE_ENABLE_TESTS=ON
cmake --build tests/build
ctest --test-dir tests/build --output-on-failure
```

## Bugs fixed

| ID  | File:line | Bug |
| --- | --- | --- |
| C2  | `StreamElementsOutput.hpp:345` | `IsMatchingIndex` used `return m_index = index;` (assignment) instead of `==`. Silently rewrote `m_index` on every call and routed encoders to the wrong output slots in multi-encoder outputs. |
| C4  | `StreamElementsApiMessageHandler.cpp:569` | `context->cefClientId = context->cefClientId;` — self-assignment left the field uninitialised; that garbage flowed into every batched child handler's CEF callback id. |
| C5  | `StreamElementsApiMessageHandler.cpp:86-91` | `CefParseJSON` return value passed straight into `CefListValue::SetValue` with no null guard. Trivially crash-triggerable by any client sending malformed JSON. |
| C6  | `StreamElementsAudioComposition.cpp:325, 333` | Audio encoder accessor guarded with `if (index > MAX_AUDIO_MIXES)` instead of `>=`. Index `MAX_AUDIO_MIXES` passed the check and read one past the end of the encoder array. |
| C10 | `StreamElementsApiMessageHandler.cpp:2403-2413` | `setCurrentProfile` API handler was registered twice; the second registration silently overwrote the first via the `m_apiCallHandlers[id] = handler;` assignment. |

## Test design

Two complementary executables under `tests/`:

1. **`test_video_encoder_template_demo`** — behavioural demonstration of C2 using a minimal mirror of the production logic. Documents what correct `IsMatchingIndex` behaviour looks like (no mutation of `m_index`, index 0 matchable, dictionary branch returns false without mutation). Useful as a permanent reference for the failure mode.
2. **`test_source_invariants`** — opens the real production source files and asserts each buggy pattern is absent. Functions as the regression gate. Catches reintroduction of any of the five patterns above without needing the full plugin to build.

No vendored test framework; tests use `<cassert>` and an `int main()` returning 0/non-zero. ctest reads the exit code.

## Verification

Tested on macOS with AppleClang 21. Test suite fails as expected against the unfixed source:

```
FAIL: C2: StreamElementsOutput.hpp must not assign to m_index in IsMatchingIndex
FAIL: C4: StreamElementsApiMessageHandler.cpp must not contain `context->cefClientId = context->cefClientId`
FAIL: C5: CefParseJSON result must be null-checked before being passed to SetValue
FAIL: C6: audio encoder bound check must use `>=`, not `>`
FAIL: C10: setCurrentProfile is registered 2 time(s); expected exactly 1
```

After the fixes in this PR, all invariants pass.

## Test plan

- [ ] CI / reviewer can build with `-DSE_ENABLE_TESTS=ON` and confirm `ctest` is 2/2 green
- [ ] Confirm the production-build target is unaffected (the new `option()` defaults to `OFF`)
- [ ] Sanity-check that the duplicate `setCurrentProfile` deletion is correct (the two bodies were byte-for-byte identical; only one registration is now wired)
- [ ] Confirm the CEF null-guard substitutes a sane "null" `CefValue` (which is what every downstream handler already has to tolerate) rather than skipping the argument

## Not in this PR

The remaining higher-effort findings from the crash-bug review (signal-handler UAF on output stop, canvas-destroyed-before-scenes use-after-free, shared_lock-while-mutating in the output manager, etc.) need real-OBS reproductions and ASan/TSan to verify, so they're left for follow-ups.