### PR TITLE
fix(ci): installers stale since 2026-07-29, and What's New nested inside Release Notes (CORE-554)

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -375,6 +375,16 @@ jobs:
           name: windows-manifest
           path: '${{ env.ROOT }}/obs-streamelements*.manifest'
 
+      # Uploading zero files is not an error as far as the upload action is
+      # concerned, so a glob that matches nothing reports success and quietly
+      # leaves the previous build's installer in place -- which is exactly what
+      # happened between 2026-07-29 and 2026-08-13. Fail loudly instead.
+      - name: Verify installer exists before upload
+        if: ${{ env.UPLOAD_BINARIES == 'true' }}
+        shell: cmd
+        run: |
+          dir /b "${{ env.ROOT }}\obs-streamelements-setup*.exe" || (echo No installer matched obs-streamelements-setup*.exe in "${{ env.ROOT }}" & exit /b 1)
+
       - name: Upload Binaries to Google Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
         uses: 'google-github-actions/upload-cloud-storage@v3'
@@ -382,7 +392,7 @@ jobs:
           parent: false
           process_gcloudignore: false
           path: ${{ env.ROOT }}
-          glob: '{obs-streamelements-setup*.exe}'
+          glob: 'obs-streamelements-setup*.exe'
           destination: 'se-obs-builds/obs-streamelements-installer/latest/windows'
 
       - name: Upload Text to Google Storage
@@ -676,6 +686,15 @@ jobs:
             ${{ env.ROOT }}/obs-streamelements.manifest
             ${{ env.ROOT }}/obs-streamelements.*.manifest
 
+      # See the matching comment in the windows job: a glob that matches nothing
+      # uploads nothing and still succeeds, leaving the previous build's package
+      # published under the new version's name.
+      - name: Verify package exists before upload
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+        run: |
+          test -f "${{ env.ROOT }}/obs-streamelements-core.pkg" \
+            || { echo "No package at ${{ env.ROOT }}/obs-streamelements-core.pkg"; exit 1; }
+
       - name: Upload Binaries to Google Storage
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         uses: 'google-github-actions/upload-cloud-storage@v3'
@@ -683,7 +702,7 @@ jobs:
           parent: false
           process_gcloudignore: false
           path: ${{ env.ROOT }}
-          glob: '{obs-streamelements-core.pkg}'
+          glob: 'obs-streamelements-core.pkg'
           destination: 'se-obs-builds/obs-streamelements-installer/latest/macos'
 
       - name: Upload Text to Google Storage

--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -81,35 +81,46 @@ jobs:
           # model-authored text cannot reach the shell as code.
           WHATS_NEW_BASE64: ${{ inputs.WHATS_NEW_BASE64 }}
         run: |
+          # The per-version notes: this release's heading, its notes, then history.
           echo "### ${{ inputs.PLUGIN_VERSION_STRING }}" >> /tmp/release_notes_raw.md
           echo "" >> /tmp/release_notes_raw.md
-
-          # "What's New" above "Release Notes", matching the GitHub release body, so a
-          # creator reads the same words in the in-app updater and on the release page.
-          # Both headings appear only when there is a blurb; without one the notes keep
-          # their previous unheaded shape rather than growing a lone "Release Notes".
-          if [ -n "${WHATS_NEW_BASE64:-}" ]; then
-            echo "$WHATS_NEW_BASE64" | base64 -d > /tmp/whats_new.md
-
-            if [ -s /tmp/whats_new.md ]; then
-              echo "#### What's New" >> /tmp/release_notes_raw.md
-              echo "" >> /tmp/release_notes_raw.md
-              cat /tmp/whats_new.md >> /tmp/release_notes_raw.md
-              # printf, not echo: the blurb has no trailing newline, so a single echo
-              # only terminates its last line and leaves the next heading glued to it
-              # with no blank line between -- which Markdown will not read as a heading.
-              printf '\n\n' >> /tmp/release_notes_raw.md
-              echo "#### Release Notes" >> /tmp/release_notes_raw.md
-              echo "" >> /tmp/release_notes_raw.md
-            fi
-          fi
-
           cat "RELEASE_NOTES.md" >> /tmp/release_notes_raw.md
           echo "" >> /tmp/release_notes_raw.md
           cat "RELEASE_NOTES.history.md" >> /tmp/release_notes_raw.md
 
+          # The product blurb, minus the "## Release Notes" heading it ends with.
+          # That heading is emitted further down instead, so "What's New" can sit
+          # beside it as a sibling section rather than nested inside one release's
+          # notes -- previously it landed as an <h4> under "## Release Notes" >
+          # "### <version>", which read as part of that version's notes rather than
+          # as a section of its own.
+          #
+          # Stripped unconditionally so this stays correct if the header ever stops
+          # carrying the heading.
+          sed -E '/^## Release Notes[[:space:]]*$/d' "RELEASE_NOTES.header.md" > /tmp/header_body.md
 
-          cat "RELEASE_NOTES.header.md" >> /tmp/release_notes_full.md
+          cat /tmp/header_body.md >> /tmp/release_notes_full.md
+          echo "" >> /tmp/release_notes_full.md
+
+          # "What's New" is a top-level section, above Release Notes, and describes
+          # only the release being built -- it is deliberately never archived into
+          # RELEASE_NOTES.history.md. Appears only when there is a blurb; without one
+          # the page keeps exactly its previous shape.
+          if [ -n "${WHATS_NEW_BASE64:-}" ]; then
+            echo "$WHATS_NEW_BASE64" | base64 -d > /tmp/whats_new.md
+
+            if [ -s /tmp/whats_new.md ]; then
+              echo "## What's New" >> /tmp/release_notes_full.md
+              echo "" >> /tmp/release_notes_full.md
+              cat /tmp/whats_new.md >> /tmp/release_notes_full.md
+              # printf, not echo: the blurb has no trailing newline, so a single echo
+              # only terminates its last line and leaves the next heading glued to it
+              # with no blank line between -- which Markdown will not read as a heading.
+              printf '\n\n' >> /tmp/release_notes_full.md
+            fi
+          fi
+
+          echo "## Release Notes" >> /tmp/release_notes_full.md
           echo "" >> /tmp/release_notes_full.md
           cat /tmp/release_notes_raw.md >> /tmp/release_notes_full.md
           echo "" >> /tmp/release_notes_full.md


### PR DESCRIPTION
Every installer published since 29 July has been the **29 July build**, renamed to the current version. Filename, manifest, version badge and release notes were all correct and current; only the payload was two weeks stale. Windows and macOS both.

## Cause

`e968097` split one upload step into two so text files could carry a `content-type` header, leaving the binaries globs as single-item brace groups:

```
'{obs-streamelements-setup*.exe}'
'{obs-streamelements-core.pkg}'
```

Brace expansion needs a comma or a range — `{a}` is the literal string `{a}`, not `a`. Both matched nothing. The text globs kept several comma-separated alternatives, which is why manifests stayed current while binaries froze: the two steps sit side by side in the same job and one worked.

**Uploading zero files is not an error**, so the step reported success on every build for a fortnight.

## Evidence

| Object in `installer/latest/` | Last modified |
|---|---|
| `obs-streamelements-setup*.exe` (all three) | **29 Jul 2026** |
| `obs-streamelements-core.pkg` | **29 Jul 2026** |
| `obs-streamelements.manifest` | 12 Aug 2026 |

`deploy-signed-*` downloads from `latest/` and renames to the current version, so the July binary kept being republished under each new version number.

## Fix

Braces dropped on both. Each job now **fails** if the artifact it is about to upload does not exist — a silent no-op that republishes a stale binary under a fresh version number is worse than a red build.

## Worth deciding separately

Anyone who installed from `signed`, or from `qa`/`beta`/`latest` after a promotion, since 29 July received the July plugin regardless of the version shown. Whether affected channels need republishing is a call for the team.

The plugin binaries themselves were fine throughout — `obs-streamelements-core/latest/` updated correctly. Only the installer packaging them went stale, so recovery needs a fresh installer build rather than a re-deploy.