### PR TITLE
chore(ci): shallow OBS clones + remove dead legacy pieces

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -139,10 +139,6 @@ jobs:
 
             curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-core/latest/windows/Version.generated.hpp --output ${{ env.ROOT }}\..\download\obs-streamelements-core\Version.generated.hpp
 
-            curl https://storage.googleapis.com/se-obs-builds/obs-streamelements-core/latest/windows/RELEASE_NOTES.md --output ${{ env.ROOT }}\..\download\obs-streamelements-core\RELEASE_NOTES.md
-
-
-
 
             curl -kL -o ${{ env.ROOT }}\..\obs-streamelements-uninstaller\obs-streamelements-uninstaller.exe https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/qa/obs-streamelements-uninstaller.exe -f --retry 5 -C -
 

--- a/.github/workflows/build-obs-streamelements-uninstaller.yml
+++ b/.github/workflows/build-obs-streamelements-uninstaller.yml
@@ -25,11 +25,6 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - name: Debug
-        shell: cmd
-        run: |
-          echo "${{ github.event.repository.updated_at }}"
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,6 @@ jobs:
 
     env:
       CHECKOUT: 31.1.2
-      GS_ACCESS_KEY_ID: ${{ secrets.GS_ACCESS_KEY_ID }}
-      GS_KEY_BASE64: ${{ secrets.GS_KEY_BASE64 }}
-      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
     steps:
       - uses: actions/checkout@v4
@@ -95,9 +92,7 @@ jobs:
         shell: cmd
         run: |
           mkdir C:\local
-          git clone --recursive https://github.com/obsproject/obs-studio.git C:\local\obs-studio
-          cd /d C:\local\obs-studio
-          git checkout %CHECKOUT%
+          git clone --depth 1 --branch %CHECKOUT% --recursive --shallow-submodules https://github.com/obsproject/obs-studio.git C:\local\obs-studio
 
       - name: Install plugin into OBS tree
         shell: cmd
@@ -105,15 +100,6 @@ jobs:
           mkdir C:\local\obs-studio\plugins\obs-streamelements-core
           xcopy "%GITHUB_WORKSPACE%\*.*" "C:\local\obs-studio\plugins\obs-streamelements-core" /S /E /I /Y
           echo add_obs_plugin(obs-streamelements-core) > C:\local\obs-studio\plugins\CMakeLists.txt
-
-      - name: Setup GCS uploader
-        shell: powershell
-        run: |
-          cd C:\local\obs-studio\plugins\obs-streamelements-core\CI\gcs
-          [System.Text.Encoding]::UTF8.GetString(
-            [System.Convert]::FromBase64String($env:GS_KEY_BASE64)
-          ) | Out-File key.json
-          npm install
 
       - name: Download BugSplat uploader
         run: |
@@ -201,7 +187,6 @@ jobs:
 
     env:
       CHECKOUT: 31.1.2
-      GS_SECRET_ACCESS_KEY: ${{ secrets.GS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -215,9 +200,7 @@ jobs:
 
       - name: Clone OBS Studio
         run: |
-          git clone --recursive https://github.com/obsproject/obs-studio.git ~/src/obs-studio
-          cd ~/src/obs-studio
-          git checkout $CHECKOUT
+          git clone --depth 1 --branch "$CHECKOUT" --recursive --shallow-submodules https://github.com/obsproject/obs-studio.git ~/src/obs-studio
 
       - name: Install plugin
         run: |


### PR DESCRIPTION
Mechanical cleanup from the pipeline review — no behavior change to what ships.

- **Shallow OBS clones**: `--depth 1 --branch $CHECKOUT --recursive --shallow-submodules` on both platforms instead of full-history clone + checkout. Should save several minutes per job.
- **Legacy HMAC uploader removed**: the `Setup GCS uploader` step wrote a static GCS key (`GS_KEY_BASE64`) to `key.json` and npm-installed `CI/gcs` — nothing invokes it anymore; all uploads use WIF-authenticated `google-github-actions`. The `GS_*` secrets can be deleted from the repo after this merges; the `CI/gcs` directory can go with the AppVeyor cleanup (CORE-272).
- **No-op `GITHUB_WORKSPACE` env override removed** (the runner ignores `GITHUB_*` overrides).
- **Dead `RELEASE_NOTES.md` download removed** from the installer — the GCS object doesn't exist, so every build saved a 404 XML body to disk; the release_notes job reads the repo checkout.
- **Uninstaller `Debug` step removed.**

Related: #81, #83. Found with Jacob's assistant.