### PR TITLE
feat(ci): make the crash-reporting backend selectable from CI (CORE-554) #partial

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ env:
     -DENABLE_SCRIPTING_LUA=OFF
     -DENABLE_UI=OFF
 
+  # Which crash-reporting backend every job compiles in. Single source of truth:
+  # it feeds -DSTREAMELEMENTS_CRASH_HANDLER at each configure site, and symbol
+  # upload will be gated on the same value, so a build's binary and its symbols
+  # cannot end up pointing at different services.
+  SE_CRASH_HANDLER: bugsplat
+
   BUILD_UNINSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
   BUILD_INSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
   UPLOAD_SYMBOLS: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
@@ -303,7 +309,7 @@ jobs:
           copy C:\local\obs-studio\plugins\obs-streamelements-core\CMakeUserPresets.json C:\local\obs-studio\CMakeUserPresets.json
           del C:\local\obs-studio\plugins\obs-streamelements-core\CMakeUserPresets.json
           cd /d C:\local\obs-studio
-          cmake --preset=windows-x64-streamelements %BUILD_OPTIONS%
+          cmake --preset=windows-x64-streamelements %BUILD_OPTIONS% -DSTREAMELEMENTS_CRASH_HANDLER=%SE_CRASH_HANDLER%
 
       - name: Build
         shell: cmd
@@ -427,6 +433,7 @@ jobs:
           cmake --preset=macos \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -B build_macos_arm64 \
+            -DSTREAMELEMENTS_CRASH_HANDLER=$SE_CRASH_HANDLER \
             $BUILD_OPTIONS
 
           cd build_macos_arm64
@@ -447,6 +454,7 @@ jobs:
           cmake --preset=macos \
             -DCMAKE_OSX_ARCHITECTURES=x86_64 \
             -B build_macos_x86_64 \
+            -DSTREAMELEMENTS_CRASH_HANDLER=$SE_CRASH_HANDLER \
             $BUILD_OPTIONS
 
           cd build_macos_x86_64


### PR DESCRIPTION
**`#partial`** — one step of CORE-554, which is not finished by this. Reopen the issue after merge.

Adds one workflow-level `SE_CRASH_HANDLER` variable, defaulting to `bugsplat`, and feeds it to `-DSTREAMELEMENTS_CRASH_HANDLER` at all three configure sites: the Windows preset and both macOS architectures.

**No behaviour change** — the default is exactly what every job already built.

## Why this is worth its own change

It's the source of truth the symbol-upload gating needs. Uploading symbols to the wrong service is a *silent* failure: the binary reports to one backend while its symbols sit in another, and nobody finds out until a crash arrives unsymbolicated — at which point the build that produced it is long gone. Driving both the configure and the upload from one variable makes that disagreement unrepresentable rather than merely unlikely.

It also makes flipping the pipeline to Sentry a one-line change, and makes a compile-check leg cheap to add.

## What CI still does not cover

CI exercises only the default backend, so **the Sentry path remains verified on a local Windows machine alone**. macOS has never compiled it, and `sentry-crash` has never been built, signed or notarized there.

Closing that gap means a build configured with `-DSTREAMELEMENTS_CRASH_HANDLER=sentry`, which is a full OBS build per platform — roughly doubling CI time if run on every PR. That's a real cost and I'd rather it were a decision than a side effect, so it isn't in this PR. Options, cheapest first:

1. run the Sentry leg only on master pushes;
2. run it only when crash-handler files change (paths filter);
3. run it on every PR as a matrix leg.

My preference is (2) — the path only breaks when someone touches it, and it gives PR-time feedback where it matters.

Either way it should land **before** PR 3 flips the pipeline over, so macOS problems surface while BugSplat is still what ships rather than during the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)