### PR TITLE
feat(crash): Sentry crash handling on macOS, and build against OBS 32.2.1 (CORE-554) #partial

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
     if: needs.version.outputs.is_workflow_automation != 'true'
 
     env:
-      CHECKOUT: 31.1.2
+      CHECKOUT: 32.2.1
       GS_ACCESS_KEY_ID: ${{ secrets.GS_ACCESS_KEY_ID }}
       GS_KEY_BASE64: ${{ secrets.GS_KEY_BASE64 }}
       GITHUB_WORKSPACE: $GITHUB_WORKSPACE
@@ -372,11 +372,11 @@ jobs:
 
   macos:
     needs: version
-    runs-on: macos-15
+    runs-on: macos-26
     if: needs.version.outputs.is_workflow_automation != 'true'
 
     env:
-      CHECKOUT: 31.1.2
+      CHECKOUT: 32.2.1
       GS_SECRET_ACCESS_KEY: ${{ secrets.GS_SECRET_ACCESS_KEY }}
 
     steps:
@@ -388,6 +388,19 @@ jobs:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
+
+      # OBS 32.2.x refuses to configure on anything below the macOS 26.5 SDK --
+      # cmake/macos/compilerconfig.cmake fails outright, before any of our code
+      # is reached. The macos-26 image ships several Xcodes and does not
+      # necessarily default to one new enough, so select it explicitly. This
+      # mirrors what obs-studio's own build-project.yaml does.
+      - name: Select Xcode
+        run: |
+          if [ -d /Applications/Xcode_26.5.app ]; then
+            sudo xcode-select --switch /Applications/Xcode_26.5.app/Contents/Developer
+          fi
+          xcodebuild -version
+          echo "macOS SDK: $(xcrun --sdk macosx --show-sdk-platform-version)"
 
       - name: Clone OBS Studio
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
 
   windows:
     needs: version
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     if: needs.version.outputs.is_workflow_automation != 'true'
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,8 +314,8 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cd /d C:\local\obs-studio\build_x64
-          msbuild obs-studio.sln -p:Configuration=RelWithDebInfo
+          cd /d C:\local\obs-studio
+          cmake --build build_x64 --config RelWithDebInfo
 
       - name: Upload BugSplat Symbols
         if: ${{ env.UPLOAD_SYMBOLS == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,11 @@ env:
 
   BUILD_UNINSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
   BUILD_INSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-  UPLOAD_SYMBOLS: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+  # UPLOAD_SYMBOLS is deliberately NOT defined here. It also depends on
+  # has_release_notes, and workflow-level env cannot read `needs`, so it is
+  # defined in the windows and macos jobs instead. Defining a weaker version
+  # here as well would mean any future job that forgot to redefine it silently
+  # uploaded symbols for builds that are never released.
   UPLOAD_BINARIES: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
 
 jobs:
@@ -234,6 +238,17 @@ jobs:
       GS_KEY_BASE64: ${{ secrets.GS_KEY_BASE64 }}
       GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
+      # Redefined here rather than taken from the workflow-level env, because
+      # that one cannot see `needs` -- only job-level env can. Same condition
+      # plus the release-notes gate.
+      #
+      # A master build with an empty RELEASE_NOTES.md is tagged by nothing,
+      # released by nothing and published by nothing: deploy-signed-* and
+      # finalize are gated on exactly the same output. Uploading its symbols
+      # would file them under a version that does not exist as far as anything
+      # downstream is concerned.
+      UPLOAD_SYMBOLS: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && needs.version.outputs.has_release_notes == 'true' }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -378,6 +393,11 @@ jobs:
     env:
       CHECKOUT: 32.2.1
       GS_SECRET_ACCESS_KEY: ${{ secrets.GS_SECRET_ACCESS_KEY }}
+
+      # See the matching comment in the windows job: job-level env is the only
+      # scope that can read `needs`, so the release-notes gate has to be applied
+      # here rather than at workflow level.
+      UPLOAD_SYMBOLS: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && needs.version.outputs.has_release_notes == 'true' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,21 @@ This plugin does **not** build standalone. It must sit at `obs-studio/plugins/ob
 
 ## Tests
 
-There are none — no ctest, gtest, or catch2 anywhere in project code. The only gates are that it compiles and that `CI/check-format.sh` passes. Don't describe a change as verified on the basis of tests.
+`tests/` holds a small ctest suite, off by default (`-DSE_ENABLE_TESTS=ON`, or configure `tests/` directly). It is **not** part of the plugin build: the tests are standalone C++17 executables that link neither libobs nor Qt, so they build and run without an obs-studio tree — on any platform, in seconds.
+
+```sh
+cmake -S tests -B tests/build && cmake --build tests/build
+ctest --test-dir tests/build --output-on-failure
+```
+
+Two kinds live there, and `se_add_test(<name> <sources>)` in `tests/CMakeLists.txt` registers both:
+
+- **Behavioural** — exercise real logic directly, or a minimal mirror of it where the real thing is entangled with libobs.
+- **Source-invariant** — open the production sources and assert a fixed bug pattern is absent, so a regression is caught without needing the OBS build to succeed.
+
+Anything self-contained enough to compile without libobs/Qt belongs here rather than in a throwaway harness — parsers, redaction, string handling, pure helpers. Deliberately keeping a unit under test free of OBS dependencies is a good reason to structure it that way.
+
+CI does **not** run these yet, so they are a local gate: the pipeline still only proves that it compiles and that `CI/check-format.sh` passes. Don't call a change verified on the basis of tests that were never run against it.
 
 ## Formatting
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,9 +435,11 @@ list(APPEND obs-streamelements-core_SOURCES
 )
 
 # Backend-agnostic crash-time collection, shared by whichever backend is
-# selected. Windows only for now: the macOS integrations gather nothing beyond a
-# single attribute set at startup, so there is no macOS implementation yet.
-if (WIN32 AND (ENABLE_BUGSPLAT OR ENABLE_SENTRY))
+# selected and by both platforms. The collection itself is portable -- the same
+# zip, the same system and performance snapshots, the same async- and API-call
+# context; only the stack walk, the temporary-file dance and the window capture
+# fork, and those are #ifdef'd inside.
+if (ENABLE_BUGSPLAT OR ENABLE_SENTRY)
 	list(APPEND obs-streamelements-core_SOURCES
 		streamelements/StreamElementsCrashContext.cpp
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,15 @@ if (APPLE)
   target_compile_options(obs-streamelements-core PRIVATE
     "$<$<CXX_COMPILER_ID:Clang>:-g>"
   )
+
+  # Applied to the target rather than through add_compile_options above: the
+  # directory-level options do not survive onto this target under the Xcode
+  # generator, so the suppression has to be attached here to take effect.
+  if (HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+    target_compile_options(obs-streamelements-core PRIVATE
+      "-Wno-deprecated-literal-operator"
+    )
+  endif()
 endif()
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,15 +445,30 @@ if (ENABLE_BUGSPLAT)
 endif()
 
 if (ENABLE_SENTRY)
-	list(APPEND obs-streamelements-core_SOURCES
-		streamelements/StreamElementsSentryCrashHandler.cpp
-	)
+	# One handler per platform. They share the header and the overall shape --
+	# arm, hand off, ask -- but not the mechanism: Windows chains SEH filters,
+	# macOS chains signal handlers and leans on sentry's own consent gate,
+	# because sentry's macOS handler chains to its predecessor and its Windows
+	# one does not. See StreamElementsSentryCrashHandler.hpp.
+	if (APPLE)
+		list(APPEND obs-streamelements-core_SOURCES
+			streamelements/StreamElementsSentryCrashHandler.mm
+		)
+	else()
+		list(APPEND obs-streamelements-core_SOURCES
+			streamelements/StreamElementsSentryCrashHandler.cpp
+		)
+	endif()
 
 	# The crash-time consent prompt. Only Sentry needs it: BugSplat's SDK
 	# shows a prompt of its own, whereas Sentry uploads silently.
 	if (WIN32)
 		list(APPEND obs-streamelements-core_SOURCES
 			streamelements/StreamElementsCrashConsentDialog.cpp
+		)
+	elseif (APPLE)
+		list(APPEND obs-streamelements-core_SOURCES
+			streamelements/StreamElementsCrashConsentDialog.mm
 		)
 	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,9 +411,20 @@ set(obs-streamelements-core_SOURCES
 if (APPLE)
     list(APPEND obs-streamelements-core_SOURCES
         streamelements/StreamElementsUtils.mm
-		streamelements/mach_excServer.c
-		streamelements/mach_excUser.c
     )
+
+	# The mig-generated Mach exception server belongs to the BugSplat handler,
+	# not to the platform: the catch_mach_exception_* callbacks it dispatches
+	# to are defined in StreamElementsBugSplatCrashHandler.mm and nowhere
+	# else. Compiled unconditionally they leave those symbols undefined in any
+	# macOS build that selects another backend, which is why this only
+	# surfaced once one was built.
+	if (ENABLE_BUGSPLAT)
+		list(APPEND obs-streamelements-core_SOURCES
+			streamelements/mach_excServer.c
+			streamelements/mach_excUser.c
+		)
+	endif()
 endif(APPLE)
 
 # The factory is platform-agnostic and always compiles; the selected backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,22 @@ else()
 
 		"-fvisibility=default"
 	)
+
+	# Xcode 26's clang added -Wdeprecated-literal-operator, which fires inside
+	# vendored nlohmann/json (deps/cef-stub/../json.hpp) on its `operator ""_json`
+	# declarations. Xcode builds with -Werror, so on that toolchain the plugin
+	# cannot compile at all -- and deps/ is vendored, so the fix belongs here
+	# rather than in the header.
+	#
+	# Probed rather than added blindly: older clang, including the one on CI's
+	# macos-15 runners, does not know this flag, and -Werror turns an unknown
+	# -Wno-* into an error of its own.
+	include(CheckCXXCompilerFlag)
+	check_cxx_compiler_flag("-Wno-deprecated-literal-operator"
+		HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+	if (HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+		add_compile_options("-Wno-deprecated-literal-operator")
+	endif()
 endif(WIN32)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -899,6 +899,25 @@ if (WIN32)
 	endif()
 endif()
 
+if (APPLE AND ENABLE_SENTRY)
+	# Same requirement as the Windows copy above -- without the daemon beside
+	# the binary, Sentry produces events with no minidump attached -- but the
+	# destination is inside the plugin bundle, next to the loadable module in
+	# Contents/MacOS. $<TARGET_FILE_DIR:...> already resolves to that
+	# directory for a MODULE inside a bundle.
+	#
+	# It has to be signed as its own executable when the bundle is signed:
+	# --deep does not reliably cover nested executables and is deprecated by
+	# Apple, so the packaging step signs this explicitly.
+	add_dependencies(obs-streamelements-core sentry-crash)
+
+	add_custom_command(TARGET obs-streamelements-core POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE:sentry-crash>"
+		"$<TARGET_FILE_DIR:obs-streamelements-core>"
+	)
+endif()
+
 
 if(BUILD_OUT_OF_TREE)
 	install_obs_plugin_with_data(obs-streamelements-core data)

--- a/streamelements/StreamElementsBandwidthTestManager.cpp
+++ b/streamelements/StreamElementsBandwidthTestManager.cpp
@@ -62,7 +62,7 @@ bool StreamElementsBandwidthTestManager::BeginBandwidthTest(CefRefPtr<CefValue> 
 				m_isTestInProgress = true;
 
 				// Signal test started
-				DispatchJSEventContainer(target, "hostBandwidthTestStarted", nullptr);
+				DispatchJSEventContainer(target, "hostBandwidthTestStarted", "null");
 
 				struct local_context {
 					StreamElementsBandwidthTestManager* self;
@@ -88,7 +88,7 @@ bool StreamElementsBandwidthTestManager::BeginBandwidthTest(CefRefPtr<CefValue> 
 						context->self->m_last_test_results = *results;
 
 						// Signal test progress
-						DispatchJSEventContainer(context->target, "hostBandwidthTestProgress", nullptr);
+						DispatchJSEventContainer(context->target, "hostBandwidthTestProgress", "null");
 					},
 					[](std::vector<StreamElementsBandwidthTestClient::Result>* results, void* data) {
 						local_context* context = (local_context*)data;
@@ -101,7 +101,7 @@ bool StreamElementsBandwidthTestManager::BeginBandwidthTest(CefRefPtr<CefValue> 
 						context->self->m_isTestInProgress = false;
 
 						// Signal test completed
-						DispatchJSEventContainer(context->target, "hostBandwidthTestCompleted", nullptr);
+						DispatchJSEventContainer(context->target, "hostBandwidthTestCompleted", "null");
 
 						delete context;
 					},

--- a/streamelements/StreamElementsCrashConsentDialog.mm
+++ b/streamelements/StreamElementsCrashConsentDialog.mm
@@ -1,0 +1,164 @@
+#include "StreamElementsCrashConsentDialog.hpp"
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <string>
+
+/* ================================================================= */
+
+//
+// Strings match the Windows dialog word for word, and are hardcoded English for
+// the same reason -- see StreamElementsCrashConsentDialog.cpp. Keep the two in
+// step: users on the two platforms should be answering the same question.
+//
+static NSString *const kPromptText =
+	@"OBS Studio has stopped working, and SE.Live can send a report to help us fix it. "
+	@"What were you doing just before this happened?";
+
+static NSString *const kContactText =
+	@"All three are optional. They let us follow up about this crash, and are remembered for next time.";
+
+static NSString *const kPrivacyText =
+	@"The report includes your OBS Studio and SE.Live configuration and an image of the OBS window. "
+	@"These may contain personal information, and are used only to diagnose this crash. Stream keys are removed.";
+
+/* ================================================================= */
+
+static NSTextField *AddLabel(NSView *parent, NSString *text, CGFloat y,
+			     CGFloat width, CGFloat height, bool small)
+{
+	NSTextField *label = [[NSTextField alloc]
+		initWithFrame:NSMakeRect(0, y, width, height)];
+
+	[label setStringValue:text];
+	[label setBezeled:NO];
+	[label setDrawsBackground:NO];
+	[label setEditable:NO];
+	[label setSelectable:NO];
+
+	if (small) {
+		[label setFont:[NSFont systemFontOfSize:
+					       [NSFont smallSystemFontSize]]];
+		[label setTextColor:[NSColor secondaryLabelColor]];
+	}
+
+	[parent addSubview:label];
+
+	return label;
+}
+
+static NSTextField *AddField(NSView *parent, NSString *caption,
+			     const std::string &value, CGFloat y, CGFloat width)
+{
+	AddLabel(parent, caption, y + 3, 60, 17, false);
+
+	NSTextField *field = [[NSTextField alloc]
+		initWithFrame:NSMakeRect(64, y, width - 64, 22)];
+
+	[field setStringValue:[NSString stringWithUTF8String:value.c_str()]];
+
+	[parent addSubview:field];
+
+	return field;
+}
+
+static std::string ToUtf8(NSTextField *field)
+{
+	NSString *value = [field stringValue];
+
+	if (!value)
+		return "";
+
+	const char *utf8 = [value UTF8String];
+
+	return utf8 ? std::string(utf8) : std::string();
+}
+
+/* ================================================================= */
+
+StreamElementsCrashConsentDialog::Result
+StreamElementsCrashConsentDialog::Prompt(const std::string &name,
+					 const std::string &email,
+					 const std::string &discord)
+{
+	Result result;
+
+	//
+	// AppKit is main-thread-only, and this is called from a signal handler
+	// that may be running on any thread. Marshalling onto the main thread is
+	// not an option either: on a crash that thread is quite possibly the one
+	// that faulted, or is blocked, and dispatch_sync would deadlock.
+	//
+	// So: only prompt when we are already on the main thread. Off it, the
+	// caller treats a declined result as "do not send", which is the safe
+	// direction -- a report is lost rather than sent unasked.
+	//
+	if (![NSThread isMainThread])
+		return result;
+
+	@autoreleasepool {
+		const CGFloat width = 420;
+
+		NSView *accessory = [[NSView alloc]
+			initWithFrame:NSMakeRect(0, 0, width, 210)];
+
+		// Laid out from the bottom up: AppKit's origin is bottom-left,
+		// so the first control added sits lowest on screen.
+		AddLabel(accessory, kPrivacyText, 0, width, 48, true);
+		AddLabel(accessory, kContactText, 52, width, 32, true);
+
+		NSTextField *discordField =
+			AddField(accessory, @"Discord:", discord, 92, width);
+		NSTextField *emailField =
+			AddField(accessory, @"Email:", email, 120, width);
+		NSTextField *nameField =
+			AddField(accessory, @"Name:", name, 148, width);
+
+		NSScrollView *scroll = [[NSScrollView alloc]
+			initWithFrame:NSMakeRect(0, 178, width, 28)];
+		NSTextView *description = [[NSTextView alloc]
+			initWithFrame:NSMakeRect(0, 0, width, 28)];
+
+		[description setRichText:NO];
+		[scroll setDocumentView:description];
+		[scroll setHasVerticalScroller:YES];
+		[scroll setBorderType:NSBezelBorder];
+		[accessory addSubview:scroll];
+
+		NSAlert *alert = [[NSAlert alloc] init];
+
+		[alert setAlertStyle:NSAlertStyleCritical];
+		[alert setMessageText:@"SE.Live"];
+		[alert setInformativeText:kPromptText];
+		[alert setAccessoryView:accessory];
+		[alert addButtonWithTitle:@"Send report"];
+		[alert addButtonWithTitle:@"Don't send"];
+
+		[[alert window] setInitialFirstResponder:description];
+
+		// Nothing else will raise this: the app is dying behind it.
+		[NSApp activateIgnoringOtherApps:YES];
+
+		const NSModalResponse response = [alert runModal];
+
+		if (response != NSAlertFirstButtonReturn)
+			return result;
+
+		result.consented = true;
+		result.name = ToUtf8(nameField);
+		result.email = ToUtf8(emailField);
+		result.discord = ToUtf8(discordField);
+
+		NSString *text = [[description textStorage] string];
+
+		if (text) {
+			const char *utf8 = [text UTF8String];
+
+			if (utf8)
+				result.description = utf8;
+		}
+	}
+
+	return result;
+}

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -35,9 +35,31 @@
 // does not have to fork for the sake of a type name or an underscore.
 typedef unsigned char BYTE;
 
-#define _read read
-#define _close close
+// Functions rather than macros on purpose: the read loops below keep their
+// byte count in a local called `read`, which a macro would rewrite into a call
+// on an int.
+static inline int _read(int fd, void *buffer, size_t count)
+{
+	return (int)::read(fd, buffer, count);
+}
+
+static inline int _close(int fd)
+{
+	return ::close(fd);
+}
 #endif
+
+/* ================================================================= */
+
+//
+// itoa is an MSVC extension. snprintf is not, and is just as safe here.
+//
+static inline const char *IntToBuf(int value, char *buffer, size_t size)
+{
+	snprintf(buffer, size, "%d", value);
+
+	return buffer;
+}
 
 /* ================================================================= */
 
@@ -847,7 +869,7 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 						item.dwMemoryLoad // % Used
 					);
 				} else {
-					sprintf(lineBuf, "%1.2Lf,%d", 0.0,
+					sprintf(lineBuf, "%1.2Lf,%d", 0.0L,
 						item.dwMemoryLoad // % Used
 					);
 				}
@@ -874,9 +896,11 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 
 		for (auto item : *asyncCallContextStack) {
 			char buf[32];
-			lines.push_back(
-				item->file.c_str() + std::string(" (line: ") +
-				std::string(itoa(item->line, buf, 10)) + ")");
+			lines.push_back(item->file.c_str() +
+					std::string(" (line: ") +
+					std::string(IntToBuf(item->line, buf,
+							     sizeof(buf))) +
+					")");
 		}
 
 		addLinesBufferToZip(lines, L"async_context.txt");
@@ -893,7 +917,8 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 			char buf[32];
 			notes += std::string(" ---- ") + item->file +
 				 std::string(" (line: ") +
-				 std::string(itoa(item->line, buf, 10)) +
+				 std::string(IntToBuf(item->line, buf,
+						      sizeof(buf))) +
 				 ")\r\n";
 
 			auto d = CefDictionaryValue::Create();

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -4,7 +4,6 @@
 #include "StreamElementsGlobalStateManager.hpp"
 #include "StreamElementsSecretRedactor.hpp"
 #include "StreamElementsUtils.hpp"
-#include "deps/StackWalker/StackWalker.h"
 #include "deps/zip/zip.h"
 
 #include <util/base.h>
@@ -14,17 +13,31 @@
 #include <time.h>
 #include <stdio.h>
 #include <fcntl.h>
-#include <io.h>
 #include <string>
 #include <vector>
 #include <map>
 #include <filesystem>
 #include <algorithm>
 
+#ifdef WIN32
+#include "deps/StackWalker/StackWalker.h"
+#include <io.h>
 #include <windows.h>
 #include <winuser.h>
-
 #include <QString>
+#else
+#include <unistd.h>
+#include <execinfo.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+
+// Windows spellings used throughout the collection below, so the shared code
+// does not have to fork for the sake of a type name or an underscore.
+typedef unsigned char BYTE;
+
+#define _read read
+#define _close close
+#endif
 
 /* ================================================================= */
 
@@ -36,6 +49,8 @@
 // the remote settings.json when that fetch succeeds -- which is why the fetch
 // happens in the constructor, at plugin startup, and not on the crash path.
 //
+#ifdef WIN32
+
 static class MyStackWalker : public StackWalker {
 public:
 	MyStackWalker(int options) : StackWalker(options)
@@ -187,6 +202,74 @@ public:
 	std::string output;
 };
 
+#else
+
+//
+// macOS equivalent of the walker above.
+//
+// backtrace() rather than StackWalker: it is async-signal-safe, needs no symbol
+// server, and dladdr gives the owning image per frame, which is all the
+// module-of-interest test requires. The symbol names are less complete than a
+// Windows walk with a PDB -- the minidump and Sentry's own symbolication cover
+// that -- so this exists for the gate and for a human-readable stack.txt.
+//
+class MyStackWalker {
+public:
+	MyStackWalker()
+	{
+		output.reserve(1024 * 16);
+
+		modulesOfInterest.push_back("obs-streamelements-core");
+		modulesOfInterest.push_back("obs-streamelements");
+	}
+
+	void Walk()
+	{
+		void *frames[128];
+
+		const int count = backtrace(frames, 128);
+
+		char **symbols = backtrace_symbols(frames, count);
+
+		for (int i = 0; i < count; ++i) {
+			Dl_info info;
+
+			const char *image = "";
+
+			if (dladdr(frames[i], &info) && info.dli_fname)
+				image = info.dli_fname;
+
+			output += image;
+			output += "\t";
+			output += (symbols && symbols[i]) ? symbols[i] : "";
+			output += "\n";
+
+			if (hasMatchModuleOfInterest || !*image)
+				continue;
+
+			const std::string path = image;
+
+			for (auto &filter : modulesOfInterest) {
+				if (path.find(filter) != std::string::npos) {
+					hasMatchModuleOfInterest = true;
+
+					break;
+				}
+			}
+		}
+
+		if (symbols)
+			free(symbols);
+	}
+
+public:
+	bool hasMatchModuleOfInterest = false;
+	std::vector<std::string> modulesOfInterest;
+	std::string output;
+};
+
+#endif
+
 /* ================================================================= */
 
 struct StreamElementsCrashContext::Impl {
@@ -199,6 +282,7 @@ static inline bool GetTemporaryFilePath(const wchar_t *basename,
 					const wchar_t *ext,
 					std::wstring &wtempBufPath)
 {
+#ifdef WIN32
 	const size_t BUF_LEN = 2048;
 
 	std::vector<wchar_t> pathBuffer;
@@ -219,6 +303,27 @@ static inline bool GetTemporaryFilePath(const wchar_t *basename,
 	wtempBufPath += ext;
 
 	return true;
+#else
+	// mkstemp rather than tmpnam: it creates the file atomically, so two
+	// crashing processes cannot land on the same name. The suffix is
+	// appended afterwards because mkstemp owns the tail of the template.
+	std::string path = "/tmp/" + wstring_to_utf8(basename) + "-XXXXXX";
+
+	std::vector<char> buffer(path.begin(), path.end());
+	buffer.push_back('\0');
+
+	const int fd = mkstemp(buffer.data());
+
+	if (fd < 0)
+		return false;
+
+	close(fd);
+
+	wtempBufPath = utf8_to_wstring(std::string(buffer.data()) +
+				       wstring_to_utf8(ext));
+
+	return true;
+#endif
 }
 
 /* ================================================================= */
@@ -227,9 +332,13 @@ StreamElementsCrashContext::StreamElementsCrashContext()
 {
 	m_impl = new Impl();
 
+#ifdef WIN32
 	m_impl->stackWalker = new MyStackWalker(
 		StackWalker::RetrieveSymbol | StackWalker::RetrieveLine |
 		StackWalker::RetrieveModuleInfo);
+#else
+	m_impl->stackWalker = new MyStackWalker();
+#endif
 }
 
 StreamElementsCrashContext::~StreamElementsCrashContext()
@@ -248,8 +357,16 @@ void StreamElementsCrashContext::WalkStack(void *contextRecord)
 	if (!m_impl || !m_impl->stackWalker)
 		return;
 
+#ifdef WIN32
 	m_impl->stackWalker->ShowCallstack(::GetCurrentThread(),
 					   (PCONTEXT)contextRecord);
+#else
+	// The context record is ignored: backtrace() walks the calling thread,
+	// which on the crash path is the thread that faulted.
+	UNUSED_PARAMETER(contextRecord);
+
+	m_impl->stackWalker->Walk();
+#endif
 }
 
 bool StreamElementsCrashContext::ShouldReport() const
@@ -282,7 +399,11 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		return result;
 	}
 
+#ifdef WIN32
 	std::wstring obsDataPath = QString(programDataPathBuf).toStdWString();
+#else
+	std::wstring obsDataPath = utf8_to_wstring(programDataPathBuf);
+#endif
 
 	zip_t *zip = zip_open(tempBufPath.c_str(), 9, 'w');
 
@@ -332,8 +453,12 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		const bool redact =
 			StreamElementsSecretRedactor::IsSensitivePath(zipPath);
 
+#ifdef WIN32
 		int fd = _wsopen(localPath.c_str(), _O_RDONLY | _O_BINARY,
 				 _SH_DENYNO, 0 /*_S_IREAD | _S_IWRITE*/);
+#else
+		int fd = open(wstring_to_utf8(localPath).c_str(), O_RDONLY);
+#endif
 
 		if (-1 != fd) {
 			size_t BUF_LEN = 32768;
@@ -384,6 +509,7 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		}
 	};
 
+#ifdef WIN32
 	auto addWindowCaptureToZip = [&](const HWND &hWnd, int nBitCount,
 					 std::wstring zipPath) {
 		//calculate the number of color indexes in the color table
@@ -516,6 +642,7 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 
 		return true;
 	};
+#endif
 
 	std::string package_manifest = "generator=crash_handler\nversion=4\n";
 	addBufferToZip((BYTE *)package_manifest.c_str(),
@@ -545,11 +672,19 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		       L"obs-studio/crashes/crash.log");
 
 	// Add window capture
+	//
+	// Windows only. The equivalent on macOS is CGWindowListCreateImage,
+	// which since Catalina requires the Screen Recording entitlement --
+	// and if it has not already been granted, the first call puts up a
+	// system permission prompt. Doing that from a crashing process would
+	// be both useless and hostile, so macOS reports go without.
+#ifdef WIN32
 	addWindowCaptureToZip(
 		(HWND)StreamElementsGlobalStateManager::GetInstance()
 			->mainWindow()
 			->winId(),
 		24, L"obs-main-window.bmp");
+#endif
 
 	std::map<std::wstring, std::wstring> local_to_zip_files_map;
 

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -2,6 +2,7 @@
 
 #include "StreamElementsConfig.hpp"
 #include "StreamElementsCrashConsentDialog.hpp"
+#include "StreamElementsCrashContext.hpp"
 #include "StreamElementsUtils.hpp"
 
 #include <util/base.h>
@@ -47,37 +48,55 @@ static struct sigaction
 
 static volatile sig_atomic_t s_handledCrash = 0;
 
+// Owns the stack walker and the remote module-of-interest list. Built at
+// startup, because building it fetches that list over HTTP.
+static StreamElementsCrashContext *s_crashContext = nullptr;
+
 /* ================================================================= */
 
 //
-// Whether the crashing stack passed through our code.
+// Attributes worth having as searchable tags. Same reasoning and same short
+// list as the Windows handler: tags are capped under WER there, and keeping the
+// two platforms queryable the same way matters more than the cap does here.
 //
-// This is not the Windows gate. On Windows a full stack walk decides it, and a
-// crash that never touched us is never reported at all. macOS has never had
-// that gate -- the BugSplat integration reports every OBS crash -- so this does
-// not narrow what is reported; it exists so the *event* can say whether we were
-// on the stack, which is the part that costs nothing to know.
-//
-static bool StackTouchesOurModule()
+static bool IsTagWorthyAttribute(const std::string &name)
 {
-	void *callstack[128];
+	return name == "product" || name == "selive.api.calls";
+}
 
-	const int frames = backtrace(callstack, 128);
+//
+// Puts everything StreamElementsCrashContext gathered onto the scope, so the
+// event sentry builds a moment later carries it. Mirrors the Windows handler.
+//
+static void ArmSentryScope(const StreamElementsCrashContext::Result &context)
+{
+	sentry_value_t attributes = sentry_value_new_object();
 
-	Dl_info info;
+	for (auto &attribute : context.attributes) {
+		sentry_value_set_by_key(
+			attributes, attribute.name.c_str(),
+			sentry_value_new_string(attribute.value.c_str()));
 
-	for (int i = 0; i < frames; ++i) {
-		if (!dladdr(callstack[i], &info) || !info.dli_fname)
-			continue;
-
-		const std::string path = info.dli_fname;
-
-		if (path.find("obs-streamelements-core") != std::string::npos ||
-		    path.find("obs-streamelements") != std::string::npos)
-			return true;
+		if (IsTagWorthyAttribute(attribute.name)) {
+			sentry_set_tag(attribute.name.c_str(),
+				       attribute.value.c_str());
+		}
 	}
 
-	return false;
+	sentry_set_context("selive", attributes);
+
+	if (context.notes.size()) {
+		sentry_value_t async = sentry_value_new_object();
+
+		sentry_value_set_by_key(
+			async, "callStack",
+			sentry_value_new_string(context.notes.c_str()));
+
+		sentry_set_context("async_call_context", async);
+	}
+
+	for (auto &attachment : context.attachments)
+		sentry_attach_file(attachment.path.c_str());
 }
 
 //
@@ -160,8 +179,20 @@ static sentry_value_t OnCrash(const sentry_ucontext_t *uctx,
 	// call). Suppression is the consent gate's job instead -- see the class
 	// comment.
 	//
-	sentry_value_set_by_key(event, "selive_module_on_stack",
-				sentry_value_new_bool(StackTouchesOurModule()));
+	// It is, however, the last point at which the scope can still be
+	// changed: the envelope is written immediately after, and there is no
+	// public API to add to one that already exists. So the whole payload is
+	// gathered here rather than alongside the prompt.
+	//
+	if (s_crashContext) {
+		s_crashContext->WalkStack(nullptr);
+
+		sentry_value_set_by_key(
+			event, "selive_module_on_stack",
+			sentry_value_new_bool(s_crashContext->ShouldReport()));
+
+		ArmSentryScope(s_crashContext->Collect());
+	}
 
 	return event;
 }
@@ -320,6 +351,11 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	}
 
 	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
+
+	// After sentry_init, and deliberately: constructing this fetches the
+	// remote module-of-interest list over HTTP, which is not something to
+	// do while a signal handler might already be arriving.
+	s_crashContext = new StreamElementsCrashContext();
 
 	s_initialized = true;
 

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -55,6 +55,35 @@ static StreamElementsCrashContext *s_crashContext = nullptr;
 /* ================================================================= */
 
 //
+// Directory containing this dylib, inside the plugin bundle.
+//
+// Left unset, sentry-native looks for the sentry-crash daemon next to the host
+// executable -- OBS.app/Contents/MacOS -- which is not a directory this plugin
+// installs into. We ship the daemon beside our own binary and point the SDK at
+// it, exactly as the Windows handler does.
+//
+static bool GetOwnModuleDirectory(std::string &result)
+{
+	Dl_info info;
+
+	// Any symbol in this image will do; this function is a convenient one.
+	if (!dladdr((const void *)&GetOwnModuleDirectory, &info) ||
+	    !info.dli_fname)
+		return false;
+
+	const std::string path = info.dli_fname;
+
+	const size_t slash = path.rfind('/');
+
+	if (slash == std::string::npos)
+		return false;
+
+	result = path.substr(0, slash + 1);
+
+	return true;
+}
+
+//
 // Attributes worth having as searchable tags. Same reasoning and same short
 // list as the Windows handler: tags are capped under WER there, and keeping the
 // two platforms queryable the same way matters more than the cap does here.
@@ -328,6 +357,17 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	// process may not survive long enough to finish the upload.
 	//
 	sentry_options_set_require_user_consent(options, 1);
+
+	std::string moduleDirectory;
+
+	if (GetOwnModuleDirectory(moduleDirectory)) {
+		const std::string daemonPath = moduleDirectory + "sentry-crash";
+
+		sentry_options_set_handler_path(options, daemonPath.c_str());
+	} else {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve own module directory; falling back to the SDK's default sentry-crash lookup, which searches next to the host executable");
+	}
 
 	sentry_options_set_minidump_mode(options, SENTRY_MINIDUMP_MODE_SMART);
 

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -1,0 +1,342 @@
+#include "StreamElementsSentryCrashHandler.hpp"
+
+#include "StreamElementsConfig.hpp"
+#include "StreamElementsCrashConsentDialog.hpp"
+#include "StreamElementsUtils.hpp"
+
+#include <util/base.h>
+#include <obs.h>
+
+#include <sentry.h>
+
+#include <string>
+#include <vector>
+
+#include <signal.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <mach-o/dyld.h>
+
+// Empty means crash reporting is inert: sentry_init() is skipped entirely rather
+// than run against a bad DSN, so a build without the DSN behaves like
+// STREAMELEMENTS_CRASH_HANDLER=none instead of failing at runtime.
+#ifndef SE_SENTRY_DSN
+#define SE_SENTRY_DSN ""
+#endif
+
+/* ================================================================= */
+
+static bool s_initialized = false;
+
+// Contact details from the last report the user filled in. Read once at startup
+// so the crash path never has to touch the config to prefill the prompt.
+static std::string s_userName;
+static std::string s_userEmail;
+static std::string s_userDiscord;
+
+//
+// The signals sentry's native backend installs handlers for. Ours go on first,
+// before sentry_init, so that sentry saves them as its "previous" handlers and
+// calls them back once the daemon has captured the minidump.
+//
+static const int s_signals[] = {SIGSEGV, SIGBUS,  SIGFPE,
+				SIGILL,  SIGABRT, SIGTRAP};
+
+static struct sigaction
+	s_previousHandlers[sizeof(s_signals) / sizeof(s_signals[0])];
+
+static volatile sig_atomic_t s_handledCrash = 0;
+
+/* ================================================================= */
+
+//
+// Whether the crashing stack passed through our code.
+//
+// This is not the Windows gate. On Windows a full stack walk decides it, and a
+// crash that never touched us is never reported at all. macOS has never had
+// that gate -- the BugSplat integration reports every OBS crash -- so this does
+// not narrow what is reported; it exists so the *event* can say whether we were
+// on the stack, which is the part that costs nothing to know.
+//
+static bool StackTouchesOurModule()
+{
+	void *callstack[128];
+
+	const int frames = backtrace(callstack, 128);
+
+	Dl_info info;
+
+	for (int i = 0; i < frames; ++i) {
+		if (!dladdr(callstack[i], &info) || !info.dli_fname)
+			continue;
+
+		const std::string path = info.dli_fname;
+
+		if (path.find("obs-streamelements-core") != std::string::npos ||
+		    path.find("obs-streamelements") != std::string::npos)
+			return true;
+	}
+
+	return false;
+}
+
+//
+// Identifies the reporter on every event. Mirrors the Windows handler.
+//
+static void SetSentryUser(const std::string &name, const std::string &email,
+			  const std::string &discord)
+{
+	sentry_value_t user = sentry_value_new_object();
+
+	sentry_value_set_by_key(
+		user, "id",
+		sentry_value_new_string(GetComputerSystemUniqueId().c_str()));
+
+	if (name.size()) {
+		sentry_value_set_by_key(user, "username",
+					sentry_value_new_string(name.c_str()));
+	}
+
+	if (email.size()) {
+		sentry_value_set_by_key(user, "email",
+					sentry_value_new_string(email.c_str()));
+	}
+
+	if (discord.size()) {
+		sentry_value_set_by_key(
+			user, "discord",
+			sentry_value_new_string(discord.c_str()));
+	}
+
+	sentry_set_user(user);
+}
+
+static void PersistContactDetails(const std::string &name,
+				  const std::string &email,
+				  const std::string &discord)
+{
+	auto config = StreamElementsConfig::GetInstance();
+
+	if (!config)
+		return;
+
+	if (name.size() && name != s_userName) {
+		config->SetCrashReportUserName(name);
+
+		s_userName = name;
+	}
+
+	if (email.size() && email != s_userEmail) {
+		config->SetCrashReportUserEmail(email);
+
+		s_userEmail = email;
+	}
+
+	if (discord.size() && discord != s_userDiscord) {
+		config->SetCrashReportUserDiscord(discord);
+
+		s_userDiscord = discord;
+	}
+}
+
+/* ================================================================= */
+
+//
+// Runs inside sentry's crash path, before the daemon is told to write the
+// minidump. This is the only point at which the event and the scope can still
+// be changed: once the envelope is written there is no public API to add to it.
+//
+static sentry_value_t OnCrash(const sentry_ucontext_t *uctx,
+			      sentry_value_t event, void *user_data)
+{
+	UNUSED_PARAMETER(uctx);
+	UNUSED_PARAMETER(user_data);
+
+	//
+	// Deliberately not the place to filter. Discarding here would suppress
+	// the event but not the minidump: the daemon notify that follows is
+	// gated only on an atomic state flag and never consults this hook's
+	// return value (sentry_crash_handler.c, around the sentry_handle_exception
+	// call). Suppression is the consent gate's job instead -- see the class
+	// comment.
+	//
+	sentry_value_set_by_key(event, "selive_module_on_stack",
+				sentry_value_new_bool(StackTouchesOurModule()));
+
+	return event;
+}
+
+//
+// Runs *after* the daemon has captured the minidump.
+//
+// sentry's macOS handler calls the handler it displaced once the dump is safely
+// written, which is what makes this ordering possible at all -- dump first, ask
+// second. Its Windows counterpart never does this.
+//
+static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
+{
+	// One crash only. A fault raised while the prompt is up must not
+	// re-enter this.
+	if (s_handledCrash) {
+		return;
+	}
+
+	s_handledCrash = 1;
+
+	if (s_initialized) {
+		const auto consent = StreamElementsCrashConsentDialog::Prompt(
+			s_userName, s_userEmail, s_userDiscord);
+
+		if (consent.consented) {
+			PersistContactDetails(consent.name, consent.email,
+					      consent.discord);
+
+			SetSentryUser(consent.name, consent.email,
+				      consent.discord);
+
+			if (consent.description.size()) {
+				sentry_value_t report =
+					sentry_value_new_object();
+
+				sentry_value_set_by_key(
+					report, "description",
+					sentry_value_new_string(
+						consent.description.c_str()));
+
+				sentry_set_context("user_report", report);
+			}
+
+			// Releases what the daemon already wrote. Until this
+			// call the envelope sits in the cache unsent, which is
+			// what makes "Don't send" mean it.
+			sentry_user_consent_give();
+		} else {
+			sentry_user_consent_revoke();
+		}
+	}
+
+	// Hand on to whoever held this signal before we did, so OBS's own
+	// handling still runs.
+	const size_t count = sizeof(s_signals) / sizeof(s_signals[0]);
+
+	for (size_t i = 0; i < count; ++i) {
+		if (s_signals[i] != signum)
+			continue;
+
+		struct sigaction *previous = &s_previousHandlers[i];
+
+		if (previous->sa_flags & SA_SIGINFO) {
+			if (previous->sa_sigaction)
+				previous->sa_sigaction(signum, info, context);
+		} else if (previous->sa_handler != SIG_DFL &&
+			   previous->sa_handler != SIG_IGN) {
+			previous->sa_handler(signum);
+		}
+
+		break;
+	}
+}
+
+static void InstallChainedHandlers()
+{
+	const size_t count = sizeof(s_signals) / sizeof(s_signals[0]);
+
+	for (size_t i = 0; i < count; ++i) {
+		struct sigaction action = {};
+
+		action.sa_sigaction = ChainedSignalHandler;
+		action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+		sigemptyset(&action.sa_mask);
+
+		sigaction(s_signals[i], &action, &s_previousHandlers[i]);
+	}
+}
+
+/* ================================================================= */
+
+StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
+{
+	if (s_initialized)
+		return;
+
+	const std::string dsn = SE_SENTRY_DSN;
+
+	if (dsn.empty()) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: no Sentry DSN was compiled in; crash reporting is disabled");
+		return;
+	}
+
+	//
+	// Installed BEFORE sentry_init, and that order is the whole design.
+	//
+	// sentry's handler saves whatever it displaces and calls it back after
+	// the daemon has captured the minidump. Going first here means going
+	// *last* at crash time, which is exactly where the prompt belongs: the
+	// dump already exists, so a slow or abandoned dialog cannot cost us the
+	// crash data.
+	//
+	InstallChainedHandlers();
+
+	sentry_options_t *options = sentry_options_new();
+
+	sentry_options_set_dsn(options, dsn.c_str());
+
+	const std::string release = "obs-streamelements-core@" +
+				    GetStreamElementsPluginVersionString();
+	sentry_options_set_release(options, release.c_str());
+
+	//
+	// Nothing leaves the machine until sentry_user_consent_give().
+	//
+	// This is what lets the prompt run after the dump and still mean
+	// something: the daemon reads consent out of shared memory rather than
+	// uploading blindly, so a refusal still stops the minidump. Envelopes
+	// captured while consent is withheld are cached, and flushed if consent
+	// is given later -- possibly not until the next launch, since a dying
+	// process may not survive long enough to finish the upload.
+	//
+	sentry_options_set_require_user_consent(options, 1);
+
+	sentry_options_set_minidump_mode(options, SENTRY_MINIDUMP_MODE_SMART);
+
+	sentry_options_set_crash_reporting_mode(
+		options, SENTRY_CRASH_REPORTING_MODE_NATIVE_WITH_MINIDUMP);
+
+	sentry_options_set_on_crash(options, OnCrash, nullptr);
+
+	if (sentry_init(options) != 0) {
+		blog(LOG_ERROR,
+		     "obs-streamelements-core: StreamElements: Crash Handler: sentry_init() failed");
+		return;
+	}
+
+	auto config = StreamElementsConfig::GetInstance();
+
+	if (config) {
+		s_userName = config->GetCrashReportUserName();
+		s_userEmail = config->GetCrashReportUserEmail();
+		s_userDiscord = config->GetCrashReportUserDiscord();
+	}
+
+	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
+
+	s_initialized = true;
+
+	blog(LOG_INFO,
+	     "obs-streamelements-core: StreamElements: Crash Handler: Sentry initialized (%s)",
+	     release.c_str());
+}
+
+void StreamElementsSentryCrashHandler::StopAsyncHangDetection()
+{
+	// There is no hang detection on macOS, matching the BugSplat handler.
+}
+
+StreamElementsSentryCrashHandler::~StreamElementsSentryCrashHandler()
+{
+	// Deliberately not calling sentry_close(), and deliberately leaving the
+	// signal handlers installed: tearing the reporter down early loses
+	// exceptions thrown during shutdown, which is when a fair number of them
+	// happen. Matches the BugSplat handler on both platforms.
+}


### PR DESCRIPTION
Completes the macOS side of CORE-554, and moves CI to OBS 32.2.1.

Everything here was verified by actually building both platforms — Windows against Visual Studio 2022, macOS against Xcode 26.6 / SDK 26.5 on a real machine, not inferred from CI.

## macOS Sentry crash handling

macOS could not reuse the Windows design, and the reason is specific: **sentry's macOS signal handler calls the handler it displaced once the daemon has captured the minidump; its Windows exception filter never chains at all.** That single difference is what makes the requested ordering possible — dump first, then ask.

So our `sigaction` handlers install **before** `sentry_init`. Going first at install time means going *last* at crash time: sentry saves ours as its "previous" handlers and calls them back after the dump exists, so a slow or abandoned prompt cannot cost the crash data.

**Consent is enforced through sentry's own gate, not by discarding the event.** `require_user_consent(1)` holds the envelope in cache, and the daemon reads consent out of shared memory rather than uploading blindly — so "Don't send" *after* the dump has been written still stops it.

The `on_crash` hook cannot do this job: the daemon notify that follows it is gated only on an atomic state flag and never looks at the hook's return value (`sentry_crash_handler.c`, around the `sentry_handle_exception` call). Discarding there would have suppressed the event while the minidump went out anyway — a silent half-failure.

A refusal may therefore only be honoured on the next launch, since a dying process may not survive long enough to finish the upload. Normal for this SDK, and noted at the call site so a late report isn't mistaken for a bug.

The prompt is Cocoa, mirroring the Windows dialog field for field and word for word. It only runs when already on the main thread — AppKit is main-thread-only, and marshalling from a signal handler could deadlock against the very thread that faulted. Off the main thread it returns "not consented", losing a report rather than sending one unasked.

## Same payload as Windows

`StreamElementsCrashContext` was Windows-only, so macOS reports carried nothing but a `product` attribute. Most of that collection was already portable — the configuration zip and its stream-key redaction, the system/hardware/memory snapshots, CPU and memory history, async- and API-call context, attributes and notes.

Rather than duplicate ~700 lines into a `.mm`, the existing file now compiles for both platforms with the three genuinely divergent pieces behind `#ifdef` — the same pattern `StreamElementsReportIssueDialog.cpp` already uses:

| | Windows | macOS |
|---|---|---|
| Stack walk | StackWalker + PDB | `backtrace` + `dladdr` — async-signal-safe, enough for the module gate |
| Temp files | `GetTempFileNameW` | `mkstemp`, so two crashing processes can't collide |
| Window capture | `BitBlt` → BMP | **omitted** |

The window capture stays Windows-only deliberately: `CGWindowListCreateImage` needs the Screen Recording entitlement, and without it the first call raises a system permission prompt — useless and hostile from a process that is already dying.

## Four bugs found by building configurations nobody had built

1. **`nullptr` passed where a `std::string` is constructed** — undefined behaviour at three bandwidth-test call sites, which should have been sending the JSON literal `"null"` anyway (an empty string wouldn't parse on the JS side).
2. **The Mach exception server was compiled on every macOS build**, but the `catch_mach_exception_*` callbacks it dispatches to exist only in the BugSplat handler — so *any* non-BugSplat macOS build failed to link. Latent since the backend became selectable; never exercised until now.
3. **Vendored nlohmann/json** breaks under Xcode 26's `-Wdeprecated-literal-operator` + `-Werror`. Suppressed at target level and probed with `check_cxx_compiler_flag`, since older clang doesn't know the flag and `-Werror` would reject it.
4. **Three MSVC-isms** in the shared collection that clang rejects: `itoa`, a `%Lf` handed a plain `0.0`, and `_read`/`_close` mapped by macro — which rewrote the read loops' local variable named `read` into a call on an `int`.

## CI: OBS 31.1.2 → 32.2.1

The macOS runner has to move with it. OBS 32.2.x refuses to configure below the macOS 26.5 SDK — `compilerconfig.cmake` fails outright, before any of our code is reached — and `macos-15` doesn't have it. `macos-26` does, but ships several Xcodes without necessarily defaulting to a new enough one, so the version is selected explicitly, mirroring obs-studio's own `build-project.yaml`. The step prints the resolved Xcode and SDK, so a future image change shows up in the log rather than as a puzzling configure failure.

**Windows stays on `windows-2022`.** obs-studio's own CI has moved to `windows-2025-vs2026`, but VS2022 builds 32.2.1 fine — the local build confirms it — and changing two things at once would obscure which one broke if either did.

## Also here

CLAUDE.md claimed the project has no tests and that nothing should be called verified on the basis of tests. Untrue since #71: `tests/` holds a ctest suite behind `SE_ENABLE_TESTS`, standalone C++17 linking neither libobs nor Qt. Both tests pass. Replaced with how to run it, what belongs there, and the caveat that still holds — CI doesn't run it, so it's a local gate.

## Verified / not verified

**Verified:** Windows and macOS both build clean against OBS 32.2.1 — 0 errors, 0 warnings on Windows under `/WX`; macOS produces the plugin bundle and the `sentry-crash` daemon. All three backend selections still build on Windows. The existing test suite passes.

**Not verified:** no crash has been triggered on either platform. The filter/handler ordering, the daemon handshake, whether crash-time attachments reach the envelope, and the prompt appearing from a genuinely dying process are all reasoned from SDK source rather than observed. That behavioural pass is the remaining work on CORE-554 and wants doing before the pipeline flips to `sentry`.

`STREAMELEMENTS_CRASH_HANDLER` still defaults to `bugsplat`, and CI still sets `bugsplat`, so none of the Sentry path ships to users from this PR.

#partial
