### PR TITLE
fix(ci): BugSplat symbol upload failures warn instead of failing the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,12 @@ jobs:
           ) | Out-File key.json
           npm install
 
+      # Symbol upload is best-effort: BugSplat being unreachable must not fail a build
+      # that otherwise compiled and signed correctly. The only consequence is that crash
+      # reports for this build are not symbolicated. BugSplat is slated to be replaced by
+      # Sentry, so this path is deliberately tolerant rather than hardened.
       - name: Download BugSplat uploader
+        shell: pwsh
         run: |
           mkdir c:\local\bugsplat
 
@@ -149,7 +154,13 @@ jobs:
 
           cd c:\local\bugsplat
 
-          curl -sL -f -O https://github.com/BugSplat-Git/symbol-upload/releases/download/v10.5.0/symbol-upload-windows.exe
+          curl.exe -sL -f -O https://github.com/BugSplat-Git/symbol-upload/releases/download/v10.5.0/symbol-upload-windows.exe
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning title=BugSplat uploader unavailable::Could not download symbol-upload-windows.exe (curl exit $LASTEXITCODE). Windows symbols will not be uploaded for this build and its crash reports will not be symbolicated."
+          }
+
+          exit 0
 
       - name: Generate Version
         shell: powershell
@@ -189,6 +200,14 @@ jobs:
             --database OBS_Live ^
             --directory "C:\local\obs-studio\build_x64\rundir\RelWithDebInfo\obs-plugins\64bit" ^
             --files obs-streamelements*.pdb
+
+          rem Captured on its own line: %ERRORLEVEL% inside an if-block would expand at
+          rem parse time, before the exe has run, because delayed expansion is off.
+          set "RC=%ERRORLEVEL%"
+
+          if not "%RC%"=="0" echo ::warning title=BugSplat symbol upload failed::symbol-upload-windows.exe exited with %RC%. Windows crash reports for ${{ needs.version.outputs.version_string }} will not be symbolicated. The build itself is unaffected.
+
+          exit /b 0
 
       - name: Package
         shell: cmd
@@ -257,12 +276,18 @@ jobs:
 
           unzip BugSplat.xcframework.zip
 
+      # Best-effort, as on Windows: a BugSplat outage must not fail an otherwise good
+      # build. chmod moved inside the success branch -- it would fail on a missing file
+      # and take the step down with it.
       - name: Download BugSplat uploader
         run: |
           cd /tmp
-          curl -sL -f -O https://github.com/BugSplat-Git/symbol-upload/releases/download/v10.5.0/symbol-upload-macos
-          #cp symbol-upload-macos-intel symbol-upload-macos
-          chmod +x symbol-upload-macos
+          if curl -sL -f -O https://github.com/BugSplat-Git/symbol-upload/releases/download/v10.5.0/symbol-upload-macos; then
+            #cp symbol-upload-macos-intel symbol-upload-macos
+            chmod +x symbol-upload-macos
+          else
+            echo "::warning title=BugSplat uploader unavailable::Could not download symbol-upload-macos. macOS symbols will not be uploaded for this build and its crash reports will not be symbolicated."
+          fi
 
       - name: Generate Version
         run: |
@@ -310,19 +335,27 @@ jobs:
 
           xcrun dsymutil obs-streamelements-core.plugin/Contents/MacOS/obs-streamelements-core -o obs-streamelements-core.dSYM
 
+      # The subshell covers the cd as well as the upload: a missing build directory would
+      # otherwise fail the step before the uploader ever ran.
       - name: Upload ARM64 to BugSplat
         if: env.UPLOAD_SYMBOLS == 'true'
         run: |
-          cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo
-
-          /tmp/symbol-upload-macos -v -a "obs-streamelements-core-macos" -b "OBS_Live" -i "${{ secrets.BUGSPLAT_CLIENTID }}" -s "${{ secrets.BUGSPLAT_CLIENTSECRET }}" -f "obs-streamelements-core.dSYM" -d . -v "${{ needs.version.outputs.version_encoded }}"
+          if ! (
+            cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo &&
+            /tmp/symbol-upload-macos -v -a "obs-streamelements-core-macos" -b "OBS_Live" -i "${{ secrets.BUGSPLAT_CLIENTID }}" -s "${{ secrets.BUGSPLAT_CLIENTSECRET }}" -f "obs-streamelements-core.dSYM" -d . -v "${{ needs.version.outputs.version_encoded }}"
+          ); then
+            echo "::warning title=BugSplat symbol upload failed (macOS arm64)::arm64 symbols for ${{ needs.version.outputs.version_string }} were not uploaded, so its crash reports will not be symbolicated. The build itself is unaffected."
+          fi
 
       - name: Upload x86_64 to BugSplat
         if: env.UPLOAD_SYMBOLS == 'true'
         run: |
-          cd ~/src/obs-studio/build_macos_x86_64/plugins/obs-streamelements-core/RelWithDebInfo
-
-          /tmp/symbol-upload-macos -v -a "obs-streamelements-core-macos" -b "OBS_Live" -i "${{ secrets.BUGSPLAT_CLIENTID }}" -s "${{ secrets.BUGSPLAT_CLIENTSECRET }}" -f "obs-streamelements-core.dSYM" -d . -v "${{ needs.version.outputs.version_encoded }}"
+          if ! (
+            cd ~/src/obs-studio/build_macos_x86_64/plugins/obs-streamelements-core/RelWithDebInfo &&
+            /tmp/symbol-upload-macos -v -a "obs-streamelements-core-macos" -b "OBS_Live" -i "${{ secrets.BUGSPLAT_CLIENTID }}" -s "${{ secrets.BUGSPLAT_CLIENTSECRET }}" -f "obs-streamelements-core.dSYM" -d . -v "${{ needs.version.outputs.version_encoded }}"
+          ); then
+            echo "::warning title=BugSplat symbol upload failed (macOS x86_64)::x86_64 symbols for ${{ needs.version.outputs.version_string }} were not uploaded, so its crash reports will not be symbolicated. The build itself is unaffected."
+          fi
       - name: Package
         run: |
           cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo


### PR DESCRIPTION
A BugSplat outage currently fails a build that compiled and signed perfectly. The only real consequence of a failed symbol upload is that crash reports for that build aren't symbolicated, so it should warn and carry on. Since BugSplat is being replaced with Sentry, this path is made tolerant rather than hardened.

## Covers all five steps, not just the uploads

The two `Download BugSplat uploader` steps use `curl -f` and are **ungated** — they run even on PRs where `UPLOAD_SYMBOLS` is false. A GitHub release outage would have failed the build there, before the upload steps were reached, defeating the purpose of guarding only the uploads.

| job | step | was |
|---|---|---|
| windows | Download BugSplat uploader | `curl -f` → hard fail |
| windows | Upload BugSplat Symbols | non-zero exit → hard fail |
| macos | Download BugSplat uploader | `curl -f`, plus `chmod` on a missing file |
| macos | Upload ARM64 to BugSplat | non-zero exit → hard fail |
| macos | Upload x86_64 to BugSplat | non-zero exit → hard fail |

## Three shells, three different traps

- **bash** — the upload and its `cd` are wrapped in one subshell, so a missing build directory warns rather than killing the step before the uploader runs. `chmod +x` moved inside the download's success branch; it would fail on a missing file.
- **cmd** — `%ERRORLEVEL%` is captured to a variable on its own line. Read inside an `if` block it expands at **parse** time, before the exe has run, because delayed expansion is off. This is the subtle one.
- **pwsh** — `$LASTEXITCODE` checked explicitly with `exit 0` at the end. The shell is now named rather than relying on the Windows default, since the check depends on it, and `curl` is called as `curl.exe` so it can't resolve to an alias.

## Verified

Each pattern was run against a simulated failure locally:

| shell | simulated | result |
|---|---|---|
| bash | missing directory, and missing binary | warns, exit 0 |
| cmd | missing exe — printed `exited with 3`, confirming the expansion trap is avoided | warns, exit 0 |
| pwsh | curl 404 — captured exit 22 | warns, exit 0 |

Failures surface as `::warning` annotations naming the platform, exit code and affected version, so they show up in the run summary rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)