### PR TITLE
fix(ci): deploy-signed-windows downloads exes from the wrong bucket path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,7 @@ jobs:
 
           for manifest in obs-streamelements.manifest obs-streamelements.qa.manifest obs-streamelements.beta.manifest obs-streamelements.latest.manifest obs-streamelements.stable.manifest
           do
-            curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/windows/$manifest --output $manifest
+            curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/windows/$manifest --output $manifest
 
             sed -i "s/\${PACKAGE_FILENAME}/$signedPackageFilename/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_64_BIT}/$signedPackageFilename64/" $manifest
@@ -392,9 +392,9 @@ jobs:
 
           cp obs-streamelements.manifest obs-streamelements-${{ needs.version.outputs.version_encoded }}.manifest
 
-          curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/obs-streamelements-setup.exe --output obs-streamelements-setup.exe
-          curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/obs-streamelements-setup-x64.exe --output obs-streamelements-setup-x64.exe
-          # curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/obs-streamelements-setup-x86.exe --output obs-streamelements-setup-x86.exe
+          curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/windows/obs-streamelements-setup.exe --output obs-streamelements-setup.exe
+          curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/windows/obs-streamelements-setup-x64.exe --output obs-streamelements-setup-x64.exe
+          # curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/windows/obs-streamelements-setup-x86.exe --output obs-streamelements-setup-x86.exe
 
           cp obs-streamelements-setup-x64.exe ${signedPackageFilename64}.exe
           cp obs-streamelements-setup-x64.exe ${signedPackageFilename32}.exe # This is not a mistake, we no longer support 32bit builds
@@ -446,7 +446,7 @@ jobs:
 
           for manifest in obs-streamelements.manifest obs-streamelements.qa.manifest obs-streamelements.beta.manifest obs-streamelements.latest.manifest obs-streamelements.stable.manifest
           do
-            curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/$manifest --output $manifest
+            curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/$manifest --output $manifest
 
             sed -i "s/\${PACKAGE_FILENAME}/$signedPackageFilename/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_64_BIT}/$signedPackageFilename/" $manifest
@@ -457,7 +457,7 @@ jobs:
 
           cp obs-streamelements.manifest obs-streamelements-${{ needs.version.outputs.version_encoded }}.manifest
 
-          curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/obs-streamelements-core.pkg --output ${signedPackageFilename}.pkg
+          curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-installer/latest/macos/obs-streamelements-core.pkg --output ${signedPackageFilename}.pkg
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
deploy-signed-windows curls its setup exes from `obs-streamelements-installer/latest/macos/` — a path nothing writes exes to. GCS returns 404 and curl without `-f` saves the XML error body, so the job uploads ~200-byte files as the signed Windows installers.

This shipped live: build 20260724000668's signed-channel exes on the CDN were 196/201-byte `NoSuchKey` XML documents (deployed 09:27 UTC today). I've already repaired the two objects by copying the real signed exes from `latest/windows/`.

Changes:
- Point the three exe downloads at `latest/windows/` where the installer job actually uploads them.
- Add `-f` to every curl in both deploy jobs (manifests + pkg included) so a missing object fails the run instead of shipping garbage.

Found during a pipeline review with Jacob's assistant.