### PR TITLE
feat(ci): attach platform installers to releases, and cache-bust manifest URLs

### DIFF
--- a/.github/actions/se-release/action.yml
+++ b/.github/actions/se-release/action.yml
@@ -6,8 +6,16 @@ description: >-
 
 inputs:
   mode:
-    description: 'prevtag | prerelease | resolve | changelog | publish | rollback'
+    description: 'prevtag | prerelease | assets | resolve | changelog | publish | rollback'
     required: true
+  platforms:
+    description: 'Space-separated platforms to attach installers for (mode=assets).'
+    required: false
+    default: 'windows macos'
+  channel:
+    description: 'CDN channel the installers are read from (mode=assets).'
+    required: false
+    default: 'signed'
   github-token:
     description: 'Token used for all gh calls. Needs contents: write.'
     required: true
@@ -126,6 +134,8 @@ runs:
         SE_VERSION_ENCODED: ${{ inputs.version-encoded }}
         SE_MANIFEST: ${{ inputs.manifest }}
         SE_PLATFORM: ${{ inputs.platform }}
+        SE_PLATFORMS: ${{ inputs.platforms }}
+        SE_CHANNEL: ${{ inputs.channel }}
         SE_TO: ${{ inputs.to }}
         SE_IS_ROLLBACK: ${{ inputs.is-rollback }}
         SE_OUTPUT_DIR: ${{ inputs.output-dir }}

--- a/.github/actions/se-release/attach-assets.sh
+++ b/.github/actions/se-release/attach-assets.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# mode=assets -- attach the platform installers to a GitHub release.
+#
+# The installers themselves live on the CDN; the manifest is what says which files
+# belong to a build, so the URLs are read from there rather than reconstructed from the
+# version. That keeps this correct if the installer naming convention ever changes --
+# the manifest is the contract the updater already relies on.
+#
+# env: SE_TAG, SE_VERSION_ENCODED, SE_PLATFORMS, SE_CHANNEL, GH_TOKEN, DRY_RUN
+set -eu
+. "$SE_ACTION_PATH/lib.sh"
+
+TAG="${SE_TAG:?mode=assets requires 'tag'}"
+ENCODED="${SE_VERSION_ENCODED:?mode=assets requires 'version-encoded'}"
+CHANNEL="${SE_CHANNEL:-signed}"
+PLATFORMS="${SE_PLATFORMS:-windows macos}"
+WORK="${RUNNER_TEMP:-/tmp}/se-assets"
+mkdir -p "$WORK"
+
+attached=0
+skipped=0
+
+for platform in $PLATFORMS; do
+	manifest="$WORK/$platform.manifest"
+
+	if ! fetch_channel_manifest "$platform" "$CHANNEL" "$manifest"; then
+		warn "no '$CHANNEL' manifest for $platform; no installers attached for it"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	if ! found=$(manifest_version_number "$manifest"); then
+		warn "could not read a version from the $platform '$CHANNEL' manifest"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	# The channel is a moving pointer: by the time this runs, a newer build may already
+	# have published over it. Attaching then would ship someone else's installers under
+	# this release's tag, which is worse than shipping none.
+	if [ "$found" != "$ENCODED" ]; then
+		warn "$platform/$CHANNEL now holds $found but this release is $ENCODED; skipping so the wrong build's installers are not attached"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	urls=$(manifest_package_urls "$manifest") || urls=""
+	if [ -z "$urls" ]; then
+		warn "no package_url entries in the $platform '$CHANNEL' manifest"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	for url in $urls; do
+		name=$(basename "$url")
+		file="$WORK/$name"
+
+		if ! curl -fsSL --max-time 600 -o "$file" "$url"; then
+			warn "could not download $url"
+			skipped=$((skipped + 1))
+			continue
+		fi
+
+		# A CDN error page is a 200 with a small HTML body; an installer never is.
+		size=$(wc -c < "$file" | tr -d ' ')
+		if [ "$size" -lt 102400 ]; then
+			warn "$name is only $size bytes -- not a plausible installer; skipping"
+			skipped=$((skipped + 1))
+			continue
+		fi
+
+		note "attaching $name ($((size / 1048576)) MiB) to $TAG"
+		# --clobber so re-running finalize replaces rather than duplicates.
+		if gh_write release upload "$TAG" "$file" --clobber; then
+			attached=$((attached + 1))
+		else
+			warn "failed to upload $name to $TAG"
+			skipped=$((skipped + 1))
+		fi
+	done
+done
+
+if [ "$attached" -eq 0 ]; then
+	warn "no installers were attached to $TAG. The release is still valid -- notes and changelog are unaffected -- but users cannot download binaries from it."
+else
+	note "attached $attached installer(s) to $TAG ($skipped skipped)"
+fi

--- a/.github/actions/se-release/dispatch.sh
+++ b/.github/actions/se-release/dispatch.sh
@@ -9,8 +9,9 @@ set -eu
 case "${SE_MODE:-}" in
 prevtag) sh "$SE_ACTION_PATH/prevtag.sh" ;;
 prerelease) sh "$SE_ACTION_PATH/prerelease.sh" ;;
+assets) sh "$SE_ACTION_PATH/attach-assets.sh" ;;
 resolve) sh "$SE_ACTION_PATH/resolve.sh" ;;
 changelog) sh "$SE_ACTION_PATH/changelog.sh" ;;
 publish | rollback) sh "$SE_ACTION_PATH/publish.sh" ;;
-*) die "unknown mode '${SE_MODE:-}' (expected: prevtag, prerelease, resolve, changelog, publish, rollback)" ;;
+*) die "unknown mode '${SE_MODE:-}' (expected: prevtag, prerelease, assets, resolve, changelog, publish, rollback)" ;;
 esac

--- a/.github/actions/se-release/lib.sh
+++ b/.github/actions/se-release/lib.sh
@@ -66,6 +66,26 @@ manifest_version_number() {
 	printf '%s\n' "$_n"
 }
 
+# Echo every distinct package_url* value from an INI manifest, one per line.
+#
+# Logs nothing: callers capture stdout, so a stray note() here would end up in the
+# returned list. Same parsing traps as manifest_version_number -- CRLF, and the HTML
+# release-notes blob that follows the marker. The ?ts= cache-buster is stripped so the
+# value can be used as a filename; it plays no part in fetching.
+#
+# Windows manifests repeat a URL across fields (package_url and package_url_32 are the
+# same installer), and on macOS all three point at the same .pkg, so the list is deduped
+# with the first occurrence winning.
+manifest_package_urls() {
+	_f="$1"
+	[ -r "$_f" ] || return 1
+	tr -d '\r' < "$_f" |
+		awk '/^\[\[\[BEGIN_RELEASE_NOTES\]\]\]/ { exit } { print }' |
+		sed -n 's#^[[:space:]]*package_url[a-z0-9_]*[[:space:]]*=[[:space:]]*\(https\{0,1\}://[^[:space:]]*\).*$#\1#p' |
+		sed 's/?.*$//' |
+		awk 'NF && !seen[$0]++'
+}
+
 # Fetch a channel manifest to a local path. Cache-busted: the promotion upload sets
 # cache-control max-age=60, so a read shortly after a promotion can otherwise be stale.
 # Returns non-zero (without dying) when the channel has no manifest.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,6 +455,7 @@ jobs:
           export signedPackageFilename=obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}
           export signedPackageFilename64=obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}-64bit
           export signedPackageFilename32=obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}
+          export manifestTs=${{ needs.version.outputs.version_encoded }}
 
           for manifest in obs-streamelements.manifest obs-streamelements.qa.manifest obs-streamelements.beta.manifest obs-streamelements.latest.manifest obs-streamelements.stable.manifest
           do
@@ -463,6 +464,14 @@ jobs:
             sed -i "s/\${PACKAGE_FILENAME}/$signedPackageFilename/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_64_BIT}/$signedPackageFilename64/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_32_BIT}/$signedPackageFilename32/" $manifest
+
+            # Cache-buster, appended once the URLs are final. It matters most on
+            # `stable`, whose installer filename carries no version -- without it a CDN
+            # or client cache can keep serving the previous build from an unchanged URL.
+            # Keyed to the build rather than the clock so the same build always yields
+            # the same URL and stays cacheable. Only package_url* lines are touched, and
+            # only those that don't already carry a query string.
+            sed -i -E "s#^(package_url[a-z0-9_]*=[^?[:space:]]+)(\r?)\$#\1?ts=$manifestTs\2#" $manifest
 
             cat $manifest
           done
@@ -558,6 +567,7 @@ jobs:
       - name: Prepare files
         run: |
           export signedPackageFilename=obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}
+          export manifestTs=${{ needs.version.outputs.version_encoded }}
 
           for manifest in obs-streamelements.manifest obs-streamelements.qa.manifest obs-streamelements.beta.manifest obs-streamelements.latest.manifest obs-streamelements.stable.manifest
           do
@@ -568,6 +578,9 @@ jobs:
             sed -i "s/\${PACKAGE_FILENAME}/$signedPackageFilename/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_64_BIT}/$signedPackageFilename/" $manifest
             sed -i "s/\${PACKAGE_FILENAME_32_BIT}/$signedPackageFilename/" $manifest
+
+            # Cache-buster; see the matching comment in deploy-signed-windows.
+            sed -i -E "s#^(package_url[a-z0-9_]*=[^?[:space:]]+)(\r?)\$#\1?ts=$manifestTs\2#" $manifest
 
             cat $manifest
           done
@@ -754,6 +767,22 @@ jobs:
           # Absent or empty whenever generation failed; the body is then composed from
           # notes + changelog alone.
           summary-file: ${{ github.workspace }}/.release-input/summary.txt
+          dry-run: 'false'
+
+      # Attach the signed installers. Runs after the release exists and after
+      # deploy-signed-* has published them, reading the URLs from the manifest rather
+      # than rebuilding them from the version -- the manifest is the contract the
+      # in-app updater already follows, so the release ships exactly what it points at.
+      # Best-effort: a failure here leaves the release valid, just without binaries.
+      - name: Attach installers to the release
+        if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/se-release
+        with:
+          mode: assets
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.version.outputs.version_string }}
+          version-encoded: ${{ needs.version.outputs.version_encoded }}
           dry-run: 'false'
 
       # Publish the blurb + notes next to the manifest in signed/, so promotion can reuse


### PR DESCRIPTION
Two changes to the release pipeline.

## 1. Installers attached to releases

Releases now carry the signed binaries as assets, read from the manifest's `package_url*` fields rather than reconstructed from the version — so a release ships exactly what the in-app updater is pointed at, and follows any future change to the installer naming convention automatically.

**Deduplication is required, not cosmetic.** In the live `signed/` manifests:

```
windows  package_url    …-setup-<v>.exe
         package_url_64 …-setup-<v>-64bit.exe
         package_url_32 …-setup-<v>.exe      ← identical to package_url
macos    package_url    …-setup-<v>.pkg      ← _32/_64 absent here, identical when present
```

Without dedup the same file would upload two or three times. Dry-run against live `signed/` gives **2 Windows installers + 1 macOS pkg, 0 skipped** (27 MiB, 16 MiB, 3 MiB).

**Version guard.** The channel is a moving pointer — a newer build can publish over `signed/` between `deploy-signed-*` and `finalize`. Attaching then would ship another build's binaries under this tag. If the manifest version no longer matches the release, nothing is attached and the step says why:

```
::warning::windows/signed now holds 20260806000759 but this release is 20260806000999;
skipping so the wrong build's installers are not attached
```

There's also a size floor (a CDN error page is a 200 with a small HTML body; an installer never is) and `--clobber` so a re-run replaces rather than duplicates.

## 2. `?ts=` cache-buster on manifest URLs

Added where the URLs become final, in both `deploy-signed-*` jobs.

It matters most on **`stable`**, whose installer filename carries no version — an unchanged URL there can keep serving the previous build from a CDN or client cache. Keyed to the build rather than the clock, so the same build always yields the same URL and stays cacheable.

Verified against a real (CRLF) manifest: all three `package_url*` updated, `version_number` and `package_arguments_g2` untouched, idempotent on a second pass, CRLF preserved. The `(\r?)…\2` in the expression is deliberate — `$` won't match after a trailing `\r`, so without it the substitution would silently no-op on a CRLF manifest.

## Failure behaviour

Attachment is `continue-on-error`. A CDN hiccup leaves the release valid — notes and changelog unaffected — and warns loudly rather than failing a build whose tag and notes rotation have already happened. **If you'd rather a missing installer hard-fail the build, say so** and I'll flip it; I chose the softer option because the failure arrives after the irreversible steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)