### PR TITLE
fix(ci): force foreground subagents in Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,17 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        # Force Task subagents to run in the foreground. Claude Code >= 2.1.198 launches
+        # them in the background by default; on runs where the model takes that default
+        # and ends its turn to wait for the completion notification, the CLI emits an
+        # interim result event and claude-code-action stops reading the stream right
+        # there (an explicit break in base-action/src/run-claude-sdk.ts), reporting
+        # success with the work unposted. Runs where the model happens to run its
+        # subagents synchronously survive, which is why the failure looks intermittent.
+        # Upstream: anthropics/claude-code-action#1499. Root-cause analysis and
+        # before/after evidence: StreamElements/pricing_clusters_prod#149.
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        # Force Task subagents to run in the foreground. Same fix as in
+        # claude-code-review.yml, which documents the mechanism: the action stops
+        # reading Claude's stream at the first result event, and a backgrounded
+        # subagent produces an interim result while the model waits, so a task
+        # whose model backgrounds a subagent dies half-done while reporting
+        # success. Upstream: anthropics/claude-code-action#1499.
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Org-wide rollout of the fix proven in StreamElements/pricing_clusters_prod#149 and StreamElements/dbt-bi-bigquery#508: step-level `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'` on each `claude-code-action` step.

Claude Code >= 2.1.198 launches Task subagents in the background by default. On runs where the model takes that default and ends its turn to wait, the CLI emits an interim result event and claude-code-action stops reading the stream there (an explicit break in `base-action/src/run-claude-sdk.ts`), reporting success with the work unposted. Runs where the model happens to run its subagents synchronously survive, so the failure presents as intermittent review silence rather than an outage. Upstream: anthropics/claude-code-action#1499 (workaround comment there is ours).

Context for maintainers: this repo surfaced in an org-wide sweep for `claude-code-action` usage after we root-caused silently failing Claude runs in the data-science repos. The change is self-contained; happy to adjust or close if you would rather handle it differently.

Note: while this PR is open, its own Claude review run will log `Exiting due to workflow validation skip` and exit green; the GitHub App validates the branch copy of a workflow file against the default branch copy. Expected, resolves at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)