### PR TITLE
feat(ci): ship the Sentry crash backend (CORE-554) #partial

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -609,6 +609,24 @@ jobs:
 
           codesign --remove-signature /tmp/obs-streamelements-core.plugin
 
+          # Nested executables are signed before the bundle that contains them.
+          # Code signatures seal inside-out, so anything nested must already be
+          # signed when the enclosing bundle is sealed. --deep is retained below
+          # for any embedded frameworks, but it is deprecated by Apple and does
+          # not reliably cover nested executables -- which is precisely what
+          # sentry-crash is.
+          DAEMON=/tmp/obs-streamelements-core.plugin/Contents/MacOS/sentry-crash
+
+          if [ -f "$DAEMON" ]; then
+            echo Signing nested sentry-crash daemon...
+
+            codesign --force --options runtime --timestamp --sign "${{ secrets.CODESIGN_DEVIDAPP_IDENTITY }}" "$DAEMON"
+
+            if [ $? -ne 0 ]; then exit 1; fi
+          else
+            echo "No sentry-crash daemon in the bundle (BugSplat build); skipping."
+          fi
+
           echo Signing plugin code...
 
           codesign --force --options runtime --sign "${{ secrets.CODESIGN_DEVIDAPP_IDENTITY }}" --deep /tmp/obs-streamelements-core.plugin
@@ -620,6 +638,21 @@ jobs:
           codesign -dvv /tmp/obs-streamelements-core.plugin
 
           if [ $? -ne 0 ]; then exit 1; fi
+
+          # --strict walks nested code and fails on anything unsigned or sealed
+          # incorrectly. Without it the daemon could ship unsigned and only be
+          # caught by notarization, or worse, at launch on a user's machine.
+          echo Verifying nested code...
+
+          codesign --verify --strict --verbose=2 /tmp/obs-streamelements-core.plugin
+
+          if [ $? -ne 0 ]; then exit 1; fi
+
+          if [ -f "$DAEMON" ]; then
+            codesign --verify --strict --verbose=2 "$DAEMON"
+
+            if [ $? -ne 0 ]; then exit 1; fi
+          fi
 
       - name: Create plugin package
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ env:
   # it feeds -DSTREAMELEMENTS_CRASH_HANDLER at each configure site, and symbol
   # upload will be gated on the same value, so a build's binary and its symbols
   # cannot end up pointing at different services.
-  SE_CRASH_HANDLER: bugsplat
+  SE_CRASH_HANDLER: sentry
 
   BUILD_UNINSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
   BUILD_INSTALLER: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
@@ -291,6 +291,7 @@ jobs:
       # reports for this build are not symbolicated. BugSplat is slated to be replaced by
       # Sentry, so this path is deliberately tolerant rather than hardened.
       - name: Download BugSplat uploader
+        if: env.SE_CRASH_HANDLER == 'bugsplat'
         shell: pwsh
         run: |
           mkdir c:\local\bugsplat
@@ -333,7 +334,7 @@ jobs:
           cmake --build build_x64 --config RelWithDebInfo
 
       - name: Upload BugSplat Symbols
-        if: ${{ env.UPLOAD_SYMBOLS == 'true' }}
+        if: ${{ env.UPLOAD_SYMBOLS == 'true' && env.SE_CRASH_HANDLER == 'bugsplat' }}
         shell: cmd
         run: |
           c:\local\bugsplat\symbol-upload-windows.exe ^
@@ -443,6 +444,7 @@ jobs:
       # build. chmod moved inside the success branch -- it would fail on a missing file
       # and take the step down with it.
       - name: Download BugSplat uploader
+        if: env.SE_CRASH_HANDLER == 'bugsplat'
         run: |
           cd /tmp
           if curl -sL -f -O https://github.com/BugSplat-Git/symbol-upload/releases/download/v10.5.0/symbol-upload-macos; then
@@ -503,7 +505,7 @@ jobs:
       # The subshell covers the cd as well as the upload: a missing build directory would
       # otherwise fail the step before the uploader ever ran.
       - name: Upload ARM64 to BugSplat
-        if: env.UPLOAD_SYMBOLS == 'true'
+        if: env.UPLOAD_SYMBOLS == 'true' && env.SE_CRASH_HANDLER == 'bugsplat'
         run: |
           if ! (
             cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo &&
@@ -513,7 +515,7 @@ jobs:
           fi
 
       - name: Upload x86_64 to BugSplat
-        if: env.UPLOAD_SYMBOLS == 'true'
+        if: env.UPLOAD_SYMBOLS == 'true' && env.SE_CRASH_HANDLER == 'bugsplat'
         run: |
           if ! (
             cd ~/src/obs-studio/build_macos_x86_64/plugins/obs-streamelements-core/RelWithDebInfo &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,6 +355,29 @@ jobs:
 
           exit /b 0
 
+      # Fatal on failure, unlike the BugSplat step above. An unsymbolicated
+      # minidump is a wall of addresses, so a build whose symbols never arrived
+      # is not one worth shipping -- better a red build than a release whose
+      # crash reports cannot be read.
+      #
+      # The directory is scanned rather than named file by file: it holds the
+      # DLL, its PDB and the sentry-crash daemon, and sentry-cli picks up all
+      # three. The DLL matters as much as the PDB -- Sentry matches a minidump's
+      # modules by code ID first, which only the PE carries, and debug files
+      # alone leave those modules unresolved.
+      - name: Upload Sentry symbols
+        if: ${{ env.UPLOAD_SYMBOLS == 'true' && env.SE_CRASH_HANDLER == 'sentry' }}
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          set -euo pipefail
+
+          npx -y @sentry/cli debug-files upload \
+            "/c/local/obs-studio/build_x64/rundir/RelWithDebInfo/obs-plugins/64bit"
+
       - name: Package
         shell: cmd
         run: |
@@ -523,6 +546,28 @@ jobs:
           ); then
             echo "::warning title=BugSplat symbol upload failed (macOS x86_64)::x86_64 symbols for ${{ needs.version.outputs.version_string }} were not uploaded, so its crash reports will not be symbolicated. The build itself is unaffected."
           fi
+
+      # Fatal on failure, unlike the BugSplat steps above -- see the matching
+      # comment in the windows job.
+      #
+      # Both slices are uploaded, and each directory is scanned rather than
+      # named file by file: it holds the .dSYM, the plugin bundle whose Mach-O
+      # carries the code ID Sentry matches minidump modules by, and the
+      # sentry-crash daemon inside that bundle.
+      - name: Upload Sentry symbols
+        if: env.UPLOAD_SYMBOLS == 'true' && env.SE_CRASH_HANDLER == 'sentry'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          set -euo pipefail
+
+          for arch in arm64 x86_64; do
+            npx -y @sentry/cli debug-files upload \
+              ~/src/obs-studio/build_macos_${arch}/plugins/obs-streamelements-core/RelWithDebInfo
+          done
+
       - name: Package
         run: |
           cd ~/src/obs-studio/build_macos_arm64/plugins/obs-streamelements-core/RelWithDebInfo

--- a/CI/obs-streamelements-installer/main.nsi
+++ b/CI/obs-streamelements-installer/main.nsi
@@ -584,10 +584,14 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
 !ifndef SKIP_64BIT_CONTENT
     SetOutPath $INSTDIR\bin\64bit
 
-    File ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BsSndRpt64.exe
-    File ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplat64.dll
-    File ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplatHD64.exe
-    File ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplatRc64.dll
+    # /nonfatal on the crash-reporting runtime: which of these exists depends on
+    # STREAMELEMENTS_CRASH_HANDLER at build time, and the installer has no way to
+    # know which backend was compiled. A Sentry build ships no BugSplat DLLs, a
+    # BugSplat build ships no sentry-crash.exe, and neither should fail packaging.
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BsSndRpt64.exe
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplat64.dll
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplatHD64.exe
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\bin\64bit\BugSplatRc64.dll
 
     SetOutPath $INSTDIR\obs-plugins\64bit\locales
 
@@ -599,6 +603,12 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
     File /oname=obs-streamelements-core.pdb ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\obs-streamelements-core.pdb
     
     File /nonfatal ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\obs-streamelements-set-machine-config.*
+
+    # The Sentry crash daemon. It writes and uploads the minidump out of
+    # process, and the handler looks for it beside its own module -- so it has
+    # to land here, next to obs-streamelements-core.dll, not in bin\64bit.
+    # /nonfatal because a BugSplat build does not produce it.
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\sentry-crash.exe
 
     Delete /REBOOTOK "$OUTDIR\obs-streamelements.dll"
     Delete /REBOOTOK "$OUTDIR\obs-streamelements.pdb"

--- a/CI/obs-streamelements-uninstaller/main.nsi
+++ b/CI/obs-streamelements-uninstaller/main.nsi
@@ -178,10 +178,15 @@ Section "section_main" section_main
     Delete "$INSTDIR\obs-plugins\64bit\obs-streamelements-core_qt6.dll"
     Delete "$INSTDIR\obs-plugins\64bit\obs-streamelements-core_qt6.pdb"
 
+    # Both backends' runtimes are removed regardless of which one this build
+    # ships. An upgrade that switches backends would otherwise leave the
+    # previous install's files on disk forever -- a stale BugSplat64.dll next
+    # to a Sentry build, or the reverse.
     Delete "$INSTDIR\bin\64bit\BsSndRpt64.exe"
     Delete "$INSTDIR\bin\64bit\BugSplat64.dll"
     Delete "$INSTDIR\bin\64bit\BugSplatHD64.exe"
     Delete "$INSTDIR\bin\64bit\BugSplatRc64.dll"
+    Delete "$INSTDIR\obs-plugins\64bit\sentry-crash.exe"
 
     Delete "$INSTDIR\obs-plugins\32bit\obs-streamelements.qt5.dymod"
     Delete "$INSTDIR\obs-plugins\32bit\obs-streamelements.qt5.pdb"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,10 +891,28 @@ if (WIN32)
 		# sentry_options_set_handler_pathw() instead of relying on it.
 		add_dependencies(obs-streamelements-core sentry-crash)
 
+		# Next to the freshly built DLL, for running out of the build tree.
 		add_custom_command(TARGET obs-streamelements-core POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			"$<TARGET_FILE:sentry-crash>"
 			"$<TARGET_FILE_DIR:obs-streamelements-core>"
+		)
+
+		# And into the rundir, which is what CI zips and the installer
+		# packages. $<TARGET_FILE_DIR:...> above is the build tree, not the
+		# rundir -- obs-studio populates that separately, and it copies the
+		# plugin module but knows nothing about a daemon sitting beside it.
+		# Without this the daemon never reaches the installer, and a Sentry
+		# build reports events with no minidump attached.
+		#
+		# obs-plugins, not bin: the handler resolves the daemon relative to
+		# its own module, which is what lands here.
+		add_custom_command(TARGET obs-streamelements-core POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E make_directory
+			"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit"
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"$<TARGET_FILE:sentry-crash>"
+			"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit/"
 		)
 	endif()
 endif()


### PR DESCRIPTION
Flips `SE_CRASH_HANDLER` to `sentry`, so builds contain the Sentry handler rather than BugSplat. Every build until now compiled BugSplat — which is why an installed build still raised **BugSplat's** dialog on a crash.

## Flipping the switch alone would not have worked

Three things had to move with it, and two would have failed **silently**.

### The daemon never reached the installer

The post-build copy put `sentry-crash.exe` next to the freshly built DLL in the *build tree*. But the installer packages the **rundir**, which obs-studio populates itself — it copies the plugin module and knows nothing about a daemon sitting beside it.

So the binary existed locally, the installer shipped without it, and the handler would have found no daemon: **events with no minidump, reported as success**. Verified before and after:

```
rundir/RelWithDebInfo/obs-plugins/64bit/    before: obs-streamelements-core.dll
                                            after:  obs-streamelements-core.dll
                                                    sentry-crash.exe
```

It goes in `obs-plugins`, not `bin`, because the handler resolves the daemon relative to its own module.

### main.nsi hardcoded the BugSplat runtime

Both backends' files are now `/nonfatal`: which set exists depends on a build-time choice the installer cannot see. A Sentry build ships no BugSplat DLLs, a BugSplat build ships no `sentry-crash.exe`, and neither should fail packaging.

The uninstaller deletes **both** sets regardless, so an upgrade that switches backends doesn't strand the previous install's files — the failure mode that leaves a stale `BugSplat64.dll` on disk forever.

### Symbol upload pointed at the wrong service

BugSplat symbol upload and its uploader download are now gated on the backend. Uploading BugSplat symbols for a Sentry binary files them where nothing will look.

## Still outstanding

Deliberately not in this PR:

- **Sentry symbol upload** — these builds will not symbolicate until it exists.
- **macOS signing of the nested daemon** — `--deep` does not reliably cover nested executables and is deprecated by Apple.

## What to expect

The next master build with release notes produces an installer carrying the Sentry handler and its daemon. A crash should then raise **our** consent dialog rather than BugSplat's, and — once symbol upload lands — arrive symbolicated in Sentry.

This is the first build that puts the Sentry path in front of real crashes, and it has still never been exercised against a real fault. #partial