### PR TITLE
feat(crash): ask before sending, and remember contact details (CORE-554) #partial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,14 @@ if (ENABLE_SENTRY)
 	list(APPEND obs-streamelements-core_SOURCES
 		streamelements/StreamElementsSentryCrashHandler.cpp
 	)
+
+	# The crash-time consent prompt. Only Sentry needs it: BugSplat's SDK
+	# shows a prompt of its own, whereas Sentry uploads silently.
+	if (WIN32)
+		list(APPEND obs-streamelements-core_SOURCES
+			streamelements/StreamElementsCrashConsentDialog.cpp
+		)
+	endif()
 endif()
 
 set(obs-streamelements-core_HEADERS
@@ -477,6 +485,7 @@ set(obs-streamelements-core_HEADERS
 	streamelements/StreamElementsAnalyticsEventsManager.hpp
 	streamelements/StreamElementsCrashHandler.hpp
 	streamelements/StreamElementsCrashContext.hpp
+	streamelements/StreamElementsCrashConsentDialog.hpp
 	streamelements/StreamElementsBugSplatCrashHandler.hpp
 	streamelements/StreamElementsSentryCrashHandler.hpp
 	streamelements/StreamElementsMessageBus.hpp

--- a/streamelements/StreamElementsConfig.hpp
+++ b/streamelements/StreamElementsConfig.hpp
@@ -209,6 +209,53 @@ public:
 		SaveConfig();
 	}
 
+	//
+	// Contact details the user supplied on a previous crash report.
+	//
+	// Kept so the crash-time prompt can prefill them and the user does not
+	// retype their details every time, and so that events can carry the user
+	// even when a crash never reaches the prompt.
+	//
+	// These are written from the crash path, where the process is already
+	// dying -- deliberately a single small ini write, and only after the
+	// user has actually typed something.
+	//
+	std::string GetCrashReportUserName()
+	{
+		const char *value = config_get_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserName");
+
+		return !!value ? value : "";
+	}
+
+	void SetCrashReportUserName(std::string value)
+	{
+		config_set_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserName", value.c_str());
+
+		SaveConfig();
+	}
+
+	std::string GetCrashReportUserEmail()
+	{
+		const char *value = config_get_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserEmail");
+
+		return !!value ? value : "";
+	}
+
+	void SetCrashReportUserEmail(std::string value)
+	{
+		config_set_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserEmail", value.c_str());
+
+		SaveConfig();
+	}
+
 	std::string GetSceneItemsAuxActionsConfig()
 	{
 		const char *value = config_get_string(

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -1,0 +1,297 @@
+#include "StreamElementsCrashConsentDialog.hpp"
+
+#include "StreamElementsUtils.hpp"
+
+#include <vector>
+
+#include <windows.h>
+
+/* ================================================================= */
+
+//
+// Strings are hardcoded English rather than routed through obs_module_text().
+//
+// This matches every other user-visible string in the crash handler -- the
+// "please wait" window and BugSplat's own prompts are hardcoded too -- and
+// keeps the dying process from reaching into the module's locale lookup. If
+// these are ever localised, the rest of the crash handler should move with
+// them rather than this one dialog diverging.
+//
+static const wchar_t *const DIALOG_TITLE = L"SE.Live";
+
+static const wchar_t *const PROMPT_TEXT =
+	L"OBS Studio has stopped working, and SE.Live can send a report to help us fix it. "
+	L"What were you doing just before this happened?";
+
+static const wchar_t *const CONTACT_TEXT =
+	L"Name and email are optional. They let us follow up about this crash, and are remembered for next time.";
+
+/* ================================================================= */
+
+#define IDC_DESCRIPTION 1001
+#define IDC_NAME 1002
+#define IDC_EMAIL 1003
+
+// System window class atoms, as used inside a dialog template.
+#define ATOM_BUTTON 0x0080
+#define ATOM_EDIT 0x0081
+#define ATOM_STATIC 0x0082
+
+//
+// Builds a DLGTEMPLATE in memory.
+//
+// The layout is a packed, DWORD-aligned byte stream rather than a struct: the
+// header and every item are followed by variable-length name/title arrays, so
+// there is nothing to declare as a type.
+//
+class DialogTemplateBuilder {
+public:
+	void AlignDword()
+	{
+		while (m_bytes.size() % sizeof(DWORD))
+			m_bytes.push_back(0);
+	}
+
+	void AddWord(WORD value)
+	{
+		const BYTE *p = (const BYTE *)&value;
+
+		m_bytes.insert(m_bytes.end(), p, p + sizeof(value));
+	}
+
+	void AddDword(DWORD value)
+	{
+		const BYTE *p = (const BYTE *)&value;
+
+		m_bytes.insert(m_bytes.end(), p, p + sizeof(value));
+	}
+
+	void AddShort(short value) { AddWord((WORD)value); }
+
+	// A sz_Or_Ord holding a string, null terminator included.
+	void AddString(const wchar_t *text)
+	{
+		for (const wchar_t *p = text; *p; ++p)
+			AddWord((WORD)*p);
+
+		AddWord(0);
+	}
+
+	// A sz_Or_Ord holding a class atom.
+	void AddOrdinal(WORD atom)
+	{
+		AddWord(0xFFFF);
+		AddWord(atom);
+	}
+
+	const DLGTEMPLATE *Get() const
+	{
+		return (const DLGTEMPLATE *)m_bytes.data();
+	}
+
+private:
+	std::vector<BYTE> m_bytes;
+};
+
+static void AddControl(DialogTemplateBuilder &builder, DWORD style, short x,
+		       short y, short cx, short cy, WORD id, WORD classAtom,
+		       const wchar_t *text)
+{
+	builder.AlignDword();
+
+	builder.AddDword(style);
+	builder.AddDword(0); // extended style
+	builder.AddShort(x);
+	builder.AddShort(y);
+	builder.AddShort(cx);
+	builder.AddShort(cy);
+	builder.AddWord(id);
+
+	builder.AddOrdinal(classAtom);
+	builder.AddString(text);
+
+	builder.AddWord(0); // no creation data
+}
+
+/* ================================================================= */
+
+struct DialogState {
+	std::wstring name;
+	std::wstring email;
+
+	std::wstring description;
+	bool consented = false;
+};
+
+static std::wstring GetControlText(HWND dialog, int id)
+{
+	HWND control = ::GetDlgItem(dialog, id);
+
+	if (!control)
+		return L"";
+
+	const int length = ::GetWindowTextLengthW(control);
+
+	if (length <= 0)
+		return L"";
+
+	std::vector<wchar_t> buffer((size_t)length + 1, 0);
+
+	::GetWindowTextW(control, buffer.data(), length + 1);
+
+	return buffer.data();
+}
+
+static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
+					  WPARAM wParam, LPARAM lParam)
+{
+	switch (message) {
+	case WM_INITDIALOG: {
+		auto *state = (DialogState *)lParam;
+
+		::SetWindowLongPtrW(dialog, GWLP_USERDATA, (LONG_PTR)state);
+
+		if (state) {
+			::SetDlgItemTextW(dialog, IDC_NAME,
+					  state->name.c_str());
+			::SetDlgItemTextW(dialog, IDC_EMAIL,
+					  state->email.c_str());
+		}
+
+		// Nothing else is going to bring this forward: it has no owner
+		// window (see Prompt), and the application it belongs to is in
+		// the middle of dying.
+		::SetForegroundWindow(dialog);
+
+		::SetFocus(::GetDlgItem(dialog, IDC_DESCRIPTION));
+
+		return FALSE; // focus was set explicitly
+	}
+
+	case WM_COMMAND: {
+		const int id = LOWORD(wParam);
+
+		if (id != IDOK && id != IDCANCEL)
+			break;
+
+		auto *state = (DialogState *)::GetWindowLongPtrW(dialog,
+								 GWLP_USERDATA);
+
+		if (state && id == IDOK) {
+			state->description =
+				GetControlText(dialog, IDC_DESCRIPTION);
+			state->name = GetControlText(dialog, IDC_NAME);
+			state->email = GetControlText(dialog, IDC_EMAIL);
+			state->consented = true;
+		}
+
+		::EndDialog(dialog, id);
+
+		return TRUE;
+	}
+	}
+
+	return FALSE;
+}
+
+/* ================================================================= */
+
+// Separate from Prompt() so that the template can be built -- and therefore
+// checked -- without showing a modal dialog. A hand-assembled DLGTEMPLATE that
+// is subtly malformed fails by returning -1 from DialogBoxIndirectParamW, which
+// this handler reads as "the user declined": every crash report would be
+// suppressed, silently. That is worth being able to test.
+static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
+{
+	const DWORD dialogStyle = DS_MODALFRAME | DS_CENTER | DS_SETFONT |
+				  WS_POPUP | WS_CAPTION | WS_SYSMENU;
+
+	builder.AddDword(dialogStyle);
+	builder.AddDword(WS_EX_TOPMOST);
+	builder.AddWord(9); // control count
+	builder.AddShort(0);
+	builder.AddShort(0);
+	builder.AddShort(320);
+	builder.AddShort(200);
+
+	builder.AddWord(0); // no menu
+	builder.AddWord(0); // default dialog class
+	builder.AddString(DIALOG_TITLE);
+
+	builder.AddWord(8); // point size
+	builder.AddString(L"MS Shell Dlg");
+
+	const DWORD visibleChild = WS_CHILD | WS_VISIBLE;
+	const DWORD editStyle = visibleChild | WS_TABSTOP | WS_BORDER |
+				ES_AUTOHSCROLL;
+
+	AddControl(builder, visibleChild, 7, 7, 306, 26, (WORD)-1, ATOM_STATIC,
+		   PROMPT_TEXT);
+
+	AddControl(builder,
+		   editStyle | ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL, 7, 37,
+		   306, 62, IDC_DESCRIPTION, ATOM_EDIT, L"");
+
+	AddControl(builder, visibleChild, 7, 108, 40, 10, (WORD)-1, ATOM_STATIC,
+		   L"Name:");
+	AddControl(builder, editStyle, 50, 106, 263, 13, IDC_NAME, ATOM_EDIT,
+		   L"");
+
+	AddControl(builder, visibleChild, 7, 128, 40, 10, (WORD)-1, ATOM_STATIC,
+		   L"Email:");
+	AddControl(builder, editStyle, 50, 126, 263, 13, IDC_EMAIL, ATOM_EDIT,
+		   L"");
+
+	AddControl(builder, visibleChild, 7, 146, 306, 20, (WORD)-1,
+		   ATOM_STATIC, CONTACT_TEXT);
+
+	AddControl(builder, visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON, 185,
+		   176, 60, 16, IDOK, ATOM_BUTTON, L"Send report");
+
+	AddControl(builder, visibleChild | WS_TABSTOP | BS_PUSHBUTTON, 253, 176,
+		   60, 16, IDCANCEL, ATOM_BUTTON, L"Don't send");
+}
+
+/* ================================================================= */
+
+StreamElementsCrashConsentDialog::Result
+StreamElementsCrashConsentDialog::Prompt(const std::string &name,
+					 const std::string &email)
+{
+	Result result;
+
+	DialogState state;
+	state.name = utf8_to_wstring(name);
+	state.email = utf8_to_wstring(email);
+
+	DialogTemplateBuilder builder;
+
+	BuildConsentDialogTemplate(builder);
+
+	//
+	// No owner window, deliberately.
+	//
+	// Owning this to the OBS main window would attach our input queue to the
+	// thread that owns it. On a crash path that thread is quite possibly the
+	// one that just faulted, or is blocked waiting on it, and attaching to a
+	// wedged input queue hangs the prompt -- turning a crash into a hang. The
+	// cost is that the dialog is not modal to OBS, which is why it is
+	// WS_EX_TOPMOST and calls SetForegroundWindow above.
+	//
+	const INT_PTR outcome = ::DialogBoxIndirectParamW(
+		::GetModuleHandleW(NULL), builder.Get(), NULL,
+		ConsentDialogProc, (LPARAM)&state);
+
+	if (outcome != IDOK) {
+		// Declined, dismissed, or the dialog could not be created
+		// (outcome -1). All three mean the same thing here.
+		return result;
+	}
+
+	result.consented = state.consented;
+	result.description = wstring_to_utf8(state.description);
+	result.name = wstring_to_utf8(state.name);
+	result.email = wstring_to_utf8(state.email);
+
+	return result;
+}

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -31,6 +31,7 @@ static const wchar_t *const CONTACT_TEXT =
 #define IDC_DESCRIPTION 1001
 #define IDC_NAME 1002
 #define IDC_EMAIL 1003
+#define IDC_ERRORICON 1004
 
 // System window class atoms, as used inside a dialog template.
 #define ATOM_BUTTON 0x0080
@@ -158,9 +159,35 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 					  state->email.c_str());
 		}
 
-		// Nothing else is going to bring this forward: it has no owner
-		// window (see Prompt), and the application it belongs to is in
-		// the middle of dying.
+		// The system error icon, in the body next to the message and
+		// again in the title bar. Loaded rather than named in the
+		// template so it follows the OS rather than shipping our own
+		// bitmap.
+		// LoadIcon rather than LoadIconW: IDI_ERROR is itself a
+		// TCHAR-generic macro, so the two have to match or the build
+		// breaks wherever UNICODE is not defined.
+		HICON icon = ::LoadIcon(NULL, IDI_ERROR);
+
+		if (icon) {
+			::SendDlgItemMessageW(dialog, IDC_ERRORICON,
+					      STM_SETICON, (WPARAM)icon, 0);
+
+			::SendMessageW(dialog, WM_SETICON, ICON_SMALL,
+				       (LPARAM)icon);
+			::SendMessageW(dialog, WM_SETICON, ICON_BIG,
+				       (LPARAM)icon);
+		}
+
+		// Always on top.
+		//
+		// WS_EX_TOPMOST is already in the template, but it is set again
+		// here because it is load-bearing rather than cosmetic: this
+		// window has no owner (see Prompt), so nothing else will raise
+		// it, and OBS is in the middle of dying behind it. A prompt the
+		// user never sees is a crash report never sent.
+		::SetWindowPos(dialog, HWND_TOPMOST, 0, 0, 0, 0,
+			       SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
 		::SetForegroundWindow(dialog);
 
 		::SetFocus(::GetDlgItem(dialog, IDC_DESCRIPTION));
@@ -208,7 +235,7 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 	builder.AddDword(dialogStyle);
 	builder.AddDword(WS_EX_TOPMOST);
-	builder.AddWord(9); // control count
+	builder.AddWord(10); // control count
 	builder.AddShort(0);
 	builder.AddShort(0);
 	builder.AddShort(320);
@@ -225,7 +252,13 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 	const DWORD editStyle = visibleChild | WS_TABSTOP | WS_BORDER |
 				ES_AUTOHSCROLL;
 
-	AddControl(builder, visibleChild, 7, 7, 306, 26, (WORD)-1, ATOM_STATIC,
+	// The icon sizes itself to the system icon; cx/cy here are only a hint.
+	// The message clears it and both share a right edge with everything
+	// below (7 + 306 == 36 + 277).
+	AddControl(builder, visibleChild | SS_ICON, 7, 9, 21, 20, IDC_ERRORICON,
+		   ATOM_STATIC, L"");
+
+	AddControl(builder, visibleChild, 36, 7, 277, 30, (WORD)-1, ATOM_STATIC,
 		   PROMPT_TEXT);
 
 	AddControl(builder,

--- a/streamelements/StreamElementsCrashConsentDialog.hpp
+++ b/streamelements/StreamElementsCrashConsentDialog.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+//
+// The crash-time consent prompt.
+//
+// BugSplat shows its own dialog before sending, asking the user what they were
+// doing and letting them supply contact details. Sentry has no such UI -- it
+// uploads silently -- so switching backends would quietly remove a prompt users
+// have been seeing for years, and remove the report descriptions with it. This
+// is that dialog, rebuilt.
+//
+// It is native Win32, built from an in-memory DLGTEMPLATE, and deliberately not
+// Qt. The crash handler touches no Qt anywhere: by the time this runs the
+// process is dying, the Qt event loop may be the very thing that is wedged, and
+// QApplication is not safe to re-enter from an exception filter.
+//
+// Sentry's User Feedback API is not what carries the answers. sentry_capture_
+// feedback() needs an event_id to associate with, and the event here is created
+// downstream by sentry's own filter -- there is no id to hand back at this
+// point. The answers instead go onto the scope before hand-off, as
+// sentry_set_user() plus a `user_report` context, so they travel with the event
+// that filter builds.
+//
+class StreamElementsCrashConsentDialog {
+public:
+	struct Result {
+		// False when the user declined, closed the dialog, or the
+		// dialog could not be shown at all. The caller must treat this
+		// as "do not send": it is the user's answer, not a hint.
+		bool consented = false;
+
+		std::string description;
+		std::string name;
+		std::string email;
+	};
+
+public:
+	// Shows the prompt modally on the calling thread, which is the crashing
+	// thread. `name` and `email` prefill their fields; pass what was saved
+	// from the last report.
+	//
+	// Returns consented=false if the dialog cannot be created, so a failure
+	// here suppresses the report rather than silently sending one the user
+	// never agreed to.
+	static Result Prompt(const std::string &name, const std::string &email);
+};

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -1,5 +1,7 @@
 #include "StreamElementsSentryCrashHandler.hpp"
 
+#include "StreamElementsConfig.hpp"
+#include "StreamElementsCrashConsentDialog.hpp"
 #include "StreamElementsCrashContext.hpp"
 #include "StreamElementsUtils.hpp"
 
@@ -38,6 +40,12 @@ static LPTOP_LEVEL_EXCEPTION_FILTER s_hostExceptionFilter = nullptr;
 static LONG s_insideExceptionFilter = 0L;
 
 static HWND s_messageWindow = NULL;
+
+// Contact details from the last report the user filled in. Read once at
+// startup, so the crash path never has to touch the config to prefill the
+// prompt.
+static std::string s_userName;
+static std::string s_userEmail;
 
 /* ================================================================= */
 
@@ -150,10 +158,71 @@ static bool IsTagWorthyAttribute(const std::string &name)
 }
 
 //
+// Identifies the reporter on every event.
+//
+// The machine id is always present; name and email only once the user has
+// supplied them on some earlier crash report. Called both at startup -- so a
+// crash that never reaches the prompt still says who it came from -- and again
+// after the prompt, with whatever was just typed.
+//
+static void SetSentryUser(const std::string &name, const std::string &email)
+{
+	sentry_value_t user = sentry_value_new_object();
+
+	sentry_value_set_by_key(
+		user, "id",
+		sentry_value_new_string(GetComputerSystemUniqueId().c_str()));
+
+	if (name.size()) {
+		sentry_value_set_by_key(user, "username",
+					sentry_value_new_string(name.c_str()));
+	}
+
+	if (email.size()) {
+		sentry_value_set_by_key(user, "email",
+					sentry_value_new_string(email.c_str()));
+	}
+
+	sentry_set_user(user);
+}
+
+//
+// Writes back what the user typed, so the next prompt starts prefilled.
+//
+// This runs on the crashing thread and writes the plugin's ini. It is one small
+// file write, guarded so it only happens when there is something to store, and
+// it sits on a path that is already about to zip the entire configuration tree
+// -- but it is still file I/O on a dying process, which is why it is not done
+// unconditionally.
+//
+static void PersistContactDetails(const std::string &name,
+				  const std::string &email)
+{
+	auto config = StreamElementsConfig::GetInstance();
+
+	if (!config)
+		return;
+
+	if (name.size() && name != s_userName) {
+		config->SetCrashReportUserName(name);
+
+		s_userName = name;
+	}
+
+	if (email.size() && email != s_userEmail) {
+		config->SetCrashReportUserEmail(email);
+
+		s_userEmail = email;
+	}
+}
+
+//
 // Puts everything StreamElementsCrashContext gathered onto the Sentry scope, so
 // that the event sentry's filter builds a moment later carries it.
 //
-static void ArmSentryScope(const StreamElementsCrashContext::Result &context)
+static void
+ArmSentryScope(const StreamElementsCrashContext::Result &context,
+	       const StreamElementsCrashConsentDialog::Result &consent)
 {
 	// Complete record, unabridged: a context is JSON in the event body, so
 	// it has neither the WER entry cap nor BugSplat's hostility to long
@@ -188,6 +257,26 @@ static void ArmSentryScope(const StreamElementsCrashContext::Result &context)
 		// in the user's temp directory survive.
 		sentry_attach_filew(utf8_to_wstring(attachment.path).c_str());
 	}
+
+	//
+	// What the user told us.
+	//
+	// Not sentry_capture_feedback(): that needs an event_id to attach to,
+	// and the event is created downstream by sentry's own filter, so there
+	// is no id to hand it at this point. On the scope it travels with the
+	// event that filter builds.
+	//
+	SetSentryUser(consent.name, consent.email);
+
+	if (consent.description.size()) {
+		sentry_value_t report = sentry_value_new_object();
+
+		sentry_value_set_by_key(
+			report, "description",
+			sentry_value_new_string(consent.description.c_str()));
+
+		sentry_set_context("user_report", report);
+	}
 }
 
 /* ================================================================= */
@@ -208,22 +297,42 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 		s_crashContext->WalkStack(pExceptionInfo->ContextRecord);
 
 	if (InterlockedIncrement(&s_insideExceptionFilter) == 1L) {
-		CreateMessageWindow();
-
 		// The gate. A stack that never passed through our code is not
 		// ours to report: we skip sentry's filter entirely, so no event
 		// and no minidump are produced, and go straight to the host
-		// filter below.
+		// filter below. The user is not asked about a crash we were
+		// never going to send.
 		if (s_initialized && s_crashContext &&
 		    s_crashContext->ShouldReport()) {
-			ArmSentryScope(s_crashContext->Collect());
+			// Ask first. Sentry uploads silently by default, and
+			// going to Sentry without this would start sending
+			// crash data from users who never agreed to it -- and
+			// would lose the descriptions, which are frequently the
+			// only account of what the user was actually doing.
+			const auto consent =
+				StreamElementsCrashConsentDialog::Prompt(
+					s_userName, s_userEmail);
 
-			if (s_sentryExceptionFilter) {
-				// Emits the event and signals the sentry-crash
-				// daemon, which writes and uploads the minidump
-				// out of process. Returns once the daemon has
-				// captured it, or on timeout.
-				s_sentryExceptionFilter(pExceptionInfo);
+			if (consent.consented) {
+				PersistContactDetails(consent.name,
+						      consent.email);
+
+				// Only now: collecting the payload and waiting
+				// on the daemon takes a moment, and there is
+				// nothing to wait for if the user declined.
+				CreateMessageWindow();
+
+				ArmSentryScope(s_crashContext->Collect(),
+					       consent);
+
+				if (s_sentryExceptionFilter) {
+					// Emits the event and signals the
+					// sentry-crash daemon, which writes and
+					// uploads the minidump out of process.
+					// Returns once the daemon has captured
+					// it, or on timeout.
+					s_sentryExceptionFilter(pExceptionInfo);
+				}
 			}
 		}
 
@@ -305,22 +414,24 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	sentry_options_set_crash_reporting_mode(
 		options, SENTRY_CRASH_REPORTING_MODE_NATIVE_WITH_MINIDUMP);
 
-	sentry_set_user(([] {
-		sentry_value_t user = sentry_value_new_object();
-
-		sentry_value_set_by_key(
-			user, "id",
-			sentry_value_new_string(
-				GetComputerSystemUniqueId().c_str()));
-
-		return user;
-	})());
-
 	if (sentry_init(options) != 0) {
 		blog(LOG_ERROR,
 		     "obs-streamelements-core: StreamElements: Crash Handler: sentry_init() failed");
 		return;
 	}
+
+	// Contact details the user gave on some previous crash report, if any.
+	// Read here rather than on the crash path, both to prefill the prompt
+	// and so that a crash which never reaches the prompt -- a fast-fail
+	// caught by WER, say -- still says who it came from.
+	auto config = StreamElementsConfig::GetInstance();
+
+	if (config) {
+		s_userName = config->GetCrashReportUserName();
+		s_userEmail = config->GetCrashReportUserEmail();
+	}
+
+	SetSentryUser(s_userName, s_userEmail);
 
 	// Whatever sentry_init() installed. Ours goes on top, so ours runs
 	// first and this one is invoked by us, deliberately, only when the


### PR DESCRIPTION
Fifth step on CORE-554, and the last of the explicitly-requested behaviours: **preserve the crash-time prompt, and remember the contact details the user enters.**

BugSplat shows its own dialog before sending, asking what the user was doing and letting them supply contact details. **Sentry has no such UI — it uploads silently.** Switching backends without this would quietly remove a prompt users have been seeing for years, start sending crash data from people who never agreed to it, and lose the report descriptions, which are frequently the only account of what the user was actually doing.

## The dialog

Native Win32, assembled from an in-memory `DLGTEMPLATE`, **deliberately not Qt**. The crash handler touches no Qt anywhere: by the time this runs the process is dying, the Qt event loop may be the very thing that is wedged, and `QApplication` is not safe to re-enter from an exception filter.

Shown **only after the module-of-interest gate passes** — the user is never asked about a crash that was never going to be sent. Declining suppresses the report entirely, and so does *failing to create the dialog*: an unshowable prompt must not degrade into a silent upload.

**No owner window, deliberately.** Owning it to the OBS main window attaches our input queue to that window's thread — which on a crash path is quite possibly the thread that just faulted, or one blocked waiting on it. Attaching to a wedged input queue would turn a crash into a hang. The cost is that it is not modal to OBS, hence `WS_EX_TOPMOST` and an explicit `SetForegroundWindow`.

## Where the answers go

**Not** through Sentry's User Feedback API. `sentry_capture_feedback()` needs an `event_id` to attach to, and the event is created downstream by sentry's own filter (see #104) — there is no id to hand it at this point. The answers go onto the scope instead, as `sentry_set_user()` plus a `user_report` context, and travel with the event that filter builds.

Name and email persist to the plugin config under a `CrashReporting` section, prefill the next prompt, and are **also read at startup and pushed to `sentry_set_user()` there** — so a crash that never reaches the prompt, such as a fast-fail caught by WER, still says who it came from.

## Verification — the part that actually mattered

A hand-assembled `DLGTEMPLATE` is easy to get subtly wrong, and the failure mode is nasty: Windows refuses to create the dialog, `DialogBoxIndirectParamW` returns `-1`, and this code reads that as *"the user declined"*. **Every crash report would be silently suppressed** — a failure that looks exactly like "no crashes happened".

That is worth testing rather than assuming, so the template builder was split out of `Prompt()` specifically so it could be exercised without showing a modal dialog. The harness creates the dialog modelessly from the same template and inspects it. **17 checks, all passing:**

| Group | Checks |
|---|---|
| Template validity | Windows accepts it; child count matches the 9 the header declares |
| Controls | description / name / email edits and both buttons all exist by ID |
| `WM_INITDIALOG` | name and email prefilled, description starts empty |
| Button identity | `IDOK` is "Send report", `IDCANCEL` is "Don't send" |
| `IDOK` path | consent recorded, typed description and edited name harvested, untouched email retained |
| `IDCANCEL` path | **no consent, nothing harvested** |

The harness compiles the dialog against a stub of `StreamElementsUtils.hpp`, so it needs no OBS/Qt/CEF. It is not part of the build — there is nowhere to put it.

Plus all three backend selections (`sentry`, `bugsplat`, `none`) build with **0 warnings** under `/WX`.

**Not verified:** no real crash has been triggered, so the dialog has never been shown from an actual exception filter. What is proven is that the template is valid and the consent logic is correct; what is not is how it behaves on a genuinely dying process.

## One judgement call worth flagging

The dialog's strings are **hardcoded English**, not routed through `obs_module_text()`. CLAUDE.md says user-visible strings should be localised, so this is a deliberate deviation: every other user-visible string in the crash handler is already hardcoded (the "please wait" window, BugSplat's own prompts), and reaching into the module's locale lookup from a dying process is a risk with little upside. Localising this one dialog would leave it inconsistent with its neighbours. Say the word if you'd rather it went through the locale file — it's a small change, and the rest of the crash handler should probably move with it.

#partial — remaining on CORE-554: the PNG screenshot, CI symbol upload, and the behavioural crash testing.
