### PR TITLE
feat(crash): add a Discord handle and a PII notice to the consent prompt (CORE-554) #partial

### DIFF
--- a/streamelements/StreamElementsConfig.hpp
+++ b/streamelements/StreamElementsConfig.hpp
@@ -256,6 +256,24 @@ public:
 		SaveConfig();
 	}
 
+	std::string GetCrashReportUserDiscord()
+	{
+		const char *value = config_get_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserDiscord");
+
+		return !!value ? value : "";
+	}
+
+	void SetCrashReportUserDiscord(std::string value)
+	{
+		config_set_string(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "UserDiscord", value.c_str());
+
+		SaveConfig();
+	}
+
 	std::string GetSceneItemsAuxActionsConfig()
 	{
 		const char *value = config_get_string(

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -24,7 +24,23 @@ static const wchar_t *const PROMPT_TEXT =
 	L"What were you doing just before this happened?";
 
 static const wchar_t *const CONTACT_TEXT =
-	L"Name and email are optional. They let us follow up about this crash, and are remembered for next time.";
+	L"All three are optional. They let us follow up about this crash, and are remembered for next time.";
+
+//
+// What the report actually contains.
+//
+// The archive is the whole OBS configuration tree plus a picture of the OBS
+// main window, which can show a camera preview, a browser source or anything
+// else on screen at the moment of the crash. That is personal information by
+// any reasonable reading, and the user is entitled to know before consenting.
+//
+// The stream-key claim is load-bearing and true: service.json is redacted in
+// place before it enters the archive. If that redaction is ever removed or
+// bypassed, this sentence has to go with it.
+//
+static const wchar_t *const PRIVACY_TEXT =
+	L"The report includes your OBS Studio and SE.Live configuration and an image of the OBS window. "
+	L"These may contain personal information, and are used only to diagnose this crash. Stream keys are removed.";
 
 /* ================================================================= */
 
@@ -32,6 +48,7 @@ static const wchar_t *const CONTACT_TEXT =
 #define IDC_NAME 1002
 #define IDC_EMAIL 1003
 #define IDC_ERRORICON 1004
+#define IDC_DISCORD 1005
 
 // System window class atoms, as used inside a dialog template.
 #define ATOM_BUTTON 0x0080
@@ -119,6 +136,7 @@ static void AddControl(DialogTemplateBuilder &builder, DWORD style, short x,
 struct DialogState {
 	std::wstring name;
 	std::wstring email;
+	std::wstring discord;
 
 	std::wstring description;
 	bool consented = false;
@@ -157,6 +175,8 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 					  state->name.c_str());
 			::SetDlgItemTextW(dialog, IDC_EMAIL,
 					  state->email.c_str());
+			::SetDlgItemTextW(dialog, IDC_DISCORD,
+					  state->discord.c_str());
 		}
 
 		// The system error icon, in the body next to the message and
@@ -209,6 +229,7 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 				GetControlText(dialog, IDC_DESCRIPTION);
 			state->name = GetControlText(dialog, IDC_NAME);
 			state->email = GetControlText(dialog, IDC_EMAIL);
+			state->discord = GetControlText(dialog, IDC_DISCORD);
 			state->consented = true;
 		}
 
@@ -235,11 +256,11 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 	builder.AddDword(dialogStyle);
 	builder.AddDword(WS_EX_TOPMOST);
-	builder.AddWord(10); // control count
+	builder.AddWord(13); // control count
 	builder.AddShort(0);
 	builder.AddShort(0);
 	builder.AddShort(320);
-	builder.AddShort(200);
+	builder.AddShort(232);
 
 	builder.AddWord(0); // no menu
 	builder.AddWord(0); // default dialog class
@@ -263,25 +284,36 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 	AddControl(builder,
 		   editStyle | ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL, 7, 37,
-		   306, 62, IDC_DESCRIPTION, ATOM_EDIT, L"");
+		   306, 58, IDC_DESCRIPTION, ATOM_EDIT, L"");
 
-	AddControl(builder, visibleChild, 7, 108, 40, 10, (WORD)-1, ATOM_STATIC,
+	// Labels are 44 wide rather than 40 so "Discord:" is not clipped; the
+	// edits start past them at 54 and share a right edge with everything
+	// else at 313.
+	AddControl(builder, visibleChild, 7, 102, 44, 10, (WORD)-1, ATOM_STATIC,
 		   L"Name:");
-	AddControl(builder, editStyle, 50, 106, 263, 13, IDC_NAME, ATOM_EDIT,
+	AddControl(builder, editStyle, 54, 100, 259, 13, IDC_NAME, ATOM_EDIT,
 		   L"");
 
-	AddControl(builder, visibleChild, 7, 128, 40, 10, (WORD)-1, ATOM_STATIC,
+	AddControl(builder, visibleChild, 7, 120, 44, 10, (WORD)-1, ATOM_STATIC,
 		   L"Email:");
-	AddControl(builder, editStyle, 50, 126, 263, 13, IDC_EMAIL, ATOM_EDIT,
+	AddControl(builder, editStyle, 54, 118, 259, 13, IDC_EMAIL, ATOM_EDIT,
 		   L"");
 
-	AddControl(builder, visibleChild, 7, 146, 306, 20, (WORD)-1,
+	AddControl(builder, visibleChild, 7, 138, 44, 10, (WORD)-1, ATOM_STATIC,
+		   L"Discord:");
+	AddControl(builder, editStyle, 54, 136, 259, 13, IDC_DISCORD, ATOM_EDIT,
+		   L"");
+
+	AddControl(builder, visibleChild, 7, 155, 306, 10, (WORD)-1,
 		   ATOM_STATIC, CONTACT_TEXT);
 
-	AddControl(builder, visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON, 185,
-		   176, 60, 16, IDOK, ATOM_BUTTON, L"Send report");
+	AddControl(builder, visibleChild, 7, 170, 306, 30, (WORD)-1,
+		   ATOM_STATIC, PRIVACY_TEXT);
 
-	AddControl(builder, visibleChild | WS_TABSTOP | BS_PUSHBUTTON, 253, 176,
+	AddControl(builder, visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON, 185,
+		   208, 60, 16, IDOK, ATOM_BUTTON, L"Send report");
+
+	AddControl(builder, visibleChild | WS_TABSTOP | BS_PUSHBUTTON, 253, 208,
 		   60, 16, IDCANCEL, ATOM_BUTTON, L"Don't send");
 }
 
@@ -289,13 +321,15 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 StreamElementsCrashConsentDialog::Result
 StreamElementsCrashConsentDialog::Prompt(const std::string &name,
-					 const std::string &email)
+					 const std::string &email,
+					 const std::string &discord)
 {
 	Result result;
 
 	DialogState state;
 	state.name = utf8_to_wstring(name);
 	state.email = utf8_to_wstring(email);
+	state.discord = utf8_to_wstring(discord);
 
 	DialogTemplateBuilder builder;
 
@@ -325,6 +359,7 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 	result.description = wstring_to_utf8(state.description);
 	result.name = wstring_to_utf8(state.name);
 	result.email = wstring_to_utf8(state.email);
+	result.discord = wstring_to_utf8(state.discord);
 
 	return result;
 }

--- a/streamelements/StreamElementsCrashConsentDialog.hpp
+++ b/streamelements/StreamElementsCrashConsentDialog.hpp
@@ -34,15 +34,17 @@ public:
 		std::string description;
 		std::string name;
 		std::string email;
+		std::string discord;
 	};
 
 public:
 	// Shows the prompt modally on the calling thread, which is the crashing
-	// thread. `name` and `email` prefill their fields; pass what was saved
-	// from the last report.
+	// thread. `name`, `email` and `discord` prefill their fields; pass what
+	// was saved from the last report.
 	//
 	// Returns consented=false if the dialog cannot be created, so a failure
 	// here suppresses the report rather than silently sending one the user
 	// never agreed to.
-	static Result Prompt(const std::string &name, const std::string &email);
+	static Result Prompt(const std::string &name, const std::string &email,
+			     const std::string &discord);
 };

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -46,6 +46,7 @@ static HWND s_messageWindow = NULL;
 // prompt.
 static std::string s_userName;
 static std::string s_userEmail;
+static std::string s_userDiscord;
 
 /* ================================================================= */
 
@@ -165,7 +166,8 @@ static bool IsTagWorthyAttribute(const std::string &name)
 // crash that never reaches the prompt still says who it came from -- and again
 // after the prompt, with whatever was just typed.
 //
-static void SetSentryUser(const std::string &name, const std::string &email)
+static void SetSentryUser(const std::string &name, const std::string &email,
+			  const std::string &discord)
 {
 	sentry_value_t user = sentry_value_new_object();
 
@@ -183,6 +185,15 @@ static void SetSentryUser(const std::string &name, const std::string &email)
 					sentry_value_new_string(email.c_str()));
 	}
 
+	// Not one of Sentry's recognised user fields, but the user object
+	// preserves and displays additional keys -- and this belongs with the
+	// rest of the reporter's identity rather than off in a context.
+	if (discord.size()) {
+		sentry_value_set_by_key(
+			user, "discord",
+			sentry_value_new_string(discord.c_str()));
+	}
+
 	sentry_set_user(user);
 }
 
@@ -196,7 +207,8 @@ static void SetSentryUser(const std::string &name, const std::string &email)
 // unconditionally.
 //
 static void PersistContactDetails(const std::string &name,
-				  const std::string &email)
+				  const std::string &email,
+				  const std::string &discord)
 {
 	auto config = StreamElementsConfig::GetInstance();
 
@@ -213,6 +225,12 @@ static void PersistContactDetails(const std::string &name,
 		config->SetCrashReportUserEmail(email);
 
 		s_userEmail = email;
+	}
+
+	if (discord.size() && discord != s_userDiscord) {
+		config->SetCrashReportUserDiscord(discord);
+
+		s_userDiscord = discord;
 	}
 }
 
@@ -266,7 +284,7 @@ ArmSentryScope(const StreamElementsCrashContext::Result &context,
 	// is no id to hand it at this point. On the scope it travels with the
 	// event that filter builds.
 	//
-	SetSentryUser(consent.name, consent.email);
+	SetSentryUser(consent.name, consent.email, consent.discord);
 
 	if (consent.description.size()) {
 		sentry_value_t report = sentry_value_new_object();
@@ -311,11 +329,12 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 			// only account of what the user was actually doing.
 			const auto consent =
 				StreamElementsCrashConsentDialog::Prompt(
-					s_userName, s_userEmail);
+					s_userName, s_userEmail, s_userDiscord);
 
 			if (consent.consented) {
 				PersistContactDetails(consent.name,
-						      consent.email);
+						      consent.email,
+						      consent.discord);
 
 				// Only now: collecting the payload and waiting
 				// on the daemon takes a moment, and there is
@@ -429,9 +448,10 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	if (config) {
 		s_userName = config->GetCrashReportUserName();
 		s_userEmail = config->GetCrashReportUserEmail();
+		s_userDiscord = config->GetCrashReportUserDiscord();
 	}
 
-	SetSentryUser(s_userName, s_userEmail);
+	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
 
 	// Whatever sentry_init() installed. Ours goes on top, so ours runs
 	// first and this one is invoked by us, deliberately, only when the


### PR DESCRIPTION
Two additions to the crash consent dialog from #106.

## Discord handle

Sits alongside name and email. Persists to the plugin config the same way, prefills the next prompt, and rides the Sentry **user object** as a custom `discord` key — not one of Sentry's recognised user fields, but the user object preserves and displays additional keys, and this belongs with the rest of the reporter's identity rather than off in a separate context.

Discord is where support conversations actually happen, so for a lot of users it will be the only contact detail they're willing to give.

## Privacy notice

Below the fields:

> The report includes your OBS Studio and SE.Live configuration and an image of the OBS window. These may contain personal information, and are used only to diagnose this crash. Stream keys are removed.

Both specifics are deliberate. The **image of the OBS window** is the most concretely personal thing in the archive — it can show a camera preview, a browser source, or whatever was on screen at the moment of the crash — and it's easy for a user not to realise it's included.

The **stream keys are removed** clause is load-bearing and currently true: `service.json` is redacted in place before it enters the archive (#105). There is a comment at the string saying that if that redaction is ever removed or bypassed, this sentence has to go with it. A privacy assurance that quietly stops being accurate is worse than none.

## Layout

The window grows `320×200` → `320×232` dialog units. Contact labels widen `40` → `44` so "Discord:" isn't clipped, and the edits shift right to match while keeping the same right edge as everything else.

## Verification

Harness re-run — **26 checks, all passing**, up from 22. New coverage:

- the Discord field exists, prefills, and is retained when untouched
- the 13-control count matches what the template declares
- **every control fits inside the client area** — a field pushed past the bottom edge by a layout change would be invisible but still tab-reachable, which is exactly the kind of thing that survives a code review and fails in front of a user

All three backend selections (`sentry`, `bugsplat`, `none`) build with **0 warnings** under `/WX`.

**Not verified:** still no real crash. The dialog has never been shown from an actual exception filter.

#partial — CORE-554 continues with the PNG screenshot, CI symbol upload, and behavioural crash testing.
