### PR TITLE
fix(crash): redact stream keys from diagnostics archives (CORE-554) #partial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ set(obs-streamelements-core_SOURCES
 	streamelements/StreamElementsUtils.cpp
 	streamelements/StreamElementsHotkeyManager.cpp
 	streamelements/StreamElementsReportIssueDialog.cpp
+	streamelements/StreamElementsSecretRedactor.cpp
 	streamelements/StreamElementsProgressDialog.cpp
 	streamelements/StreamElementsPerformanceHistoryTracker.cpp
 	streamelements/StreamElementsNetworkDialog.cpp
@@ -469,6 +470,7 @@ set(obs-streamelements-core_HEADERS
 	streamelements/StreamElementsBrowserDialog.hpp
 	streamelements/StreamElementsHotkeyManager.hpp
 	streamelements/StreamElementsReportIssueDialog.hpp
+	streamelements/StreamElementsSecretRedactor.hpp
 	streamelements/StreamElementsProgressDialog.hpp
 	streamelements/StreamElementsPerformanceHistoryTracker.hpp
 	streamelements/StreamElementsNetworkDialog.hpp

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -2,6 +2,7 @@
 
 #include "cef-headers.hpp"
 #include "StreamElementsGlobalStateManager.hpp"
+#include "StreamElementsSecretRedactor.hpp"
 #include "StreamElementsUtils.hpp"
 #include "deps/StackWalker/StackWalker.h"
 #include "deps/zip/zip.h"
@@ -324,6 +325,13 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 	};
 
 	auto addFileToZip = [&](std::wstring localPath, std::wstring zipPath) {
+		// service.json carries the stream key in plaintext, so it is
+		// buffered whole and sanitized rather than streamed straight
+		// through. It is a few hundred bytes; everything else keeps the
+		// chunked path.
+		const bool redact =
+			StreamElementsSecretRedactor::IsSensitivePath(zipPath);
+
 		int fd = _wsopen(localPath.c_str(), _O_RDONLY | _O_BINARY,
 				 _SH_DENYNO, 0 /*_S_IREAD | _S_IWRITE*/);
 
@@ -334,13 +342,33 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 
 			zip_entry_open(zip, wstring_to_utf8(zipPath).c_str());
 
-			int read = _read(fd, buf, BUF_LEN);
-			while (read > 0) {
-				if (0 != zip_entry_write(zip, buf, read)) {
-					break;
+			if (redact) {
+				std::string content;
+
+				int read = _read(fd, buf, BUF_LEN);
+				while (read > 0) {
+					content.append((const char *)buf,
+						       (size_t)read);
+
+					read = _read(fd, buf, BUF_LEN);
 				}
 
-				read = _read(fd, buf, BUF_LEN);
+				const std::string sanitized =
+					StreamElementsSecretRedactor::Redact(
+						content);
+
+				zip_entry_write(zip, sanitized.c_str(),
+						sanitized.size());
+			} else {
+				int read = _read(fd, buf, BUF_LEN);
+				while (read > 0) {
+					if (0 !=
+					    zip_entry_write(zip, buf, read)) {
+						break;
+					}
+
+					read = _read(fd, buf, BUF_LEN);
+				}
 			}
 
 			zip_entry_close(zip);

--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -3,6 +3,7 @@
 #include "StreamElementsUtils.hpp"
 #include "StreamElementsGlobalStateManager.hpp"
 #include "StreamElementsNetworkDialog.hpp"
+#include "StreamElementsSecretRedactor.hpp"
 #include "StreamElementsConfig.hpp"
 #include "Version.hpp"
 #include "ui_StreamElementsReportIssueDialog.h"
@@ -284,13 +285,40 @@ void StreamElementsReportIssueDialog::accept()
 
 				zip_entry_open(zip, wstring_to_utf8(zipPath).c_str());
 
-				int read = ::read(fd, buf, BUF_LEN);
-				while (read > 0) {
-					if (0 != zip_entry_write(zip, buf, read)) {
-						break;
+				// service.json carries the stream key in
+				// plaintext, so it is buffered whole and
+				// sanitized rather than streamed straight
+				// through to the upload.
+				if (StreamElementsSecretRedactor::IsSensitivePath(
+					    zipPath)) {
+					std::string content;
+
+					int read = ::read(fd, buf, BUF_LEN);
+					while (read > 0) {
+						content.append(
+							(const char *)buf,
+							(size_t)read);
+
+						read = ::read(fd, buf, BUF_LEN);
 					}
 
-					read = ::read(fd, buf, BUF_LEN);
+					const std::string sanitized =
+						StreamElementsSecretRedactor::
+							Redact(content);
+
+					zip_entry_write(zip, sanitized.c_str(),
+							sanitized.size());
+				} else {
+					int read = ::read(fd, buf, BUF_LEN);
+					while (read > 0) {
+						if (0 !=
+						    zip_entry_write(zip, buf,
+								    read)) {
+							break;
+						}
+
+						read = ::read(fd, buf, BUF_LEN);
+					}
 				}
 
 				zip_entry_close(zip);

--- a/streamelements/StreamElementsSecretRedactor.cpp
+++ b/streamelements/StreamElementsSecretRedactor.cpp
@@ -1,0 +1,201 @@
+#include "StreamElementsSecretRedactor.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cwctype>
+
+/* ================================================================= */
+
+static const char *const REDACTED = "[redacted]";
+
+//
+// Keys whose string value is a credential in its entirety.
+//
+// "key" is the stream key for rtmp_common services; "password" is the custom
+// RTMP auth password; "bearer_token" is used by services authenticating with a
+// token rather than a key.
+//
+static bool IsSecretKeyName(const std::string &name)
+{
+	return name == "key" || name == "password" || name == "bearer_token";
+}
+
+//
+// Finds the closing quote of a JSON string whose contents start at `start`,
+// honouring backslash escapes. Returns npos when the string is unterminated.
+//
+static size_t FindClosingQuote(const std::string &s, size_t start)
+{
+	for (size_t i = start; i < s.size(); ++i) {
+		if (s[i] == '\\') {
+			++i; // skip the escaped character
+
+			continue;
+		}
+
+		if (s[i] == '"')
+			return i;
+	}
+
+	return std::string::npos;
+}
+
+//
+// Replaces the userinfo component of a URL, if it has one.
+//
+// OBS stores custom RTMP endpoints as a plain URL, and a user pasting one from
+// their provider can easily bring credentials along:
+//
+//     rtmp://user:pass@live.example.com/app
+//
+// The host and path stay -- they say which provider and ingest endpoint were in
+// use, which is the diagnostically interesting part.
+//
+static bool RedactUrlUserInfo(const std::string &url, std::string &result)
+{
+	const size_t schemeEnd = url.find("://");
+
+	if (schemeEnd == std::string::npos)
+		return false;
+
+	const size_t authorityStart = schemeEnd + 3;
+
+	// The authority ends at the first '/', '?' or '#'.
+	size_t authorityEnd = url.size();
+
+	for (size_t i = authorityStart; i < url.size(); ++i) {
+		if (url[i] == '/' || url[i] == '?' || url[i] == '#') {
+			authorityEnd = i;
+
+			break;
+		}
+	}
+
+	const size_t at = url.rfind('@', authorityEnd);
+
+	if (at == std::string::npos || at < authorityStart)
+		return false;
+
+	result = url.substr(0, authorityStart) + REDACTED +
+		 url.substr(at, url.size() - at);
+
+	return true;
+}
+
+/* ================================================================= */
+
+bool StreamElementsSecretRedactor::IsSensitivePath(const std::wstring &zipPath)
+{
+	std::wstring normalized = zipPath;
+
+	std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+		       ::towlower);
+	std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+		       [](wchar_t ch) { return ch == L'\\' ? L'/' : ch; });
+
+	// basic/profiles/<profile name>/service.json, wherever it sits inside
+	// the archive.
+	if (normalized.find(L"basic/profiles/") == std::wstring::npos)
+		return false;
+
+	const std::wstring suffix = L"/service.json";
+
+	if (normalized.size() < suffix.size())
+		return false;
+
+	return normalized.compare(normalized.size() - suffix.size(),
+				  suffix.size(), suffix) == 0;
+}
+
+std::string StreamElementsSecretRedactor::Redact(const std::string &content)
+{
+	std::string result;
+	result.reserve(content.size() + 64);
+
+	size_t i = 0;
+
+	while (i < content.size()) {
+		if (content[i] != '"') {
+			result += content[i++];
+
+			continue;
+		}
+
+		// A quoted token. It is a key if a colon follows it.
+		const size_t nameStart = i + 1;
+		const size_t nameEnd = FindClosingQuote(content, nameStart);
+
+		if (nameEnd == std::string::npos) {
+			// Unterminated: copy the remainder verbatim.
+			result.append(content, i, std::string::npos);
+
+			break;
+		}
+
+		const std::string name =
+			content.substr(nameStart, nameEnd - nameStart);
+
+		size_t cursor = nameEnd + 1;
+
+		while (cursor < content.size() &&
+		       isspace((unsigned char)content[cursor]))
+			++cursor;
+
+		bool handled = false;
+
+		if (cursor < content.size() && content[cursor] == ':') {
+			++cursor;
+
+			while (cursor < content.size() &&
+			       isspace((unsigned char)content[cursor]))
+				++cursor;
+
+			if (cursor < content.size() && content[cursor] == '"') {
+				const size_t valueStart = cursor + 1;
+				const size_t valueEnd =
+					FindClosingQuote(content, valueStart);
+
+				if (valueEnd != std::string::npos) {
+					const std::string value =
+						content.substr(
+							valueStart,
+							valueEnd - valueStart);
+
+					std::string replacement;
+					bool redact = false;
+
+					if (IsSecretKeyName(name)) {
+						replacement = REDACTED;
+						redact = true;
+					} else if (name == "server") {
+						redact = RedactUrlUserInfo(
+							value, replacement);
+					}
+
+					if (redact) {
+						// Everything up to and including
+						// the value's opening quote is
+						// copied byte for byte.
+						result.append(content, i,
+							      valueStart - i);
+						result += replacement;
+						result += '"';
+
+						i = valueEnd + 1;
+						handled = true;
+					}
+				}
+			}
+		}
+
+		if (!handled) {
+			// Copy the quoted token and carry on from just after
+			// it, so its contents are never rescanned as keys.
+			result.append(content, i, nameEnd + 1 - i);
+
+			i = nameEnd + 1;
+		}
+	}
+
+	return result;
+}

--- a/streamelements/StreamElementsSecretRedactor.hpp
+++ b/streamelements/StreamElementsSecretRedactor.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+
+//
+// Removes streaming credentials from OBS configuration files before they leave
+// the machine.
+//
+// Both diagnostics paths -- the crash report built by StreamElementsCrashContext
+// and the user-initiated report built by StreamElementsReportIssueDialog -- zip
+// up the entire obs-studio configuration tree. That tree includes
+// basic/profiles/<name>/service.json, where OBS stores the stream key in
+// plaintext. Those archives are uploaded to a third party, and neither BugSplat
+// nor Sentry scrubs attachments.
+//
+// The file is redacted in place rather than excluded: which service is
+// configured, whether authentication is enabled, the server URL and the encoder
+// settings are all genuinely useful when diagnosing a streaming problem, and
+// dropping the file loses all of it to protect one field.
+//
+// Redaction is deliberately a targeted byte replacement and not a JSON
+// round-trip. Parsing and re-serialising would reformat the document, making
+// diffs between a user's file and a known-good one useless, and -- more
+// importantly -- Redact() runs on a dying thread in the crash path, where
+// invoking a full JSON parser is exactly the sort of thing to avoid. Every byte
+// that is not part of a credential value comes out where it went in.
+//
+class StreamElementsSecretRedactor {
+public:
+	// True when `zipPath` names a file known to carry credentials. Matching
+	// is case-insensitive and accepts either slash direction.
+	//
+	// Redact() is only ever applied to paths this accepts. That containment
+	// is what makes it safe to treat a field as generic as "key" as a
+	// secret: in service.json it is the stream key, whereas elsewhere in the
+	// configuration tree it would mean something else entirely.
+	static bool IsSensitivePath(const std::wstring &zipPath);
+
+	// Returns `content` with credential values replaced by [redacted].
+	//
+	// Redacted: the string values of "key", "password" and "bearer_token",
+	// plus the userinfo component of "server" when the URL carries inline
+	// credentials (rtmp://user:pass@host/...).
+	//
+	// This recognises patterns, it does not validate: any `"name": "value"`
+	// pair it can see is redacted regardless of how it is nested or whether
+	// the surrounding document is well formed. The consequence worth
+	// knowing is the inverse -- a credential stored in a shape this does not
+	// recognise, such as a non-string value or a key spelled differently by
+	// a future OBS version, passes through untouched.
+	static std::string Redact(const std::string &content);
+};


### PR DESCRIPTION
Fourth step on CORE-554, and the one with the clearest standalone value: **stream keys have been leaving user machines in every diagnostics archive.**

## The leak

Both diagnostics paths zip the entire `obs-studio` configuration tree:

- `StreamElementsCrashContext` (crash reports → BugSplat today, Sentry next)
- `StreamElementsReportIssueDialog` (user-initiated reports → `obs-reports.streamelements.com`)

That tree includes `basic/profiles/<name>/service.json`, where OBS stores the **stream key in plaintext**. The blacklist excludes CEF caches, `updates/`, `profiler_data/` and `crashes/` — but not this. Neither BugSplat nor Sentry scrubs attachments.

This is pre-existing, not introduced by the Sentry work. It was flagged as an open item on the original plan; this closes it for both paths at once.

## Redacted in place, not excluded

Which service is configured, whether auth is enabled, the server URL and the encoder settings are all genuinely useful when diagnosing a streaming problem. Dropping the file loses all of that to protect one field.

**Redacted:** the string values of `key`, `password` and `bearer_token`, plus the userinfo component of `server` when the URL carries inline credentials — `rtmp://user:pass@host/app` keeps its host and path, which is the diagnostically interesting part.

**Targeted byte replacement, not a JSON round-trip.** Parsing and re-serialising would reformat the document, making a diff against a known-good profile useless — and more importantly this runs on a **dying thread in the crash path**, where invoking a full JSON parser is exactly what not to do. Every byte that is not part of a credential comes out where it went in, including whitespace and key order.

**Scoped to `basic/profiles/*/service.json`.** That containment is what makes it safe to treat a name as generic as `key` as a secret — elsewhere in the config tree it means something else entirely.

## Verification — actually run, not just compiled

The project has no test framework. So the redactor was deliberately written with **no OBS dependencies**, which allowed a standalone harness to exercise it directly. 22 cases, all passing:

| Group | Cases |
|---|---|
| Path matching | both slash directions, mixed case, profile names with spaces, `basic.ini` and `scenes/*.json` correctly rejected, `service.json` outside `profiles/` rejected |
| Real shapes | `rtmp_common` stream key, custom-RTMP `password`, `bearer_token` |
| Server URLs | inline credentials redacted, credential-free URL untouched, `@` in a *path* not mistaken for userinfo |
| Must not touch | byte-for-byte formatting preserved, `"key"` appearing as a **value**, non-string `key`, near-misses `keyint_sec` / `password_hint` |
| Escaping | escaped quote inside a secret, trailing escaped backslash, escaped quote in a neighbouring value not desyncing the scanner, unterminated string, empty input |

The harness is not part of the build — there is nowhere to put it. It is reproducible: the redactor compiles standalone with any C++17 compiler.

Plus all three backend selections (`bugsplat`, `sentry`, `none`) build and link on Windows with 0 warnings under `/WX`.

**Not verified:** no real crash was triggered and no real report was uploaded end-to-end, so this is proven at the function level rather than observed in a delivered archive.

## Known limit, stated plainly

This recognises patterns; it does not validate. Any `"name": "value"` pair it can see is redacted regardless of nesting or surrounding validity — but the inverse is the real caveat: **a credential stored in a shape it doesn't recognise passes through untouched**. A non-string value, or a key spelled differently by a future OBS version, would not be caught. That is written into the header so the next person doesn't assume more coverage than exists.

#partial — CORE-554 continues with the consent dialog, the PNG screenshot, and CI symbol upload.
