### PR TITLE
feat(ci): release notes travel with the manifest and are reused at promotion

### DIFF
--- a/.github/actions/se-release/action.yml
+++ b/.github/actions/se-release/action.yml
@@ -43,6 +43,13 @@ inputs:
     description: 'Path to RELEASE_NOTES.md (mode=prerelease) or recovered notes (mode=publish).'
     required: false
     default: ''
+  release-notes-file:
+    description: >-
+      Path to obs-streamelements.release_notes.md fetched from the source channel
+      (mode=publish). Contains the blurb and notes composed at build time; when present it
+      is reused verbatim and no summary is regenerated.
+    required: false
+    default: ''
   changelog-file:
     description: 'Path the changelog is written to, then read from.'
     required: false
@@ -116,6 +123,7 @@ runs:
         SE_IS_ROLLBACK: ${{ inputs.is-rollback }}
         SE_OUTPUT_DIR: ${{ inputs.output-dir }}
         SE_NOTES_FILE: ${{ inputs.notes-file }}
+        SE_RELEASE_NOTES_FILE: ${{ inputs.release-notes-file }}
         SE_CHANGELOG_FILE: ${{ inputs.changelog-file }}
         SE_PREVIOUS_TAG: ${{ inputs.previous-tag }}
         SE_HEAD_REF: ${{ inputs.head-ref }}

--- a/.github/actions/se-release/lib.sh
+++ b/.github/actions/se-release/lib.sh
@@ -21,6 +21,15 @@ RELEASE_NOTES_END='<!-- SE_RELEASE_NOTES_END -->'
 # second platform's promotion of the same version.
 PUBLISHED_MARKER='<!-- SE_RELEASE_PUBLISHED -->'
 
+# Written to a channel when the build being published there has no notes of its own.
+#
+# The manifest and the version SVG are always replaced on a promotion, so the notes file
+# has to be replaced too -- leaving the previous one behind would make the channel serve
+# notes describing a build it no longer points at. A placeholder keeps the three in step
+# without pretending the notes exist; publish.sh treats a file carrying this marker as
+# absent and falls back to the notes recovered from the prerelease.
+NOTES_UNAVAILABLE_MARKER='<!-- SE_RELEASE_NOTES_UNAVAILABLE -->'
+
 CDN_BASE='https://cdn.streamelements.com/obs/dist/obs-streamelements'
 
 die() { printf '::error::%s\n' "$*" >&2; exit 1; }

--- a/.github/actions/se-release/prerelease.sh
+++ b/.github/actions/se-release/prerelease.sh
@@ -17,16 +17,35 @@ is_version_tag "$TAG" || die "'$TAG' does not look like a version tag (yy.m.d.bu
 # that gate is broken rather than that there is nothing to say.
 [ -s "$NOTES" ] || die "$NOTES is empty -- build.yml should not have reached this step"
 
-BODY="${RUNNER_TEMP:-/tmp}/se-prerelease-body.md"
+# The reusable artifact: the version-pinned half of the release body -- Claude's blurb
+# plus the hand-written notes verbatim. This is published to the CDN next to the manifest
+# as obs-streamelements.release_notes.md and travels with it through the channels, so
+# promoting a build to `latest` reuses this text instead of paying for another model call.
+#
+# The changelog is deliberately NOT in here. It is cheap to recompute and it is relative
+# to the previous full release, which can differ between build time and promotion time;
+# freezing it would publish a stale range.
+ARTIFACT="${RUNNER_TEMP:-/tmp}/obs-streamelements.release_notes.md"
 {
 	if [ -n "${SE_SUMMARY:-}" ]; then
 		printf "## What's new\n\n%s\n\n" "$SE_SUMMARY"
 	fi
-	# The hand-written notes are preserved verbatim between the fence markers, so the
-	# promotion to a full release can recover them exactly and recompose (requirement 5).
+	# The notes are fenced so a later promotion can recover them exactly (requirement 5).
 	printf '%s\n' "$RELEASE_NOTES_BEGIN"
 	cat "$NOTES"
-	printf '\n%s\n\n' "$RELEASE_NOTES_END"
+	printf '\n%s\n' "$RELEASE_NOTES_END"
+} > "$ARTIFACT"
+
+if [ -n "${SE_OUTPUT_DIR:-}" ]; then
+	mkdir -p "$SE_OUTPUT_DIR"
+	cp "$ARTIFACT" "$SE_OUTPUT_DIR/obs-streamelements.release_notes.md"
+	note "wrote $SE_OUTPUT_DIR/obs-streamelements.release_notes.md for upload to the CDN"
+fi
+
+BODY="${RUNNER_TEMP:-/tmp}/se-prerelease-body.md"
+{
+	cat "$ARTIFACT"
+	printf '\n'
 	if [ -n "${SE_CHANGELOG_FILE:-}" ] && [ -s "${SE_CHANGELOG_FILE:-}" ]; then
 		cat "$SE_CHANGELOG_FILE"
 	fi

--- a/.github/actions/se-release/publish.sh
+++ b/.github/actions/se-release/publish.sh
@@ -71,7 +71,8 @@ fi
 # Decide the notes source and log it BEFORE composing. note()/warn() write to stdout so
 # GitHub renders them as annotations, which means they must never be called inside the
 # redirection below or they end up inside the published release body.
-if [ -n "${SE_RELEASE_NOTES_FILE:-}" ] && [ -s "${SE_RELEASE_NOTES_FILE:-}" ]; then
+if [ -n "${SE_RELEASE_NOTES_FILE:-}" ] && [ -s "${SE_RELEASE_NOTES_FILE:-}" ] &&
+	! grep -qF "$NOTES_UNAVAILABLE_MARKER" "$SE_RELEASE_NOTES_FILE"; then
 	# The artifact that travelled with the manifest from `signed/`: Claude's blurb plus
 	# the hand-written notes, composed at build time. Reused verbatim, so the text a user
 	# sees on `latest` is exactly what was reviewed on the prerelease and no second model

--- a/.github/actions/se-release/publish.sh
+++ b/.github/actions/se-release/publish.sh
@@ -68,17 +68,38 @@ if [ "$WAS_PRERELEASE" = "false" ] && grep -qF "$PUBLISHED_MARKER" "$cur"; then
 	exit 0
 fi
 
+# Decide the notes source and log it BEFORE composing. note()/warn() write to stdout so
+# GitHub renders them as annotations, which means they must never be called inside the
+# redirection below or they end up inside the published release body.
+if [ -n "${SE_RELEASE_NOTES_FILE:-}" ] && [ -s "${SE_RELEASE_NOTES_FILE:-}" ]; then
+	# The artifact that travelled with the manifest from `signed/`: Claude's blurb plus
+	# the hand-written notes, composed at build time. Reused verbatim, so the text a user
+	# sees on `latest` is exactly what was reviewed on the prerelease and no second model
+	# call is needed.
+	note "using the release notes artifact that travelled with the manifest"
+	USE_ARTIFACT=true
+else
+	# Fallback for builds predating the artifact, or where the CDN copy is missing:
+	# rebuild from the notes recovered out of the prerelease body. No blurb on this path.
+	warn "no release notes artifact for $TAG; composing from the recovered notes instead"
+	USE_ARTIFACT=false
+fi
+
 body="$TMP/se-release-body.md"
 {
 	printf '%s\n\n' "$PUBLISHED_MARKER"
-	if [ -n "${SE_SUMMARY:-}" ]; then
-		printf "## What's new\n\n%s\n\n" "$SE_SUMMARY"
+
+	if [ "$USE_ARTIFACT" = "true" ]; then
+		cat "$SE_RELEASE_NOTES_FILE"
+		printf '\n'
+	else
+		printf '%s\n' "$RELEASE_NOTES_BEGIN"
+		if [ -n "${SE_NOTES_FILE:-}" ] && [ -s "${SE_NOTES_FILE:-}" ]; then cat "$SE_NOTES_FILE"; fi
+		printf '%s\n\n' "$RELEASE_NOTES_END"
 	fi
-	# The hand-written notes are preserved verbatim and still fenced, so every later
-	# recomposition starts from the same pristine text (requirement 5: AUGMENT).
-	printf '%s\n' "$RELEASE_NOTES_BEGIN"
-	if [ -n "${SE_NOTES_FILE:-}" ] && [ -s "${SE_NOTES_FILE:-}" ]; then cat "$SE_NOTES_FILE"; fi
-	printf '%s\n\n' "$RELEASE_NOTES_END"
+
+	# Always recomputed rather than taken from the artifact: the range is relative to the
+	# previous full release, which can have moved since this build was made.
 	if [ -n "${SE_CHANGELOG_FILE:-}" ] && [ -s "${SE_CHANGELOG_FILE:-}" ]; then cat "$SE_CHANGELOG_FILE"; fi
 } > "$body"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,13 @@ jobs:
   deploy-signed-windows:
     needs: [ version, windows, build-installer ]
     runs-on: ubuntu-latest
-    if: needs.version.outputs.is_workflow_automation != 'true' && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && (vars.SKIP_WINDOWS_SIGNING != 'true' && vars.SKIP_WINDOWS_SIGNING != '1' && vars.SKIP_WINDOWS_SIGNING != 'yes')
+    # has_release_notes gates this whole job: a build with an empty RELEASE_NOTES.md must
+    # put nothing new on signed/ -- no binaries, no manifest, no version SVG. Such a build
+    # gets no tag and no GitHub release either, so publishing it would advance the channel
+    # to a version that can never be promoted to `latest` (the promotion fails by design)
+    # and would leave signed/ serving a manifest whose release notes belong to an earlier
+    # build.
+    if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true' && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && (vars.SKIP_WINDOWS_SIGNING != 'true' && vars.SKIP_WINDOWS_SIGNING != '1' && vars.SKIP_WINDOWS_SIGNING != 'yes')
 
     steps:
       - name: Auth Google API
@@ -496,7 +502,8 @@ jobs:
   deploy-signed-macos:
     needs: [ version, macos, build-installer ]
     runs-on: ubuntu-latest
-    if: needs.version.outputs.is_workflow_automation != 'true' && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && (vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes')
+    # Gated on has_release_notes for the same reason as deploy-signed-windows above.
+    if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true' && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && (vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'true' && vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != '1' && vars.SKIP_APPLE_SIGNING_AND_NOTARIZATION != 'yes')
 
     steps:
       - name: Auth Google API
@@ -571,6 +578,15 @@ jobs:
             content-type: text/plain; charset=utf-8
 
   finalize:
+    # Note this job is now skipped entirely for a build with an empty RELEASE_NOTES.md:
+    # it needs deploy-signed-*, those are gated on has_release_notes, and GitHub skips a
+    # job whose dependencies were skipped. That is the intended outcome -- every step
+    # below is already individually gated on has_release_notes, with one exception, the
+    # VirusTotal prune. Losing the prune on notes-less builds is consistent rather than a
+    # gap: the matching VirusTotal upload lives in deploy-signed-windows and is skipped
+    # too, so no new files were submitted, and release.yml prunes again on every
+    # non-dry-run promotion. The same implicit skip already happens when
+    # SKIP_WINDOWS_SIGNING or SKIP_APPLE_SIGNING_AND_NOTARIZATION is set.
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     needs: [version, windows, macos, build-uninstaller, build-installer, deploy-signed-macos, deploy-signed-windows]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -668,10 +668,51 @@ jobs:
           tag: ${{ needs.version.outputs.version_string }}
           notes-file: RELEASE_NOTES.md
           changelog-file: ${{ github.workspace }}/.release-input/changelog.md
+          # Also makes the step write obs-streamelements.release_notes.md here, for the
+          # CDN upload below.
+          output-dir: ${{ github.workspace }}/.release-input
           # Empty when the step above timed out, failed, or produced no structured
           # output. Model text reaches the script only as an environment variable.
           summary: ${{ (steps.claude_summary.outcome == 'success' && steps.claude_summary.outputs.structured_output != '' && fromJSON(steps.claude_summary.outputs.structured_output).summary) || '' }}
           dry-run: 'false'
+
+      # Publish the blurb + notes next to the manifest in signed/, so promotion can reuse
+      # the text instead of regenerating it, and so the notes for a given build follow
+      # that build through the channels. Uploaded here rather than from deploy-signed-*
+      # because the blurb does not exist until the step above has run.
+      - name: Auth Google API
+        if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          project_id: streamelements-core
+          workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
+          service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
+
+      - name: Upload release notes to windows/signed
+        if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
+        with:
+          parent: false
+          process_gcloudignore: false
+          path: ${{ github.workspace }}/.release-input
+          glob: 'obs-streamelements.release_notes.md'
+          destination: 'cdn.streamelements.com/obs/dist/obs-streamelements/windows/signed'
+          headers: |
+            content-type: text/markdown; charset=utf-8
+            cache-control: 'public, max-age=60'
+
+      - name: Upload release notes to macos/signed
+        if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
+        with:
+          parent: false
+          process_gcloudignore: false
+          path: ${{ github.workspace }}/.release-input
+          glob: 'obs-streamelements.release_notes.md'
+          destination: 'cdn.streamelements.com/obs/dist/obs-streamelements/macos/signed'
+          headers: |
+            content-type: text/markdown; charset=utf-8
+            cache-control: 'public, max-age=60'
 
       - name: Clear RELEASE_NOTES.md
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -627,7 +627,13 @@ jobs:
         # yields an empty summary and the prerelease is composed from notes + changelog.
         continue-on-error: true
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@v1
+        # The base action, NOT anthropics/claude-code-action. The wrapper parses the
+        # GitHub event context and rejects anything it does not recognise -- on this job
+        # it fails immediately with "Unsupported event type: push", because finalize runs
+        # inside the push-triggered Build workflow. The base action has no such gate; it
+        # just runs Claude Code, which is all this step needs.
+        # Pinned to an exact version: the base action publishes no moving major tag.
+        uses: anthropics/claude-code-base-action@v0.0.63
         # Force Task subagents to run in the foreground; same rationale as
         # claude-code-review.yml, which documents the mechanism.
         # Upstream: anthropics/claude-code-action#1499.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,26 @@ jobs:
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
 
-      - name: Download manifest and version SVG
+      - name: Download manifest, version SVG and release notes
+        id: download
         run: |
           curl -f --output obs-streamelements.manifest https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.manifest
 
           curl -f --output obs-streamelements.version.svg https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.version.svg
+
+          # The release notes travel with the manifest so the text always matches the
+          # build on the channel. Builds from before this was introduced have no such
+          # file, so a 404 is expected and must not fail the promotion -- the release
+          # body then falls back to the notes recovered from the prerelease.
+          if curl -fsS --output obs-streamelements.release_notes.md \
+              "https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.release_notes.md"; then
+            echo "::notice::fetched release notes from '${{ github.event.inputs.from }}'"
+            echo "has_release_notes=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::no obs-streamelements.release_notes.md on '${{ github.event.inputs.from }}'; it will not be promoted and the release body will omit the summary"
+            rm -f obs-streamelements.release_notes.md
+            echo "has_release_notes=false" >> $GITHUB_OUTPUT
+          fi
 
       # ---------------------------------------------------------------------------
       # MUST stay above "Upload Manifests to CDN Google Storage". Two independent
@@ -202,6 +217,23 @@ jobs:
             content-type: text/plain; charset=utf-8
             cache-control: 'public, max-age=60'
 
+      # Moves in lockstep with the manifest above, on promotions and rollbacks alike, so
+      # every channel serves the notes belonging to the build it is actually pointing at.
+      # Same 60s max-age as the manifest for the same reason: a channel's contents can
+      # change at any time and stale notes would describe the wrong build.
+      - name: Upload release notes to CDN Google Storage
+        if: ${{ github.event.inputs.dry-run == 'false' && steps.download.outputs.has_release_notes == 'true' }}
+        uses: 'google-github-actions/upload-cloud-storage@v3'
+        with:
+          parent: false
+          process_gcloudignore: false
+          path: ${{ github.workspace }}
+          glob: 'obs-streamelements.release_notes.md'
+          destination: 'cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.to }}'
+          headers: |
+            content-type: text/markdown; charset=utf-8
+            cache-control: 'public, max-age=60'
+
       - name: Upload SVGs to CDN Google Storage
         if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
@@ -214,49 +246,6 @@ jobs:
           headers: |
             cache-control: 'no-store, no-cache, must-revalidate'
 
-      # Deliberately after the CDN uploads: the promotion users actually see completes
-      # before any model call, so a slow or failing generation can never delay it.
-      - name: Generate release summary with Claude
-        id: claude_summary
-        if: env.SE_PROMOTE == 'true'
-        continue-on-error: true
-        timeout-minutes: 10
-        uses: anthropics/claude-code-action@v1
-        # Force Task subagents to run in the foreground; same rationale as
-        # claude-code-review.yml, which documents the mechanism.
-        # Upstream: anthropics/claude-code-action#1499.
-        env:
-          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            Write the "What's new" blurb for SE.Live (the StreamElements OBS plugin)
-            release ${{ steps.version.outputs.version_string }}, which is being promoted
-            to the `latest` channel where ordinary users receive it.
-
-            Read these files, relative to the repository root:
-              - .release-input/notes.md        release notes written by the team
-              - .release-input/changelog.md    PRs and commits since the last release
-
-            The changelog covers everything since the previous full release, which may
-            span several builds. Summarise the whole span, not just the newest change.
-
-            Write 2-4 sentences, or up to 4 short bullets, aimed at OBS streamers rather
-            than developers. Lead with what changed for them.
-
-            Rules:
-            - Use only what is in those files. Invent nothing.
-            - Do not restate the notes verbatim; they are published directly below your
-              text.
-            - Skip CI, build-system, refactor and dependency work entirely.
-            - No heading: the workflow adds "## What's new" itself.
-            - Plain Markdown, no code fences.
-
-            Return the text as the "summary" field of the JSON response.
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep"
-            --json-schema '{"type":"object","additionalProperties":false,"required":["summary"],"properties":{"summary":{"type":"string","maxLength":1200}}}'
-
       - name: Publish GitHub release
         if: env.SE_PROMOTE == 'true'
         uses: ./.github/actions/se-release
@@ -265,12 +254,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.version.outputs.version_string }}
           previous-tag: ${{ steps.version.outputs.previous_tag }}
+          # The blurb + notes composed at build time, fetched from the source channel
+          # above. Reused verbatim, which is why there is no Claude step in this
+          # workflow: the text was generated once, when the build was made, and has
+          # travelled with the manifest ever since.
+          release-notes-file: ${{ github.workspace }}/obs-streamelements.release_notes.md
+          # Fallback source, used only when the artifact is absent (builds predating it).
           notes-file: ${{ github.workspace }}/.release-input/notes.md
+          # Always recomputed: the range is relative to the previous full release, which
+          # can have moved since the build was made.
           changelog-file: ${{ github.workspace }}/.release-input/changelog.md
-          # Empty when the step above timed out, failed, or produced no structured
-          # output; the body is then composed from notes + changelog alone. Model text
-          # reaches the script only as an environment variable, never as shell code.
-          summary: ${{ (steps.claude_summary.outcome == 'success' && steps.claude_summary.outputs.structured_output != '' && fromJSON(steps.claude_summary.outputs.structured_output).summary) || '' }}
           dry-run: ${{ github.event.inputs.dry-run }}
 
       - name: Revert displaced GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,17 +153,25 @@ jobs:
 
           curl -f --output obs-streamelements.version.svg https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.version.svg
 
-          # The release notes travel with the manifest so the text always matches the
-          # build on the channel. Builds from before this was introduced have no such
-          # file, so a 404 is expected and must not fail the promotion -- the release
-          # body then falls back to the notes recovered from the prerelease.
+          # The release notes travel with the manifest, in both directions, so a channel
+          # always serves the notes belonging to the build it points at.
+          #
+          # When the source has none -- builds predating this file, or a finalize whose
+          # upload failed -- a placeholder is synthesised rather than skipping the upload.
+          # The manifest and the version SVG are replaced unconditionally, so leaving the
+          # destination's previous notes in place would leave it describing a build it no
+          # longer points at. Writing the placeholder keeps all three in step.
           if curl -fsS --output obs-streamelements.release_notes.md \
               "https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.release_notes.md"; then
             echo "::notice::fetched release notes from '${{ github.event.inputs.from }}'"
             echo "has_release_notes=true" >> $GITHUB_OUTPUT
           else
-            echo "::warning::no obs-streamelements.release_notes.md on '${{ github.event.inputs.from }}'; it will not be promoted and the release body will omit the summary"
-            rm -f obs-streamelements.release_notes.md
+            echo "::warning::no obs-streamelements.release_notes.md on '${{ github.event.inputs.from }}'; writing a placeholder so '${{ github.event.inputs.to }}' does not keep notes from a different build"
+            {
+              echo "<!-- SE_RELEASE_NOTES_UNAVAILABLE -->"
+              echo
+              echo "_No release notes were published for this build._"
+            } > obs-streamelements.release_notes.md
             echo "has_release_notes=false" >> $GITHUB_OUTPUT
           fi
 
@@ -221,8 +229,13 @@ jobs:
       # every channel serves the notes belonging to the build it is actually pointing at.
       # Same 60s max-age as the manifest for the same reason: a channel's contents can
       # change at any time and stale notes would describe the wrong build.
+      #
+      # Guarded only on dry-run, exactly like the manifest and SVG uploads. The download
+      # step guarantees the file exists -- real notes or a placeholder -- because skipping
+      # this upload would leave the destination's previous notes beside a manifest that
+      # has moved on.
       - name: Upload release notes to CDN Google Storage
-        if: ${{ github.event.inputs.dry-run == 'false' && steps.download.outputs.has_release_notes == 'true' }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false


### PR DESCRIPTION
Claude's blurb is now generated **once**, at build time, published to `signed/` as `obs-streamelements.release_notes.md`, and carried along with the manifest through every channel change. Promoting a build to `latest` reuses that text instead of paying for a second generation.

## What changed

**The prerelease body is now two parts.** The version-pinned half — blurb + hand-written notes verbatim — becomes the artifact. The changelog stays out of it on purpose: it is cheap to recompute and its range is relative to the previous *full* release, which can move between build time and promotion time. Freezing it would publish a stale range.

```
obs-streamelements.release_notes.md     ## What's new + <!-- SE_RELEASE_NOTES_BEGIN --> … <!-- END -->
release body                            = artifact + freshly computed changelog
```

**Uploaded from `finalize`**, not from `deploy-signed-*`, because the blurb doesn't exist until the prerelease step has run. `finalize` inherits `contents: write` / `id-token: write` from the workflow level exactly as `deploy-signed-*` does, so WIF auth works with no permissions change.

**`text/markdown`, `cache-control: public, max-age=60`** — the same ceiling as the manifest, for the same reason: a channel's contents can change at any moment, and a longer cache would hand out notes describing a build that is no longer there.

**Travels on promotion and rollback alike**, in lockstep with the manifest, so every channel serves notes matching the build it points at.

**The Claude step is removed from `release.yml`.** It is no longer needed, and reuse has a side benefit: the text on `latest` is exactly what was reviewed on the `[BETA]` prerelease, rather than a fresh generation that might describe the same build differently.

## Degradation

A missing artifact is not an error — builds predating this have none. The fetch tolerates a 404, the upload is skipped rather than pushing a file that was never fetched, and the body falls back to the notes recovered from the prerelease. Correct, just without a blurb.

## Verified locally

- Artifact contains blurb + fenced notes and **no** changelog; the prerelease body adds the changelog.
- Publish with the artifact present reuses it verbatim; absent, it falls back cleanly.
- Step order still holds: `resolve` remains above all three CDN uploads.

Testing caught a bug worth noting: the notes-source `note()`/`warn()` calls were inside the `{ … } > "$body"` redirection, so `::notice::using the release notes artifact…` was being written **into the published release body**. The decision and its logging are now hoisted out. Same class of stdout-capture bug as the one fixed in #87.

## Known wrinkle, not addressed here

A build with an **empty** `RELEASE_NOTES.md` skips `finalize` entirely, so `signed/` keeps the *previous* build's `release_notes.md` while its manifest advances. That version can never reach `latest` (it has no release, so the promotion fails by design), but it can move to `qa`/`beta` carrying mismatched notes. Worth a follow-up if that matters — the fix is to clear or replace the artifact on notes-less builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)