### PR TITLE
fix(ci): PR runs sign builds and deploy to production CDN

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -46,7 +46,7 @@ on:
 
 env:
   SIGN_WINDOWS_BINARIES: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && (inputs.SKIP_WINDOWS_SIGNING != 'true' && inputs.SKIP_WINDOWS_SIGNING != '1' && inputs.SKIP_WINDOWS_SIGNING != 'yes') }}
-  SIGN_MACOS_BINARIES: ${{ inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes' }}
+  SIGN_MACOS_BINARIES: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes' }}
   UPLOAD_BINARIES: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
 
 jobs:
@@ -380,7 +380,7 @@ jobs:
           if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Prepare for code signing and notarization
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES == 'true' }}
         run: |
           # Create temporary keychain
 
@@ -508,7 +508,7 @@ jobs:
           echo 'RequiredBundlesDescription = "Could not find OBS installed, Please download and install OBS from https://obsproject.com and run SE.Live setup again"' >/tmp/obs-streamelements-core.plugin/Contents/Resources/en.lproj/InfoPlist.strings
 
       - name: Sign plugin code
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES == 'true' }}
         run: |
           cd ${{ env.ROOT }}
 
@@ -559,7 +559,7 @@ jobs:
           if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Sign product installer
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES == 'true' }}
         run: |
           cd ${{ env.ROOT }}
 
@@ -568,7 +568,7 @@ jobs:
           if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Mock product installer signature
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION == 'true' || inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION == '1' || inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION == 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES != 'true' }}
         run: |
           cd ${{ env.ROOT }}
 
@@ -578,7 +578,7 @@ jobs:
 
 
       - name: Notarize product installer
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES == 'true' }}
         run: |
           cd ${{ env.ROOT }}
 
@@ -587,7 +587,7 @@ jobs:
           if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Staple product installer
-        if: inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && inputs.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes'
+        if: ${{ env.SIGN_MACOS_BINARIES == 'true' }}
         run: |
           cd ${{ env.ROOT }}
 
@@ -606,11 +606,12 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: setup-windows
+          name: macos-setup
+          if-no-files-found: error
           path: |
-            '${{ env.ROOT }}/obs-streamelements-core.pkg'
-            '${{ env.ROOT }}/obs-streamelements.manifest'
-            '${{ env.ROOT }}/obs-streamelements.*.manifest'
+            ${{ env.ROOT }}/obs-streamelements-core.pkg
+            ${{ env.ROOT }}/obs-streamelements.manifest
+            ${{ env.ROOT }}/obs-streamelements.*.manifest
 
       - name: Upload to Google Storage
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'

--- a/.github/workflows/build-obs-streamelements-uninstaller.yml
+++ b/.github/workflows/build-obs-streamelements-uninstaller.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Sign Windows binaries
         uses: azure/artifact-signing-action@v2
-        if: ${{ env.SIGN_BINARIES }}
+        if: ${{ env.SIGN_BINARIES == 'true' }}
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -126,12 +126,12 @@ jobs:
 
 # Automatically finds signtool.exe and exposes its path
       - name: Find SignTool
-        if: ${{ env.SIGN_BINARIES }}
+        if: ${{ env.SIGN_BINARIES == 'true' }}
         uses: KamaranL/add-signtool-action@v1
         id: signtool
 
       - name: Verify Windows binaries code signature
-        if: ${{ env.SIGN_BINARIES }}
+        if: ${{ env.SIGN_BINARIES == 'true' }}
         shell: cmd
         run: |
           signtool verify /pa /v "${{ env.ROOT }}\\obs-streamelements-uninstaller.exe"
@@ -140,10 +140,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: uninstaller
-          path: obs-streamelements-uninstaller.exe
+          path: ${{ env.ROOT }}/obs-streamelements-uninstaller.exe
+          if-no-files-found: error
 
       - name: Upload to Google Artifact Storage
-        if: ${{ env.UPLOAD_BINARIES }}
+        if: ${{ env.UPLOAD_BINARIES == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false
@@ -152,7 +153,7 @@ jobs:
           destination: 'se-obs-builds/obs-streamelements-uninstaller/latest/windows'
 
       - name: Upload to CDN Signed Artifact Storage
-        if: ${{ env.UPLOAD_BINARIES }}
+        if: ${{ env.UPLOAD_BINARIES == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false
@@ -161,7 +162,7 @@ jobs:
           destination: 'cdn.streamelements.com/obs/dist/obs-streamelements-uninstaller/windows/signed'
 
       - name: Upload to CDN QA Artifact Storage
-        if: ${{ env.UPLOAD_BINARIES }}
+        if: ${{ env.UPLOAD_BINARIES == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false
@@ -170,7 +171,7 @@ jobs:
           destination: 'cdn.streamelements.com/obs/dist/obs-streamelements-uninstaller/windows/qa'
 
       - name: Upload to CDN Latest Artifact Storage
-        if: ${{ env.UPLOAD_BINARIES }}
+        if: ${{ env.UPLOAD_BINARIES == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
           msbuild obs-studio.sln -p:Configuration=RelWithDebInfo
 
       - name: Upload BugSplat Symbols
-        if: ${{ env.UPLOAD_SYMBOLS }}
+        if: ${{ env.UPLOAD_SYMBOLS == 'true' }}
         shell: cmd
         run: |
           c:\local\bugsplat\symbol-upload-windows.exe ^
@@ -284,14 +284,14 @@ jobs:
           xcrun dsymutil obs-streamelements-core.plugin/Contents/MacOS/obs-streamelements-core -o obs-streamelements-core.dSYM
 
       - name: Upload ARM64 to BugSplat
-        if: ${{ env.UPLOAD_SYMBOLS }}
+        if: ${{ env.UPLOAD_SYMBOLS == 'true' }}
         run: |
           cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo
 
           /tmp/symbol-upload-macos -v -a "obs-streamelements-core-macos" -b "OBS_Live" -i "${{ secrets.BUGSPLAT_CLIENTID }}" -s "${{ secrets.BUGSPLAT_CLIENTSECRET }}" -f "obs-streamelements-core.dSYM" -d . -v "${{ needs.version.outputs.version_encoded }}"
 
       - name: Upload x86_64 to BugSplat
-        if: ${{ env.UPLOAD_SYMBOLS }}
+        if: ${{ env.UPLOAD_SYMBOLS == 'true' }}
         run: |
           cd ~/src/obs-studio/build_macos_x86_64/plugins/obs-streamelements-core/RelWithDebInfo
 


### PR DESCRIPTION
Follow-up from the pipeline review. Two gate bugs, both **verified on the live PR run** for #82 (run 30153261570):

**1. Bare `if: ${{ env.X }}` is always truthy.** GHA env values are strings and the string `'false'` passes a bare `if`. Confirmed consequences on that PR run:
- The uninstaller job **signed its build and uploaded it to the production CDN** (`obs-streamelements-uninstaller/windows/signed|qa|latest`) — so any PR replaces the production uninstaller before review.
- BugSplat symbol uploads ran on PR builds.

All bare conditions now compare `== 'true'` (the installer's Windows job already did this — now all three files agree).

**2. macOS signing was never branch-gated.** The installer's signing/notarization steps only checked the SKIP var, so every PR imported the Developer ID certs into a runner keychain and burned a real Apple notarization. `SIGN_MACOS_BINARIES` now requires master + non-PR and the steps use it; PR builds take the existing "mock signature" path.

**3. Silent empty artifacts.** The `uninstaller` artifact (wrong path) and the macOS installer artifact (quoted glob patterns, plus it was named `setup-windows`) uploaded nothing, with no failure. Fixed paths, renamed to `macos-setup`, and set `if-no-files-found: error` so this fails loudly next time.

Note for reviewers: the uninstaller currently on the CDN qa/signed/latest channels was built by a PR run (workflow-only changes, so content matches master), and the next master build will overwrite it with a proper master build.

Related: #81 (deploy path fix). Found with Jacob's assistant.