### PR TITLE
refactor(ci): shared composite action for NSIS plugin install

### DIFF
--- a/.github/actions/install-nsis-plugins/action.yml
+++ b/.github/actions/install-nsis-plugins/action.yml
@@ -1,0 +1,41 @@
+name: Install NSIS plugins
+description: >
+  Download the StreamElements NSIS plugins (NSISLockDetector, NSISHTTP,
+  NSISConfig) from the CDN and install them into the system NSIS Plugins
+  directory. Shared by the installer and uninstaller builds so the plugin
+  list only lives in one place. curl runs with -f so a missing CDN object
+  fails the build instead of a 404 body getting signed into the installer.
+
+inputs:
+  working-directory:
+    description: Directory in which to stage the nsis/ tree before copying it into NSIS
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install NSIS plugins
+      shell: cmd
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if not exist nsis\Plugins\x64-ansi mkdir nsis\Plugins\x64-ansi
+        if not exist nsis\Plugins\x64-unicode mkdir nsis\Plugins\x64-unicode
+        if not exist nsis\Plugins\x86-ansi mkdir nsis\Plugins\x86-ansi
+        if not exist nsis\Plugins\x86-unicode mkdir nsis\Plugins\x86-unicode
+
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-ansi/NSISLockDetector.dll --output nsis\Plugins\x64-ansi\NSISLockDetector.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-unicode/NSISLockDetector.dll --output nsis\Plugins\x64-unicode\NSISLockDetector.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-ansi/NSISLockDetector.dll --output nsis\Plugins\x86-ansi\NSISLockDetector.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-unicode/NSISLockDetector.dll --output nsis\Plugins\x86-unicode\NSISLockDetector.dll || exit /b 1
+
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-ansi/NSISHTTP.dll --output nsis\Plugins\x64-ansi\NSISHTTP.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-unicode/NSISHTTP.dll --output nsis\Plugins\x64-unicode\NSISHTTP.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-ansi/NSISHTTP.dll --output nsis\Plugins\x86-ansi\NSISHTTP.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-unicode/NSISHTTP.dll --output nsis\Plugins\x86-unicode\NSISHTTP.dll || exit /b 1
+
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-ansi/NSISConfig.dll --output nsis\Plugins\x64-ansi\NSISConfig.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-unicode/NSISConfig.dll --output nsis\Plugins\x64-unicode\NSISConfig.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-ansi/NSISConfig.dll --output nsis\Plugins\x86-ansi\NSISConfig.dll || exit /b 1
+        curl -f -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-unicode/NSISConfig.dll --output nsis\Plugins\x86-unicode\NSISConfig.dll || exit /b 1
+
+        xcopy nsis "%ProgramFiles(x86)%\NSIS" /S /E /I /Y

--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -180,49 +180,9 @@ jobs:
           curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/obs-probe-libobs-version/windows/qa/obs-probe-libobs-version-64.exe --output resources\obs-probe-libobs-version-64.exe
 
       - name: Install NSIS plugins
-        shell: cmd
-        run: |
-          cd /d "${{ env.ROOT }}"
-
-          if not exist nsis mkdir nsis
-          if not exist nsis\Plugins mkdir nsis\Plugins
-
-          if not exist nsis\Plugins\x64-ansi mkdir nsis\Plugins\x64-ansi
-          if not exist nsis\Plugins\x64-unicode mkdir nsis\Plugins\x64-unicode
-          if not exist nsis\Plugins\x86-ansi mkdir nsis\Plugins\x86-ansi
-          if not exist nsis\Plugins\x86-unicode mkdir nsis\Plugins\x86-unicode
-
-          if exist nsis\Plugins\x64-ansi\NSISLockDetector.dll del nsis\Plugins\x64-ansi\NSISLockDetector.dll
-          if exist nsis\Plugins\x64-unicode\NSISLockDetector.dll del nsis\Plugins\x64-unicode\NSISLockDetector.dll
-          if exist nsis\Plugins\x86-ansi\NSISLockDetector.dll del nsis\Plugins\x86-ansi\NSISLockDetector.dll
-          if exist nsis\Plugins\x86-unicode\NSISLockDetector.dll del nsis\Plugins\x86-unicode\NSISLockDetector.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-ansi/NSISLockDetector.dll --output nsis\Plugins\x64-ansi\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-unicode/NSISLockDetector.dll --output nsis\Plugins\x64-unicode\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-ansi/NSISLockDetector.dll --output nsis\Plugins\x86-ansi\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-unicode/NSISLockDetector.dll --output nsis\Plugins\x86-unicode\NSISLockDetector.dll
-
-          if exist nsis\Plugins\x64-ansi\NSISHTTP.dll del nsis\Plugins\x64-ansi\NSISHTTP.dll
-          if exist nsis\Plugins\x64-unicode\NSISHTTP.dll del nsis\Plugins\x64-unicode\NSISHTTP.dll
-          if exist nsis\Plugins\x86-ansi\NSISHTTP.dll del nsis\Plugins\x86-ansi\NSISHTTP.dll
-          if exist nsis\Plugins\x86-unicode\NSISHTTP.dll del nsis\Plugins\x86-unicode\NSISHTTP.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-ansi/NSISHTTP.dll --output nsis\Plugins\x64-ansi\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-unicode/NSISHTTP.dll --output nsis\Plugins\x64-unicode\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-ansi/NSISHTTP.dll --output nsis\Plugins\x86-ansi\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-unicode/NSISHTTP.dll --output nsis\Plugins\x86-unicode\NSISHTTP.dll
-
-          if exist nsis\Plugins\x64-ansi\NSISConfig.dll del nsis\Plugins\x64-ansi\NSISConfig.dll
-          if exist nsis\Plugins\x64-unicode\NSISConfig.dll del nsis\Plugins\x64-unicode\NSISConfig.dll
-          if exist nsis\Plugins\x86-ansi\NSISConfig.dll del nsis\Plugins\x86-ansi\NSISConfig.dll
-          if exist nsis\Plugins\x86-unicode\NSISConfig.dll del nsis\Plugins\x86-unicode\NSISConfig.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-ansi/NSISConfig.dll --output nsis\Plugins\x64-ansi\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-unicode/NSISConfig.dll --output nsis\Plugins\x64-unicode\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-ansi/NSISConfig.dll --output nsis\Plugins\x86-ansi\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-unicode/NSISConfig.dll --output nsis\Plugins\x86-unicode\NSISConfig.dll
-
-          xcopy nsis "%ProgramFiles(x86)%\NSIS" /S /E /I /Y
+        uses: ./.github/actions/install-nsis-plugins
+        with:
+          working-directory: ${{ env.ROOT }}
 
       - name: Build installer
         shell: powershell

--- a/.github/workflows/build-obs-streamelements-uninstaller.yml
+++ b/.github/workflows/build-obs-streamelements-uninstaller.yml
@@ -57,49 +57,9 @@ jobs:
           curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/obs-probe-libobs-version/windows/qa/obs-probe-libobs-version-64.exe --output resources\obs-probe-libobs-version-64.exe
 
       - name: Install NSIS plugins
-        shell: cmd
-        run: |
-          cd /d "${{ env.ROOT }}"
-
-          if not exist nsis mkdir nsis
-          if not exist nsis\Plugins mkdir nsis\Plugins
-
-          if not exist nsis\Plugins\x64-ansi mkdir nsis\Plugins\x64-ansi
-          if not exist nsis\Plugins\x64-unicode mkdir nsis\Plugins\x64-unicode
-          if not exist nsis\Plugins\x86-ansi mkdir nsis\Plugins\x86-ansi
-          if not exist nsis\Plugins\x86-unicode mkdir nsis\Plugins\x86-unicode
-
-          if exist nsis\Plugins\x64-ansi\NSISLockDetector.dll del nsis\Plugins\x64-ansi\NSISLockDetector.dll
-          if exist nsis\Plugins\x64-unicode\NSISLockDetector.dll del nsis\Plugins\x64-unicode\NSISLockDetector.dll
-          if exist nsis\Plugins\x86-ansi\NSISLockDetector.dll del nsis\Plugins\x86-ansi\NSISLockDetector.dll
-          if exist nsis\Plugins\x86-unicode\NSISLockDetector.dll del nsis\Plugins\x86-unicode\NSISLockDetector.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-ansi/NSISLockDetector.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-ansi\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x64-unicode/NSISLockDetector.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-unicode\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-ansi/NSISLockDetector.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-ansi\NSISLockDetector.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-lockdetector/windows/qa/x86-unicode/NSISLockDetector.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-unicode\NSISLockDetector.dll
-
-          if exist nsis\Plugins\x64-ansi\NSISHTTP.dll del nsis\Plugins\x64-ansi\NSISHTTP.dll
-          if exist nsis\Plugins\x64-unicode\NSISHTTP.dll del nsis\Plugins\x64-unicode\NSISHTTP.dll
-          if exist nsis\Plugins\x86-ansi\NSISHTTP.dll del nsis\Plugins\x86-ansi\NSISHTTP.dll
-          if exist nsis\Plugins\x86-unicode\NSISHTTP.dll del nsis\Plugins\x86-unicode\NSISHTTP.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-ansi/NSISHTTP.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-ansi\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x64-unicode/NSISHTTP.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-unicode\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-ansi/NSISHTTP.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-ansi\NSISHTTP.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-http/windows/qa/x86-unicode/NSISHTTP.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-unicode\NSISHTTP.dll
-
-          if exist nsis\Plugins\x64-ansi\NSISConfig.dll del nsis\Plugins\x64-ansi\NSISConfig.dll
-          if exist nsis\Plugins\x64-unicode\NSISConfig.dll del nsis\Plugins\x64-unicode\NSISConfig.dll
-          if exist nsis\Plugins\x86-ansi\NSISConfig.dll del nsis\Plugins\x86-ansi\NSISConfig.dll
-          if exist nsis\Plugins\x86-unicode\NSISConfig.dll del nsis\Plugins\x86-unicode\NSISConfig.dll
-
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-ansi/NSISConfig.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-ansi\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x64-unicode/NSISConfig.dll --output ${{ env.ROOT }}\nsis\Plugins\x64-unicode\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-ansi/NSISConfig.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-ansi\NSISConfig.dll
-          curl -L https://storage.googleapis.com/cdn.streamelements.com/obs/dist/nsis-config/windows/qa/x86-unicode/NSISConfig.dll --output ${{ env.ROOT }}\nsis\Plugins\x86-unicode\NSISConfig.dll
-
-          xcopy nsis "%ProgramFiles(x86)%\NSIS" /S /E /I /Y
+        uses: ./.github/actions/install-nsis-plugins
+        with:
+          working-directory: ${{ env.ROOT }}
 
       - name: Build installer
         shell: cmd


### PR DESCRIPTION
Dedupe from the pipeline review: the installer and uninstaller workflows each carried a ~45-line copy of the NSIS plugin download/install block. Both now call a single composite action, `.github/actions/install-nsis-plugins`.

Two deliberate behavior changes:
- **`curl -f`** on every plugin download — a missing CDN object now fails the build instead of a 404 XML body getting signed into the shipped installer (the same failure class as the deploy-signed-windows incident, #81).
- The pre-download `del` lines are gone; `curl --output` overwrites.

The PR build exercises the action in both jobs (they run on PRs). Longer term the plugin DLLs should be version-pinned rather than pulled from the mutable `qa` channel — that's part of the supply-chain discussion in CORE-414.

Related: #81, #83, #84. Found with Jacob's assistant.