### PR TITLE
fix(ci): missing version badge no longer blocks promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,24 @@ jobs:
         run: |
           curl -f --output obs-streamelements.manifest https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.manifest
 
-          curl -f --output obs-streamelements.version.svg https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.version.svg
+          # The version badge is cosmetic -- it is the image the README embeds -- and it
+          # is missing from beta, latest and stable on both platforms. Fetching it with
+          # `curl -f` under `bash -e` therefore killed the job before it reached any
+          # promotion logic, which blocked beta -> latest, latest -> stable and both
+          # rollbacks outright. Its absence must not stop a release from being promoted.
+          #
+          # Unlike the release notes below, a missing badge cannot be substituted: the
+          # notes have a meaningful placeholder, whereas an SVG stating the wrong version
+          # would be worse than none. So the upload is skipped instead and the
+          # destination keeps whatever badge it had.
+          if curl -fsS --output obs-streamelements.version.svg \
+              "https://cdn.streamelements.com/obs/dist/obs-streamelements/${{ github.event.inputs.platform }}/${{ github.event.inputs.from }}/obs-streamelements.version.svg"; then
+            echo "has_version_svg=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::no obs-streamelements.version.svg on '${{ github.event.inputs.from }}'; the version badge on '${{ github.event.inputs.to }}' will not be updated"
+            rm -f obs-streamelements.version.svg
+            echo "has_version_svg=false" >> $GITHUB_OUTPUT
+          fi
 
           # The release notes travel with the manifest, in both directions, so a channel
           # always serves the notes belonging to the build it points at.
@@ -247,8 +264,11 @@ jobs:
             content-type: text/markdown; charset=utf-8
             cache-control: 'public, max-age=60'
 
+      # Conditional, unlike the manifest and release notes above: when the source channel
+      # has no badge there is nothing meaningful to publish, and an empty glob would fail
+      # the upload action.
       - name: Upload SVGs to CDN Google Storage
-        if: ${{ github.event.inputs.dry-run == 'false' }}
+        if: ${{ github.event.inputs.dry-run == 'false' && steps.download.outputs.has_version_svg == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           parent: false


### PR DESCRIPTION
Found while dry-running `beta → latest` to test #88. **Promotion past `qa → beta` is currently impossible**, and has nothing to do with the release automation — the run dies before reaching any of it.

## The bug

`obs-streamelements.version.svg` exists on only two of the five channels:

```
              manifest   version.svg
signed          200         200
qa              200         200
beta            200         404   ←
latest          200         404   ←
stable          200         404   ←
```

The download step fetches it with `curl -f`, and GitHub runs `run:` blocks under `bash -e`, so a 404 kills the job on that line. That blocks **`beta → latest`**, **`latest → stable`** and **both rollback directions** outright — before validation, before the manifest is parsed, before any release logic.

Confirmed by [the dry-run](https://github.com/StreamElements/obs-streamelements-core/actions/runs/31006080187): the manifest fetched fine (4138 bytes), then

```
curl: (22) The requested URL returned error: 404
##[error]Process completed with exit code 22.
```

It is also **self-perpetuating**: a badge only reaches a channel by being promoted into it, and the promotion that would carry it is precisely the one that fails. So `beta`, `latest` and `stable` can never acquire one on their own.

## The fix

The badge fetch tolerates a 404 and its upload is skipped when there's nothing to publish.

Deliberately *not* symmetric with the release notes, which I made unconditional in #88: the notes have a meaningful placeholder to substitute, whereas an SVG announcing the **wrong** version would be worse than none — so the destination keeps whatever badge it had. The manifest fetch stays strict, since a promotion without a manifest is meaningless.

## Impact

Unblocks `beta → latest`, which is the transition that actually cuts a full GitHub release. Without this, none of #87/#88 can ever run in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)