### PR TITLE
feat(ci): restructure the release body into creator-facing sections

### DIFF
--- a/.github/actions/se-release/changelog.sh
+++ b/.github/actions/se-release/changelog.sh
@@ -47,28 +47,14 @@ else
 	warn "continuing with the git-log section only"
 fi
 
-# ---- git log ----------------------------------------------------------------------
-# tformat (not format) terminates every entry with a newline, so wc -l and head -n are
-# honest about the count. --invert-grep drops CI's own commits at the source.
-commits="$TMP/se-commits.md"
-git log --no-merges --invert-grep --grep='^\[WORKFLOW-AUTOMATION\]' \
-	--pretty=tformat:'- %s (%an)' "$PREV..$HEAD_REF" > "$commits" 2>/dev/null || : > "$commits"
-
-if [ -s "$commits" ]; then
-	total=$(wc -l < "$commits" | tr -d ' ')
-	printf '### All commits\n\n' >> "$OUT"
-	head -n 200 "$commits" >> "$OUT"
-	if [ "$total" -gt 200 ]; then
-		printf '\n_...and %d more commits._\n' "$((total - 200))" >> "$OUT"
-	fi
-	printf '\n' >> "$OUT"
-else
-	warn "no non-automation commits found in $PREV..$TAG"
-fi
-
 # ---- contributors -----------------------------------------------------------------
-# The bot's commits are already excluded above; the name filter is belt-and-braces and
-# survives a future change to the commit-message prefix.
+# Derived from git log rather than from the generated notes above, because a large share
+# of this repo's work lands as direct pushes to master, whose authors PR-based generation
+# cannot see. The per-commit list this used to print was dropped: the generated section
+# already covers what changed, and a raw commit dump is noise in a user-facing release.
+#
+# --invert-grep drops CI's own commits at the source; the bot name filter below is
+# belt-and-braces and survives a future change to the commit-message prefix.
 # Joined with awk rather than `paste -sd ', '`: paste treats the delimiter argument as a
 # LIST of single characters used cyclically, so ', ' yields "a,b c" instead of "a, b, c".
 people=$(

--- a/.github/actions/se-release/prerelease.sh
+++ b/.github/actions/se-release/prerelease.sh
@@ -28,9 +28,11 @@ is_version_tag "$TAG" || die "'$TAG' does not look like a version tag (yy.m.d.bu
 ARTIFACT="${RUNNER_TEMP:-/tmp}/obs-streamelements.release_notes.md"
 {
 	if [ -n "${SE_SUMMARY:-}" ]; then
-		printf "## What's new\n\n%s\n\n" "$SE_SUMMARY"
+		printf "## What's New\n\n%s\n\n" "$SE_SUMMARY"
 	fi
-	# The notes are fenced so a later promotion can recover them exactly (requirement 5).
+	# The heading sits outside the fence on purpose: the fence must hold the pristine
+	# RELEASE_NOTES.md and nothing else, so a promotion can recover it byte for byte.
+	printf '## Release Notes\n\n'
 	printf '%s\n' "$RELEASE_NOTES_BEGIN"
 	cat "$NOTES"
 	printf '\n%s\n' "$RELEASE_NOTES_END"

--- a/.github/actions/se-release/publish.sh
+++ b/.github/actions/se-release/publish.sh
@@ -94,6 +94,7 @@ body="$TMP/se-release-body.md"
 		cat "$SE_RELEASE_NOTES_FILE"
 		printf '\n'
 	else
+		printf '## Release Notes\n\n'
 		printf '%s\n' "$RELEASE_NOTES_BEGIN"
 		if [ -n "${SE_NOTES_FILE:-}" ] && [ -s "${SE_NOTES_FILE:-}" ]; then cat "$SE_NOTES_FILE"; fi
 		printf '%s\n\n' "$RELEASE_NOTES_END"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,22 +691,28 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Write the "What's new" blurb for SE.Live (the StreamElements OBS plugin)
+            Write the "What's New" section for SE.Live (the StreamElements OBS plugin)
             release ${{ needs.version.outputs.version_string }}.
+
+            The audience is creators -- people who stream and record with OBS. They are
+            not developers and do not know this codebase. Write about what they will
+            notice: what works better, what is new, what no longer breaks.
 
             Read these files, relative to the repository root:
               - RELEASE_NOTES.md               release notes written by the team
-              - .release-input/changelog.md    PRs and commits since the last release
+              - .release-input/changelog.md    PRs merged since the last release
 
-            Write 2-4 sentences, or up to 4 short bullets, aimed at OBS streamers rather
-            than developers. Lead with what changed for them.
+            Write 2-4 sentences, or up to 4 short bullets.
 
             Rules:
             - Use only what is in those files. Invent nothing.
             - Do not restate the notes verbatim; they are published directly below your
-              text.
-            - Skip CI, build-system, refactor and dependency work entirely.
-            - No heading: the workflow adds "## What's new" itself.
+              text under a "Release Notes" heading.
+            - Skip CI, build-system, refactor and dependency work entirely -- none of it
+              is visible to a creator.
+            - Avoid internal jargon: say "scene switching" rather than naming a class,
+              and describe an effect rather than a code path.
+            - No heading: the workflow adds "## What's New" itself.
             - Plain Markdown, no code fences.
 
             Return the text as the "summary" field of the JSON response.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -716,7 +716,13 @@ jobs:
             - Plain Markdown, no code fences.
 
             Return the text as the "summary" field of the JSON response.
+          # --model is pinned because the base action's own default is
+          # claude-sonnet-4-20250514, which is retired -- it fails the run with
+          # `API Error: 404 {"type":"not_found_error","message":"model:
+          # claude-sonnet-4-20250514"}`. Without this the step always fails and
+          # the release publishes with no "What's New" section.
           claude_args: >-
+            --model claude-opus-5
             --allowedTools "Read,Glob,Grep"
             --json-schema '{"type":"object","additionalProperties":false,"required":["summary"],"properties":{"summary":{"type":"string","maxLength":1200}}}'
 


### PR DESCRIPTION
The release body now reads as three clearly-labelled sections, with the raw commit dump removed.

```
## What's New      ← Claude's summary, written for creators
## Release Notes   ← RELEASE_NOTES.md verbatim, still fenced
## Changelog       ← merged PRs, new contributors, contributor line
```

## Removed: "All commits"

74 commit subjects for the current range. The generated `What's Changed` section already covers what changed, and a raw dump is noise in something a creator reads.

**Contributors are still derived from `git log`**, not from the generated notes — a large share of this repo's work lands as direct pushes to master, whose authors PR-based generation cannot see. That was the original reason for reading `git log`, and it still holds; only the per-commit list is dropped.

## The "Release Notes" heading sits outside the fence

Deliberate: the `SE_RELEASE_NOTES_BEGIN/END` markers must hold the pristine `RELEASE_NOTES.md` and nothing else, so a promotion can recover it byte for byte and recompose. Putting the heading inside would leak it into every later recomposition.

Added to the fallback path too, so a body composed from recovered notes has the same shape as one built from the travelled artifact.

## Prompt

Now states the audience explicitly — creators who stream and record with OBS, not developers — and asks for observable effects rather than code paths. The previous wording said "streamers rather than developers" without saying what to actually write about, and added an anti-jargon rule.

## Verified locally

Ran the real generators against real history (`26.2.5.549..26.7.29.706`):

- `All commits` occurrences: **0**; raw bullet lines: **0** (was 74)
- Contributors line intact: `Ilya Melamed, Keith Williams, Styler`
- Artifact contains `## What's New` + `## Release Notes` + fence, and **no** changelog — it stays out so the range is recomputed at promotion
- Both publish paths produce the same section order; the fallback emits `## Release Notes` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)