### PR TITLE
feat(ci): track SE.Live releases in Linear at the beta and latest hops (CORE-266)

### DIFF
--- a/.github/actions/se-release/action.yml
+++ b/.github/actions/se-release/action.yml
@@ -106,6 +106,12 @@ outputs:
   previous_tag:
     description: 'Tag of the previous full release, or empty.'
     value: ${{ steps.run.outputs.previous_tag }}
+  previous_channel_tag:
+    description: >-
+      Tag the destination channel served before this promotion, read before the upload
+      overwrote it. Used as the Linear commit-scan base on `qa -> beta`. Empty when that
+      version is unknown, untagged, or not older than the one being promoted.
+    value: ${{ steps.run.outputs.previous_channel_tag }}
   is_prerelease:
     description: 'Whether the release for this tag is currently a prerelease.'
     value: ${{ steps.run.outputs.is_prerelease }}

--- a/.github/actions/se-release/resolve.sh
+++ b/.github/actions/se-release/resolve.sh
@@ -79,6 +79,50 @@ if [ "$IS_ROLLBACK" = "true" ]; then
 	exit 0
 fi
 
+# -------------------------------------------------------------------- Linear sync base
+# `qa -> beta` is the hop at which a build becomes something worth announcing, so that is
+# where release.yml creates the Linear release for it. The commit scan needs a lower
+# bound, and the honest one is "whatever beta served until a moment ago" -- which is the
+# version sitting on the destination channel right now. Reading it here rather than after
+# the upload is the same ordering constraint the rollback path has, for the same reason:
+# the upload is about to overwrite it with the version being promoted.
+#
+# Windows and macOS promote separately, so the second platform through reads back the
+# first one's upload and resolves an empty range. That is correct rather than a bug: the
+# issues were attached on the first pass and `sync` for the same version adds nothing.
+#
+# Nothing below this point applies to a beta promotion -- no release is created or
+# relabelled there, so requirement 10 must not fire and there is no changelog to base.
+if [ "${SE_TO:-}" = "beta" ]; then
+	BASE=""
+	beta="${RUNNER_TEMP:-/tmp}/se-beta-$PLATFORM.manifest"
+	# stderr is dropped because manifest_version_number reports a parse failure with
+	# die(), and an ::error:: annotation would misrepresent what is only a missing lower
+	# bound: the CLI falls back to its own scan base and the sync still happens.
+	if fetch_channel_manifest "$PLATFORM" beta "$beta" && B=$(manifest_version_number "$beta" 2> /dev/null); then
+		if [ "$B" -ge "$ENCODED" ]; then
+			note "linear: $PLATFORM/beta already serves $B (>= $ENCODED); no new commits to scan"
+		else
+			BASE=$(decode_version "$B")
+			note "linear: $PLATFORM/beta serves $B; scanning $BASE..$TAG"
+		fi
+	else
+		warn "linear: no readable version on $PLATFORM/beta; the CLI will choose its own scan base"
+	fi
+
+	# The scan is `git log <base>..<tag>`, so the lower bound has to exist as a tag in
+	# this clone. Not every version that reached a channel was tagged -- windows/stable
+	# references 20241127000268 and tag 24.11.27.268 was never pushed -- so this is a live
+	# condition rather than a hypothetical.
+	if [ -n "$BASE" ] && ! git rev-parse -q --verify "refs/tags/$BASE^{commit}" > /dev/null 2>&1; then
+		warn "linear: tag '$BASE' is not present in this clone; the CLI will choose its own scan base"
+		BASE=""
+	fi
+
+	emit previous_channel_tag "$BASE"
+	exit 0
+fi
+
 # ------------------------------------------------------------------ requirement 10
 # A version may not reach `latest` without a release. The usual cause is a build whose
 # RELEASE_NOTES.md was empty: build.yml then skips both the tag and the prerelease, so

--- a/.github/workflows/linear-issue-key.yml
+++ b/.github/workflows/linear-issue-key.yml
@@ -1,0 +1,287 @@
+name: Linear Issue Key
+
+# master is squash-merged, so a merged PR's commit subject keeps only `(#93)` and the
+# branch name that carried the Linear key is gone for good. `release.yml` recovers the
+# issues at `qa -> beta` by resolving that `(#93)` back to its pull request and reading
+# whatever Linear linked to it -- and Linear links from the branch name, the PR title, or
+# a magic word in the PR body. If none of the three carried a key while the PR was open,
+# the work is invisible in release tracking forever after.
+#
+# Measured before this existed: over 26.2.5.549..26.8.6.759 the CLI detected all 18 pull
+# requests and zero issues, because not one of them carried a key anywhere.
+#
+# Two jobs, in order of trust:
+#
+#   check    literal string match, no model involved. Cannot mislink.
+#   suggest  runs only when check found nothing. Reads the diff against the team's open
+#            issues and proposes a key for a human to accept.
+#
+# The split is deliberate. A wrong link is worse than a missing one -- an issue attached
+# to the wrong release is a silent error, whereas an unlinked PR is merely absent -- so
+# the model never gets to decide on its own unless someone explicitly opts in.
+
+on:
+  pull_request:
+    # `edited` matters: it is what lets an author fix a failing check by editing the
+    # title or body, rather than having to push a commit.
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Linear issue key present
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_key: ${{ steps.scan.outputs.has_key }}
+      key: ${{ steps.scan.outputs.key }}
+      exempt: ${{ steps.scan.outputs.exempt }}
+    steps:
+      - name: Scan branch, title and body for an issue key
+        id: scan
+        env:
+          # Every one of these is attacker-controlled text on a fork PR, so none of them
+          # is interpolated into the script body -- they arrive as environment variables
+          # and are only ever read by grep.
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          TITLE: ${{ github.event.pull_request.title }}
+          BODY: ${{ github.event.pull_request.body }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY || 'CORE' }}
+        run: |
+          set -eu
+
+          # Linear itself is case-insensitive here: `jacob/core-266-...` links just as
+          # `CORE-266` does, and the existing branches use lowercase.
+          pattern="\\b${TEAM_KEY}-[0-9]+\\b"
+
+          key=$(printf '%s\n%s\n%s\n' "$BRANCH" "$TITLE" "$BODY" |
+                grep -oiE "$pattern" | head -n 1 | tr '[:lower:]' '[:upper:]')
+
+          exempt=false
+          case "$ACTOR" in
+          *'[bot]' | dependabot | renovate) exempt=true ;;
+          esac
+          case ",$LABELS," in
+          *,no-linear-issue,*) exempt=true ;;
+          esac
+
+          {
+            echo "has_key=$([ -n "$key" ] && echo true || echo false)"
+            echo "key=$key"
+            echo "exempt=$exempt"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$key" ]; then
+            echo "::notice::$key found; Linear will link this PR to it"
+            exit 0
+          fi
+
+          if [ "$exempt" = "true" ]; then
+            echo "::notice::no ${TEAM_KEY} key, but this PR is exempt (bot author or no-linear-issue label)"
+            exit 0
+          fi
+
+          echo "::error::No ${TEAM_KEY}-nnn key in the branch name, PR title, or PR body. Linear links a PR to an issue from one of those three, and master is squash-merged -- once this lands, the branch name is gone and the work cannot be traced to an issue. Fix it by renaming the branch to carry the key (jacob/core-266-short-description), or by adding a line like 'Fixes ${TEAM_KEY}-266' to the PR body. Label the PR 'no-linear-issue' if it genuinely has no issue behind it."
+          exit 1
+
+  suggest:
+    name: Suggest a Linear issue key
+    needs: check
+    # always(), because `check` fails by design when there is no key -- which is exactly
+    # when this job is useful. Fork PRs are excluded: they get no secrets and only a
+    # read-only token, so every step below would fail.
+    if: >-
+      always() &&
+      needs.check.outputs.has_key == 'false' &&
+      needs.check.outputs.exempt == 'false' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Check for a Linear API key
+        id: gate
+        env:
+          # LINEAR_ACCESS_KEY, used by release.yml, is a release-pipeline key and cannot
+          # read issues. This needs a separate personal or workspace API key.
+          HAS_KEY: ${{ secrets.LINEAR_API_KEY != '' }}
+        run: |
+          set -eu
+          echo "ok=$HAS_KEY" >> "$GITHUB_OUTPUT"
+          [ "$HAS_KEY" = "true" ] ||
+            echo "::warning::LINEAR_API_KEY is not set, so no issue suggestion can be made. Add a Linear API key to repository secrets to enable it."
+
+      # Shallow on purpose. Everything the model needs about the diff comes from the API
+      # below -- file paths and commit subjects -- so there is no reason to pay for this
+      # repo's ~120 MB of history. The checkout exists only to give the action a
+      # workspace to read and write files in.
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.ok == 'true'
+        with:
+          fetch-depth: 1
+
+      - name: Collect the PR and the team's open issues
+        if: steps.gate.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY || 'CORE' }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          mkdir -p .linear
+
+          # Written to files rather than into the prompt. The title and body are
+          # author-controlled, and a prompt built by string interpolation would let a PR
+          # description issue instructions to the model.
+          gh pr view "$PR" --json title,body,headRefName \
+            -q '"# Title\n" + .title + "\n\n# Branch\n" + .headRefName + "\n\n# Description\n" + (.body // "(none)")' \
+            > .linear/pr.md
+
+          {
+            echo
+            echo "# Files changed"
+            gh pr view "$PR" --json files \
+              -q '.files[] | "- \(.path) (+\(.additions)/-\(.deletions))"' | head -n 200
+            echo
+            echo "# Commit subjects"
+            gh pr view "$PR" --json commits \
+              -q '.commits[].messageHeadline | "- " + .' | head -n 100
+          } >> .linear/pr.md
+
+          # Parameterised rather than interpolated, so a team key with a quote in it
+          # cannot break out of the query.
+          q='query($team:String!){ issues(first:200, orderBy:updatedAt, filter:{ team:{ key:{ eq:$team } }, completedAt:{ null:true }, canceledAt:{ null:true } }){ nodes { identifier title description state { name } } } }'
+          jq -n --arg q "$q" --arg team "$TEAM_KEY" '{query:$q, variables:{team:$team}}' > .linear/query.json
+
+          curl -sS --fail-with-body -X POST https://api.linear.app/graphql \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -d @.linear/query.json > .linear/raw.json
+
+          if jq -e '.errors' .linear/raw.json > /dev/null 2>&1; then
+            echo "::error::Linear API returned errors:"
+            jq -c '.errors' .linear/raw.json
+            exit 1
+          fi
+
+          # Descriptions can run to thousands of words; the first 600 characters carry
+          # enough to match against a diff.
+          jq '[.data.issues.nodes[] | {identifier, title, state: .state.name,
+               description: ((.description // "") | .[0:600])}]' \
+            .linear/raw.json > .linear/issues.json
+
+          echo "::notice::$(jq 'length' .linear/issues.json) open $TEAM_KEY issues to match against"
+
+      - name: Match the PR against the open issues
+        if: steps.gate.outputs.ok == 'true'
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        # Same reason as claude-code-review.yml: background subagents make the action
+        # stop reading the stream early and report success with nothing written.
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Read,Write,Glob,Grep" --model claude-opus-5'
+          # Static text. Everything the model reads about this PR comes from files, so
+          # nothing author-controlled reaches the prompt itself.
+          prompt: |
+            Read `.linear/pr.md` (a pull request) and `.linear/issues.json` (the open
+            issues on this team). Decide which issue, if any, this pull request is the
+            work for.
+
+            Judge on substance, not vocabulary. A shared word is not a match; the PR must
+            plausibly be the implementation of the issue. Most pull requests will match
+            nothing, and saying so is the correct answer -- a wrong link is worse than no
+            link, because it attaches the work to the wrong release and nobody notices.
+
+            Write `.linear/suggestion.json` and nothing else:
+
+            {
+              "recommendation": "CORE-123" | null,
+              "confidence": "high" | "medium" | "low",
+              "reason": "one sentence, naming the specific evidence",
+              "alternatives": [{"identifier": "CORE-456", "why": "one clause"}]
+            }
+
+            Set "recommendation" to null unless one issue clearly stands out. Use "high"
+            only when the PR is unmistakably that issue's implementation. Put near-misses
+            in "alternatives" (at most three) instead of promoting them.
+
+      - name: Post the suggestion
+        if: steps.gate.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY || 'CORE' }}
+          # Opt-in, and off by default. With it on, a high-confidence single match is
+          # written straight into the PR body; otherwise the comment just says what to
+          # paste. See the note at the top about wrong links being the expensive failure.
+          AUTO_LINK: ${{ vars.LINEAR_AUTO_LINK }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+        run: |
+          set -eu
+
+          if [ "$CLAUDE_OUTCOME" != "success" ] || [ ! -s .linear/suggestion.json ]; then
+            echo "::warning::no suggestion was produced (claude outcome: $CLAUDE_OUTCOME); the check failure stands on its own"
+            exit 0
+          fi
+
+          rec=$(jq -r '.recommendation // empty' .linear/suggestion.json)
+          conf=$(jq -r '.confidence // "low"' .linear/suggestion.json)
+          reason=$(jq -r '.reason // ""' .linear/suggestion.json)
+
+          {
+            echo "### No Linear issue key on this PR"
+            echo
+            if [ -n "$rec" ]; then
+              printf '**%s** looks like the issue behind this work (confidence: %s).\n\n' "$rec" "$conf"
+              printf '> %s\n\n' "$reason"
+              printf 'To link it, add this line to the PR description:\n\n```\nFixes %s\n```\n\n' "$rec"
+            else
+              echo "I could not identify an issue this PR implements."
+              # `[ -n ... ] && printf` would be the obvious form, but its exit status is
+              # non-zero when the reason is empty and `set -e` would kill the script
+              # mid-comment.
+              if [ -n "$reason" ]; then printf '\n> %s\n' "$reason"; fi
+              echo
+            fi
+
+            if [ "$(jq -r '.alternatives // [] | length' .linear/suggestion.json)" -gt 0 ]; then
+              echo "Other candidates:"
+              jq -r '.alternatives[] | "- **\(.identifier)** — \(.why)"' .linear/suggestion.json
+              echo
+            fi
+
+            printf 'If this PR genuinely has no issue behind it, add the `no-linear-issue` label and the check will pass.\n\n'
+            printf -- '---\n<sub>Suggested by Claude. Nothing was linked automatically%s.</sub>\n' \
+              "$([ "${AUTO_LINK:-}" = 'true' ] && echo ' unless stated above' || echo '')"
+          } > .linear/comment.md
+
+          # One comment per PR rather than one per push: re-running on `synchronize`
+          # would otherwise bury the conversation.
+          existing=$(gh pr view "$PR" --json comments \
+            -q '.comments[] | select(.body | contains("### No Linear issue key on this PR")) | .url' |
+            tail -n 1)
+
+          if [ -n "$existing" ]; then
+            gh pr comment "$PR" --edit-last --body-file .linear/comment.md
+          else
+            gh pr comment "$PR" --body-file .linear/comment.md
+          fi
+
+          if [ "${AUTO_LINK:-}" = 'true' ] && [ -n "$rec" ] && [ "$conf" = 'high' ]; then
+            body=$(gh pr view "$PR" --json body -q '.body // ""')
+            printf '%s\n\nFixes %s\n' "$body" "$rec" > .linear/body.md
+            gh pr edit "$PR" --body-file .linear/body.md
+            echo "::notice::LINEAR_AUTO_LINK is on and confidence is high; wrote 'Fixes $rec' into the PR body"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ on:
         default: true
         required: true
 
+      linear-dry-run:
+        description: >-
+          Scan commits and read from Linear, but write nothing to it. Separate from
+          dry-run so a real promotion can still leave Linear untouched while the issue
+          detection is being validated. A dry-run promotion forces this on regardless.
+        type: boolean
+        default: true
+        required: true
+
       is-rollback:
         type: boolean
         default: false
@@ -54,9 +63,20 @@ jobs:
     # latest -> beta is deliberately absent. It copies latest's manifest onto `beta` and
     # leaves `latest` serving the same build, so nothing is taken away from users and no
     # release changes.
+    #
+    # Linear tracks one more hop than GitHub does. `qa -> beta` creates no release here --
+    # nothing has shipped to anyone yet -- but it is the point at which the build is worth
+    # announcing, so it is where the Linear release is created and its issues attached.
     env:
       SE_PROMOTE: ${{ github.event.inputs.to == 'latest' && github.event.inputs.is-rollback != 'true' }}
       SE_ROLLBACK: ${{ github.event.inputs.is-rollback == 'true' && github.event.inputs.from == 'stable' && github.event.inputs.to == 'latest' }}
+      SE_LINEAR_BETA: ${{ github.event.inputs.to == 'beta' && github.event.inputs.is-rollback != 'true' }}
+      # Skips the Linear steps entirely rather than failing them, so the workflow stays
+      # usable in a fork or a clone that has no pipeline access key.
+      SE_HAS_LINEAR: ${{ secrets.LINEAR_ACCESS_KEY != '' }}
+      # A dry-run promotion must not write to Linear either -- otherwise rehearsing a
+      # promotion would leave a real release behind.
+      SE_LINEAR_DRY_RUN: ${{ (github.event.inputs.dry-run == 'true' || github.event.inputs.linear-dry-run == 'true') && 'true' || 'false' }}
 
     steps:
       - name: debug
@@ -208,7 +228,7 @@ jobs:
       # ---------------------------------------------------------------------------
       - name: Resolve version, tag and previous full release
         id: version
-        if: env.SE_PROMOTE == 'true' || env.SE_ROLLBACK == 'true'
+        if: env.SE_PROMOTE == 'true' || env.SE_ROLLBACK == 'true' || (env.SE_LINEAR_BETA == 'true' && env.SE_HAS_LINEAR == 'true')
         uses: ./.github/actions/se-release
         with:
           mode: resolve
@@ -309,6 +329,101 @@ jobs:
           displaced-tag: ${{ steps.version.outputs.displaced_tag }}
           should-revert: ${{ steps.version.outputs.should_revert }}
           dry-run: ${{ github.event.inputs.dry-run }}
+
+      # ---------------------------------------------------------------------------
+      # Linear release tracking. Two hops matter, mirroring how the channels are used:
+      #
+      #   qa -> beta      the build becomes announceable: create the Linear release for
+      #                   this version and attach every issue resolved since the build
+      #                   beta served until a moment ago
+      #   beta -> latest  the build reaches everyone: complete that release
+      #
+      # All of it runs after the CDN uploads and after the GitHub release, and every step
+      # is continue-on-error. Issue bookkeeping must never be able to hold up a promotion,
+      # least of all during an incident.
+      #
+      # Issue detection is the part to watch. Linear keys do not appear in this repo's
+      # commit subjects -- master is squash-merged, so subjects read `feat(ci): ... (#93)`
+      # and the branch name that carried the key is gone. The CLI bridges that by
+      # resolving the `(#93)` reference to its pull request and reading the issues Linear
+      # linked to it, which works only for PRs whose branch carried a key. Coverage is
+      # therefore a branch-naming question; issue_pattern is additive and catches keys
+      # written into the subject by hand.
+      # ---------------------------------------------------------------------------
+      - name: Check out the promoted build
+        id: linear_checkout
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_LINEAR_BETA == 'true'
+        continue-on-error: true
+        env:
+          TAG: ${{ steps.version.outputs.version_string }}
+        run: |
+          # The commit scan is relative to HEAD, and HEAD is master -- which has moved on
+          # since this build was made. Detach onto the tag so the range is the one that
+          # was actually promoted.
+          if git rev-parse -q --verify "refs/tags/$TAG^{commit}" > /dev/null; then
+            git checkout --detach --quiet "refs/tags/$TAG"
+            echo "ok=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::tag $TAG is not present in this clone; skipping the Linear sync"
+            echo "ok=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Sync Linear release
+        id: linear_sync
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_LINEAR_BETA == 'true' && steps.linear_checkout.outputs.ok == 'true'
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          # Only `sync` sets a version on a release; `update` and `complete` select an
+          # existing one. Passing it explicitly at every hop is what lets the beta and
+          # latest promotions of the same build agree on which release they mean.
+          version: ${{ steps.version.outputs.version_string }}
+          name: SE.Live ${{ steps.version.outputs.version_string }}
+          # Empty when the previous beta version is unknown or untagged, in which case the
+          # CLI falls back to its own scan base.
+          base_ref: ${{ steps.version.outputs.previous_channel_tag }}
+          # The blurb and notes composed at build time, which have travelled with the
+          # manifest through every channel. Skipped when the source channel only had the
+          # "no release notes" placeholder -- there is no point copying that into Linear.
+          release_notes: ${{ steps.download.outputs.has_release_notes == 'true' && format('{0}/obs-streamelements.release_notes.md', github.workspace) || '' }}
+          links: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version_string }}
+          # Scoped to the team prefix on purpose. A generic [A-Z]+-[0-9]+ also matches
+          # UTF-8, SHA-256 and every other hyphenated token in a commit subject.
+          issue_pattern: ${{ vars.LINEAR_ISSUE_PATTERN || '\b(CORE-[0-9]+)\b' }}
+          dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
+          log_level: verbose
+
+      # The SE.Live pipeline currently has only Planned / In Progress / Released, so there
+      # is no stage that means "on the beta channel" and this step stays dormant. Add one
+      # in Linear and set the LINEAR_BETA_STAGE repository variable to its name to switch
+      # it on; nothing here needs to change.
+      - name: Move Linear release to the beta stage
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_LINEAR_BETA == 'true' && vars.LINEAR_BETA_STAGE != '' && steps.linear_sync.outcome == 'success'
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: update
+          version: ${{ steps.version.outputs.version_string }}
+          stage: ${{ vars.LINEAR_BETA_STAGE }}
+          dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
+          log_level: verbose
+
+      # Reaching `latest` on either platform is what makes a build everyone's, so this
+      # mirrors requirement 1: the first platform through completes the release and the
+      # second one is a no-op on an already-completed release.
+      - name: Complete Linear release
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_PROMOTE == 'true'
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ steps.version.outputs.version_string }}
+          dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
+          log_level: verbose
 
       - name: Prune old versions from VirusTotal Monitor
         uses: streamelements/virustotal-monitor-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,8 +389,12 @@ jobs:
           # "no release notes" placeholder -- there is no point copying that into Linear.
           release_notes: ${{ steps.download.outputs.has_release_notes == 'true' && format('{0}/obs-streamelements.release_notes.md', github.workspace) || '' }}
           links: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version_string }}
-          # Scoped to the team prefix on purpose. A generic [A-Z]+-[0-9]+ also matches
-          # UTF-8, SHA-256 and every other hyphenated token in a commit subject.
+          # Additive to the CLI's built-in detection, and scoped to the team prefix so it
+          # contributes nothing but CORE keys. It does not suppress the built-in subject
+          # scan, which is broader: the first dry-run over this range reported an issue
+          # named UTF-8, matched out of `fix: UTF-8 output into manifests`. That is
+          # cosmetic -- identifiers absent from the workspace are ignored server-side --
+          # and it is not something this input can turn off.
           issue_pattern: ${{ vars.LINEAR_ISSUE_PATTERN || '\b(CORE-[0-9]+)\b' }}
           dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
           log_level: verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Format only the files you edited: `clang-format -i -style=file -fallback-style=n
 ## Git
 
 - Never commit to `master`. Branch and open a PR (`gh pr create`), even for small fixes.
-- **Put the Linear issue key in the branch name** (`jacob/core-266-track-selive-releases`). Linear links the PR to the issue from that name, and the `qa -> beta` promotion attaches those issues to the Linear release. master is squash-merged, so a branch without a key leaves the work untraceable — the commit subject keeps only `(#93)`, and that PR links to nothing.
+- **Put the Linear issue key in the branch name** (`jacob/core-266-track-selive-releases`). Linear links the PR to the issue from that name, and the `qa -> beta` promotion attaches those issues to the Linear release. master is squash-merged, so a branch without a key leaves the work untraceable — the commit subject keeps only `(#93)`, and that PR links to nothing. `linear-issue-key.yml` enforces this and will suggest an issue when it fails; label a PR `no-linear-issue` if there genuinely isn't one. A key in the PR title or a `Fixes CORE-266` line in the body works too.
 - Conventional Commits: `fix:`, `feat:`, with scopes where they apply (`fix(ci):`, `fix(workflow):`).
 - **Never start a commit message with `[WORKFLOW-AUTOMATION]`** — CI uses that prefix to recognize its own commits and skip the build.
 - `RELEASE_NOTES.md` must be non-empty for a master build to tag a release. Use `/release-prep`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Format only the files you edited: `clang-format -i -style=file -fallback-style=n
 ## Git
 
 - Never commit to `master`. Branch and open a PR (`gh pr create`), even for small fixes.
+- **Put the Linear issue key in the branch name** (`jacob/core-266-track-selive-releases`). Linear links the PR to the issue from that name, and the `qa -> beta` promotion attaches those issues to the Linear release. master is squash-merged, so a branch without a key leaves the work untraceable — the commit subject keeps only `(#93)`, and that PR links to nothing.
 - Conventional Commits: `fix:`, `feat:`, with scopes where they apply (`fix(ci):`, `fix(workflow):`).
 - **Never start a commit message with `[WORKFLOW-AUTOMATION]`** — CI uses that prefix to recognize its own commits and skip the build.
 - `RELEASE_NOTES.md` must be non-empty for a master build to tag a release. Use `/release-prep`.


### PR DESCRIPTION
Wires `linear/linear-release-action@v0` into `release.yml` at the two channel transitions that matter to issue tracking.

| Hop | Command | Effect |
|---|---|---|
| `qa → beta` | `sync` | creates the Linear release for this version, attaches the issues resolved since the build beta served until a moment ago |
| `beta → latest` | `complete` | finalises it |

## How the scan range is bounded

`sync` scans `base_ref..HEAD`. Both ends are derived rather than guessed:

- **HEAD** — `release.yml` checks out master, which has moved on since the build was made, so a step detaches onto the promoted tag first.
- **base_ref** — the version the destination channel served *before* this promotion, read in `resolve.sh` from the live `beta` manifest. That read has to happen before the upload overwrites it, which is the same ordering constraint the rollback path already lives under.

Verified against production: `windows/qa` serves `20260806000759` and `windows/beta` serves `20260205000549`, so the range resolves to `26.2.5.549..26.8.6.759`.

Windows and macOS promote separately, so the second platform reads back the first one's upload and resolves an empty range. That is correct, not a bug — the issues were attached on the first pass, and `sync` for the same version adds nothing.

## Blast radius

Linear is bookkeeping and must never hold up a promotion:

- every Linear step is `continue-on-error`
- the whole block runs **after** the CDN uploads and the GitHub release
- it skips entirely when `LINEAR_ACCESS_KEY` is absent, so forks and clones are unaffected
- a new `linear-dry-run` input defaults to **true**, and a dry-run promotion forces it on regardless — rehearsing a promotion cannot leave a real Linear release behind

`resolve.sh` gains a beta branch that exits before the requirement-10 check, which must not fire on a hop that creates no GitHub release. The `latest` and rollback paths are byte-for-byte unchanged.

## Two things this does not do yet

**1. Issue detection currently finds nothing.** Measured over the exact range above: 120 commits, 16 distinct PR references, and **0 of those 16 PRs carry a Linear key** in branch name, title, or body. Keys are absent from commit subjects too (master is squash-merged, so subjects keep only `(#93)`). The CLI's PR-reference detection is the bridge, but it can only resolve issues Linear already linked to the PR — and Linear links from the branch name. One remote branch in the whole repo carries a key. Adding a CLAUDE.md convention line is the fix; the wiring is inert until branches carry keys.

**2. `complete` moves the *release* to the Released stage — it is not established that it closes the issues.** The pipeline has `rolloverIssuesOnCompletion: true`, which suggests incomplete issues roll into the next release rather than being closed. If closing issues at `latest` is a hard requirement, it likely needs a Linear-side automation or an explicit follow-up step. The `linear-dry-run` default is what makes this cheap to settle.

There is also no stage meaning "on the beta channel" — the SE.Live pipeline has only Planned / In Progress / Released. The `update --stage` step is written but dormant; add a stage in Linear and set the `LINEAR_BETA_STAGE` repository variable to switch it on with no code change.

## Supersedes

`origin/jacob/core-266-track-selive-releases-in-linear-linearlinear-release` — that branch synced on every master build and declared `needs: [version, tag-master-commit]`, a job that no longer exists since tagging moved into `finalize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Part 2 — `linear-issue-key.yml`

The dry-run above proved the release side works and finds nothing: **18 PRs detected, 0 issues**, because no PR in the range carried a key. This is the fix for that, as two jobs ordered by trust.

### `check` — deterministic, cannot mislink

Literal string match for `CORE-nnn` across the branch name, PR title, and PR body — the same three places Linear itself reads. Fails the PR when absent. Exempt: bot authors, and a `no-linear-issue` label for work that genuinely has no issue.

Verified by extracting the script straight out of the YAML and running it over 8 cases:

| input | result |
|---|---|
| `jacob/core-266-track-selive-releases` | pass → `CORE-266` (lowercase normalized) |
| title `fix(ci): CORE-99 handle retries` | pass → `CORE-99` |
| body `Fixes CORE-42` | pass → `CORE-42` |
| `dependabot[bot]` author | exempt |
| `no-linear-issue` label | exempt |
| `feat/attach-installers` | **fail** |
| `fix: UTF-8 output into manifests` | **fail** |
| `feat: SHA-256 checksums` | **fail** |

The last two matter: those are exactly the tokens that fooled the release CLI's built-in scan into reporting an issue named `UTF-8`.

This job is **not** wired into the ruleset — it reports, it does not block, until someone decides it should.

### `suggest` — AI fallback, runs only when `check` finds nothing

Pulls the team's open issues from Linear's GraphQL API, hands Claude the PR's file list and commit subjects, and posts one sticky comment naming a candidate with a confidence and a reason.

Linking stays **manual by default**. The comment gives you the line to paste; the model only writes `Fixes CORE-nnn` into a PR body when `LINEAR_AUTO_LINK` is explicitly set and confidence is high. A wrong link is worse than a missing one — an issue attached to the wrong release is silent, an unlinked PR is merely absent.

Prompt injection is handled structurally: the PR title, body, and branch are author-controlled, so they are passed as environment variables and written to files the model reads. They never reach the prompt string or a shell body.

### Needs a secret

`LINEAR_API_KEY` (a personal or workspace API key). `LINEAR_ACCESS_KEY` is a release-pipeline key and cannot read issues. Without it the `suggest` job degrades to a warning and `check` keeps working on its own.

### Verified vs. not

- **Verified live** — the pass path, on this very PR: `CORE-266 found; Linear will link this PR to it`, `suggest` skipped ([run 31191029208](https://github.com/StreamElements/obs-streamelements-core/actions/runs/31191029208)).
- **Verified locally** — all 8 scan cases above, using the script extracted from the workflow.
- **Not yet exercised** — the comment-posting step, which cannot run until `LINEAR_API_KEY` exists and a keyless PR is opened.