### PR TITLE
fix(ci): use the base action's real inputs so the release summary is generated

### DIFF
--- a/.github/actions/se-release/action.yml
+++ b/.github/actions/se-release/action.yml
@@ -76,6 +76,13 @@ inputs:
     description: 'Claude-generated blurb. Empty when generation failed; the release is then composed without it.'
     required: false
     default: ''
+  summary-file:
+    description: >-
+      Path to a file holding the Claude-generated blurb. Preferred over `summary`:
+      the text never passes through GitHub expression interpolation. Missing or empty
+      means no blurb, and the release is composed without one.
+    required: false
+    default: ''
   dry-run:
     description: 'When true, every mutating gh call is logged instead of executed.'
     required: false
@@ -132,6 +139,7 @@ runs:
         # Model-generated text. Passed as an environment variable and never interpolated
         # into the script body, so it cannot reach the shell as code.
         SE_SUMMARY: ${{ inputs.summary }}
+        SE_SUMMARY_FILE: ${{ inputs.summary-file }}
         DRY_RUN: ${{ inputs.dry-run }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: sh "$SE_ACTION_PATH/dispatch.sh"

--- a/.github/actions/se-release/extract-summary.js
+++ b/.github/actions/se-release/extract-summary.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+//
+// Pull the final assistant text out of claude-code-base-action's execution file.
+//
+// The released base action (v0.0.63) predates the `claude_args` /
+// `structured_output` interface that only exists on main: its outputs are
+// `conclusion` and `execution_file` and nothing else. So there is no JSON schema
+// to constrain the reply and no structured field to read -- the blurb is simply
+// the model's final text, and this recovers it from the transcript.
+//
+// argv: <execution file> <output file>
+//
+// Never fails the build. A missing file, malformed JSON, or an errored run all
+// produce an empty output file, and the release is then composed from notes and
+// changelog alone.
+
+const fs = require('fs');
+
+const [, , execPath, outPath] = process.argv;
+const warn = (m) => console.log(`::warning title=Release summary unavailable::${m}`);
+
+function extract(entries) {
+	// Prefer the terminal result event; it is what the CLI reports as the answer.
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const e = entries[i];
+		if (e && e.type === 'result') {
+			if (e.is_error) {
+				warn(`Claude reported an error: ${String(e.result ?? '').slice(0, 300)}`);
+				return '';
+			}
+			if (typeof e.result === 'string' && e.result.trim()) return e.result;
+		}
+	}
+	// Fall back to the last assistant turn if no result event was written.
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const e = entries[i];
+		if (!e || e.type !== 'assistant' || !Array.isArray(e.message?.content)) continue;
+		const text = e.message.content
+			.filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+			.map((b) => b.text)
+			.join('\n')
+			.trim();
+		if (text) return text;
+	}
+	warn('No assistant text found in the execution transcript.');
+	return '';
+}
+
+let summary = '';
+try {
+	if (!execPath || !fs.existsSync(execPath)) {
+		warn('The Claude step produced no execution file.');
+	} else {
+		const parsed = JSON.parse(fs.readFileSync(execPath, 'utf8'));
+		summary = extract(Array.isArray(parsed) ? parsed : [parsed]);
+	}
+} catch (err) {
+	warn(`Could not read the execution transcript: ${err.message}`);
+}
+
+// Strip any code fence the model wrapped the text in despite being asked not to.
+summary = summary.replace(/^\s*```[a-z]*\n?/i, '').replace(/\n?```\s*$/, '').trim();
+
+fs.mkdirSync(require('path').dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, summary ? `${summary}\n` : '');
+console.log(
+	summary
+		? `::notice::Recovered a ${summary.length}-character release summary.`
+		: '::notice::No release summary; the release will be composed without one.',
+);

--- a/.github/actions/se-release/prerelease.sh
+++ b/.github/actions/se-release/prerelease.sh
@@ -25,10 +25,22 @@ is_version_tag "$TAG" || die "'$TAG' does not look like a version tag (yy.m.d.bu
 # The changelog is deliberately NOT in here. It is cheap to recompute and it is relative
 # to the previous full release, which can differ between build time and promotion time;
 # freezing it would publish a stale range.
+# The blurb arrives either inline or as a file. The file form is preferred: model
+# output never passes through GitHub expression interpolation on that path.
+SUMMARY="${SE_SUMMARY:-}"
+if [ -z "$SUMMARY" ] && [ -n "${SE_SUMMARY_FILE:-}" ] && [ -s "${SE_SUMMARY_FILE:-}" ]; then
+	SUMMARY=$(cat "$SE_SUMMARY_FILE")
+fi
+if [ -n "$SUMMARY" ]; then
+	note "composing the release body with a What's New section"
+else
+	warn "no release summary available; composing from notes and changelog only"
+fi
+
 ARTIFACT="${RUNNER_TEMP:-/tmp}/obs-streamelements.release_notes.md"
 {
-	if [ -n "${SE_SUMMARY:-}" ]; then
-		printf "## What's New\n\n%s\n\n" "$SE_SUMMARY"
+	if [ -n "$SUMMARY" ]; then
+		printf "## What's New\n\n%s\n\n" "$SUMMARY"
 	fi
 	# The heading sits outside the fence on purpose: the fence must hold the pristine
 	# RELEASE_NOTES.md and nothing else, so a promotion can recover it byte for byte.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -715,16 +715,29 @@ jobs:
             - No heading: the workflow adds "## What's New" itself.
             - Plain Markdown, no code fences.
 
-            Return the text as the "summary" field of the JSON response.
-          # --model is pinned because the base action's own default is
-          # claude-sonnet-4-20250514, which is retired -- it fails the run with
-          # `API Error: 404 {"type":"not_found_error","message":"model:
-          # claude-sonnet-4-20250514"}`. Without this the step always fails and
-          # the release publishes with no "What's New" section.
-          claude_args: >-
-            --model claude-opus-5
-            --allowedTools "Read,Glob,Grep"
-            --json-schema '{"type":"object","additionalProperties":false,"required":["summary"],"properties":{"summary":{"type":"string","maxLength":1200}}}'
+            Reply with the blurb text and nothing else -- no preamble, no JSON, no
+            explanation of what you did. Your entire reply is published verbatim.
+          # These are v0.0.63's real inputs. `claude_args` belongs to a newer interface
+          # that exists only on the action's main branch: passing it to this tag logs
+          # "Unexpected input(s) 'claude_args'" and drops it wholesale -- which is why
+          # earlier attempts still ran on the action's default model,
+          # claude-sonnet-4-20250514, and failed with a 404 because that model is
+          # retired. `model` must therefore be set as its own input.
+          model: claude-opus-5
+          allowed_tools: Read,Glob,Grep
+          timeout_minutes: '10'
+
+      # v0.0.63 exposes only `conclusion` and `execution_file` -- there is no
+      # `structured_output`, so the blurb is recovered from the transcript. Writing it
+      # to a file rather than a step output keeps model text out of GitHub expression
+      # interpolation entirely.
+      - name: Extract release summary
+        if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
+        continue-on-error: true
+        run: |
+          node .github/actions/se-release/extract-summary.js \
+            "${{ steps.claude_summary.outputs.execution_file }}" \
+            "${{ github.workspace }}/.release-input/summary.txt"
 
       - name: Create GitHub prerelease
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
@@ -738,9 +751,9 @@ jobs:
           # Also makes the step write obs-streamelements.release_notes.md here, for the
           # CDN upload below.
           output-dir: ${{ github.workspace }}/.release-input
-          # Empty when the step above timed out, failed, or produced no structured
-          # output. Model text reaches the script only as an environment variable.
-          summary: ${{ (steps.claude_summary.outcome == 'success' && steps.claude_summary.outputs.structured_output != '' && fromJSON(steps.claude_summary.outputs.structured_output).summary) || '' }}
+          # Absent or empty whenever generation failed; the body is then composed from
+          # notes + changelog alone.
+          summary-file: ${{ github.workspace }}/.release-input/summary.txt
           dry-run: 'false'
 
       # Publish the blurb + notes next to the manifest in signed/, so promotion can reuse

--- a/RELEASE_NOTES.history.md
+++ b/RELEASE_NOTES.history.md
@@ -1,8 +1,0 @@
-### 26.8.6.754
-
-- Fix: lazy video encoder creation on use to reduce GPU resource consumption
-- Fix: cache encoder basic properties to reduce GPU resource consumption
-- Fix: crash under certain conditions when scenes are changed
-- Fix: use OBS private canvas objects in custom video compositions instead of OBS views directly
-- Fix: adjust unknown encoder video formats to preferred NV12 video format
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+- Fix: lazy video encoder creation on use to reduce GPU resource consumption
+- Fix: cache encoder basic properties to reduce GPU resource consumption
+- Fix: crash under certain conditions when scenes are changed
+- Fix: use OBS private canvas objects in custom video compositions instead of OBS views directly
+- Fix: adjust unknown encoder video formats to preferred NV12 video format


### PR DESCRIPTION
The release summary has never once succeeded. `[BETA] 26.8.6.754` built **after** the model pin merged and still published with no "What's New". The `finalize` log gives the real cause — a **warning**, not an error, which is why it went unnoticed:

```
##[warning]Unexpected input(s) 'claude_args', valid inputs are
['prompt','prompt_file','allowed_tools','disallowed_tools','max_turns',
 'mcp_config','settings','system_prompt','append_system_prompt','model', …]
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

## The tag is far behind `main`

| | `v0.0.63` (newest tag) | `main` |
|---|---|---|
| `claude_args` input | ❌ | ✅ |
| `structured_output` output | ❌ | ✅ |
| outputs available | `conclusion`, `execution_file` | + `structured_output` |

I built against `main`'s documented interface but pinned the newest *released* tag. `claude_args` was therefore dropped wholesale — taking with it both the `--model` pin (leaving the action's retired default → 404) **and** `--json-schema`, which would have left `structured_output` empty even if the model had resolved.

## The fix

- **Use the tag's real inputs**: `model: claude-opus-5`, `allowed_tools`, `timeout_minutes` as discrete inputs. Verified every input against the tag's actual list.
- **Recover the blurb from `execution_file`**, since there is no `structured_output`. `extract-summary.js` prefers the terminal `result` event, falls back to the last assistant turn, strips a stray code fence, and writes an empty file on any failure.
- **Pass it as a file, not a step output** — model text never enters GitHub expression interpolation.
- Prompt now asks for the blurb text directly instead of a JSON `summary` field.

## Verified

`extract-summary.js` against six cases: success, the real `is_error` 404 payload, assistant-turn fallback, code-fence stripping, missing file, malformed JSON — the last four all degrade to empty without failing. Composition tested both ways: with a summary file the body opens `## What's New`; without one it starts at `## Release Notes`.

## Three failures, three unrelated causes

| Build | Cause | Fix |
|---|---|---|
| `26.8.4.735` | Wrapper action rejects `push` events | base action (#88) |
| `26.8.6.748` | Base action defaults to a retired model | pin `--model` (#91) |
| `26.8.6.754` | `claude_args` isn't an input on the pinned tag | this PR |

Each was invisible outside the run log: the guard degrades cleanly, so the release publishes with notes + changelog and the step reports `success` under `continue-on-error`. Correct behaviour, but it means **the next build with notes should be checked directly** rather than assumed fixed — this is the third attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)