### PR TITLE
style(ci): render the manifest release notes in Arial (CORE-557)

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -127,7 +127,14 @@ jobs:
           cat "RELEASE_NOTES.footer.md" >> /tmp/release_notes_full.md
 
           # Generate HTML
-          markdown-to-html-cli --source /tmp/release_notes_full.md --output /tmp/release_notes.raw.html --no-dark-mode --markdown-style-theme dark --no-corners --style ".markdown-style { max-width: 100% !important; }"
+          # Arial throughout, headings and code included. These notes are rendered
+          # inside the updater's embedded browser, whose default font stack does not
+          # match the rest of the product. The universal selector plus !important is
+          # deliberate: the generator's own theme sets font-family on several
+          # elements, and anything less specific loses to it.
+          NOTES_CSS='.markdown-style { max-width: 100% !important; } body, .markdown-style, .markdown-style *, .markdown-style code, .markdown-style pre { font-family: Arial, Helvetica, sans-serif !important; }'
+
+          markdown-to-html-cli --source /tmp/release_notes_full.md --output /tmp/release_notes.raw.html --no-dark-mode --markdown-style-theme dark --no-corners --style "$NOTES_CSS"
 
           # Remove javascript from HTML
           awk '/<script/,/<\/script>/ {next} 1' /tmp/release_notes.raw.html > /tmp/release_notes.html


### PR DESCRIPTION
The release notes embedded in the manifest are shown inside the updater's embedded browser, where the generator's default stack (`-apple-system, BlinkMacSystemFont, …`) does not match the rest of the product. This puts them in Arial.

## How

Applied through the existing `--style` injection:

```css
body, .markdown-style, .markdown-style *, .markdown-style code, .markdown-style pre {
  font-family: Arial, Helvetica, sans-serif !important;
}
```

The universal selector and `!important` are both load-bearing — the generator's theme sets `font-family` on `body`, on `code` and on `pre`, so a plainer rule loses to it.

## Verified against real output, not assumed

Ran `markdown-to-html-cli` locally with these exact arguments and inspected the result:

- the injected `<style>` survives into the document
- content sits inside `<div class="markdown-style">`, so `*` actually reaches it
- ours is the **only** `!important` font-family rule in the document, so it wins on cascade regardless of source order — the theme's `-apple-system` and `monospace` declarations are unqualified

## One judgement call

`code` and `pre` are included, so inline code renders in Arial rather than monospace. That reads "everywhere" literally. Easy to exempt them if prose-only was the intent.

## Scope

Only the live generator is changed. `CI/obs-streamelements-installer` contains a copy of the same command, but it builds a readme and sits in a nested workflow directory GitHub never runs.

Takes effect on the next master build — the currently published manifest keeps the old font.