### PR TITLE
feat(ci): track SE.Live releases in Linear (CORE-266)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -494,3 +494,27 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           tag: "${{ needs.version.outputs.version_string }}"
+
+  linear-release:
+    # Mirrors every shipped master build into Linear (CORE-266): scans the
+    # commits since the last release for CORE-xxx references and attaches
+    # those issues to a Linear release named after the build version.
+    # Uses a "scheduled" pipeline on the Linear side — stages map to the
+    # qa/beta/stable channels once channel promotion moves into CI.
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+    needs: [version, tag-master-commit]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # linear-release scans commit history
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ needs.version.outputs.version_string }}
+          release_notes: RELEASE_NOTES.md


### PR DESCRIPTION
Implements CORE-266: every shipped master build now shows up as a release in Linear with its issues attached.

How it works:
- New `linear-release` job runs after `tag-master-commit` on master builds only.
- `linear/linear-release-action@v0` scans commit history for CORE-xxx references and creates/updates a Linear release named after the build version (e.g. `26.7.24.668`), using `RELEASE_NOTES.md` as the release notes.
- Full checkout (`fetch-depth: 0`) because the CLI diffs commits since the previous release.

Before merge, one manual step: create a **scheduled** pipeline in Linear (Workspace settings → Releases → Pipelines — scheduled stages line up with our qa → beta → stable channels) and store its access key as the `LINEAR_ACCESS_KEY` repo secret. Until the secret exists the job fails; nothing else in the pipeline depends on it.

Stage promotion (`command: update` with `stage: qa/beta/stable`) is deliberately left out for now — the current deploy writes all channel manifests in one shot, so there's no real promotion step in CI yet to hang stages on. When channel promotion lands, add one `update` call per stage.

Linear: CORE-266