### PR TITLE
fix(crash): stop the crash path hanging or discarding reports (CORE-554) #partial

### DIFF
--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -349,9 +349,13 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 		::GetModuleHandleW(NULL), builder.Get(), NULL,
 		ConsentDialogProc, (LPARAM)&state);
 
+	// IDOK and IDCANCEL both mean the dialog appeared and was answered; -1
+	// means Windows refused the template and it never did.
+	result.prompted = (outcome == IDOK || outcome == IDCANCEL);
+
 	if (outcome != IDOK) {
-		// Declined, dismissed, or the dialog could not be created
-		// (outcome -1). All three mean the same thing here.
+		// Declined, dismissed, or the dialog could not be created. All
+		// three mean do not send.
 		return result;
 	}
 

--- a/streamelements/StreamElementsCrashConsentDialog.hpp
+++ b/streamelements/StreamElementsCrashConsentDialog.hpp
@@ -31,6 +31,17 @@ public:
 		// as "do not send": it is the user's answer, not a hint.
 		bool consented = false;
 
+		// Whether the user was actually asked. False means the prompt
+		// could not be shown -- on macOS, because the crash happened
+		// off the main thread and AppKit cannot be driven from there.
+		//
+		// This is not the same as declining, and conflating the two
+		// throws away most crashes: a caller that treats "could not
+		// ask" as "no" discards every report from a worker thread,
+		// which is where the majority of crashes happen. Callers that
+		// can defer should leave the report pending instead.
+		bool prompted = false;
+
 		std::string description;
 		std::string name;
 		std::string email;

--- a/streamelements/StreamElementsCrashConsentDialog.mm
+++ b/streamelements/StreamElementsCrashConsentDialog.mm
@@ -142,6 +142,10 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 
 		const NSModalResponse response = [alert runModal];
 
+		// Asked and answered, whichever button it was. Only a prompt
+		// that never appeared leaves this false.
+		result.prompted = true;
+
 		if (response != NSAlertFirstButtonReturn)
 			return result;
 

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -701,11 +701,23 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 	// system permission prompt. Doing that from a crashing process would
 	// be both useless and hostile, so macOS reports go without.
 #ifdef WIN32
-	addWindowCaptureToZip(
-		(HWND)StreamElementsGlobalStateManager::GetInstance()
-			->mainWindow()
-			->winId(),
-		24, L"obs-main-window.bmp");
+	//
+	// Guarded, because this runs while the process is dying and a crash
+	// during shutdown is one of the cases worth reporting most. By then the
+	// global state manager is gone, and dereferencing it here would fault
+	// inside the crash handler -- losing the whole report rather than just
+	// the screenshot.
+	//
+	if (StreamElementsGlobalStateManager::IsInstanceAvailable()) {
+		auto mainWindow =
+			StreamElementsGlobalStateManager::GetInstance()
+				->mainWindow();
+
+		if (mainWindow) {
+			addWindowCaptureToZip((HWND)mainWindow->winId(), 24,
+					      L"obs-main-window.bmp");
+		}
+	}
 #endif
 
 	std::map<std::wstring, std::wstring> local_to_zip_files_map;
@@ -823,18 +835,21 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		addCefValueToZip(sysMemoryInfo, L"system\\memory.json");
 	}
 
-	{
+	// Same guard as the window capture above: gone during shutdown, and a
+	// null dereference here would cost the entire report.
+	auto performanceTracker =
+		StreamElementsGlobalStateManager::IsInstanceAvailable()
+			? StreamElementsGlobalStateManager::GetInstance()
+				  ->GetPerformanceHistoryTracker()
+			: nullptr;
+
+	if (performanceTracker) {
 		// Histogram CPU & memory usage (past hour, 1 minute intervals)
 
-		auto cpuUsageHistory =
-			StreamElementsGlobalStateManager::GetInstance()
-				->GetPerformanceHistoryTracker()
-				->getCpuUsageSnapshot();
+		auto cpuUsageHistory = performanceTracker->getCpuUsageSnapshot();
 
 		auto memoryUsageHistory =
-			StreamElementsGlobalStateManager::GetInstance()
-				->GetPerformanceHistoryTracker()
-				->getMemoryUsageSnapshot();
+			performanceTracker->getMemoryUsageSnapshot();
 
 		char lineBuf[512];
 

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -52,6 +52,36 @@ static inline int _close(int fd)
 /* ================================================================= */
 
 //
+// Reserved at construction, released the moment collection begins.
+//
+// A process that died of exhaustion has no room for the configuration zip, the
+// JSON or the stack text, so the report it needs most is the one it cannot
+// produce. Handing this block back first buys that room. BugSplat reserved 1MB
+// for the same purpose and the same size; matched here rather than guessed.
+//
+// Deliberately allocated with malloc rather than new: it is released from a
+// crash path, and free() on a raw block is the smallest possible operation to
+// perform there.
+//
+static const size_t GUARD_BUFFER_SIZE = 1024 * 1024;
+
+static void *s_guardBuffer = nullptr;
+
+void StreamElementsCrashContext::ReleaseGuardBuffer()
+{
+	void *buffer = s_guardBuffer;
+
+	if (!buffer)
+		return;
+
+	s_guardBuffer = nullptr;
+
+	free(buffer);
+}
+
+/* ================================================================= */
+
+//
 // itoa is an MSVC extension. snprintf is not, and is just as safe here.
 //
 static inline const char *IntToBuf(int value, char *buffer, size_t size)
@@ -352,6 +382,11 @@ static inline bool GetTemporaryFilePath(const wchar_t *basename,
 
 StreamElementsCrashContext::StreamElementsCrashContext()
 {
+	// Reserved now, while allocation still works, so that Collect() has
+	// something to hand back if the process dies of exhaustion.
+	if (!s_guardBuffer)
+		s_guardBuffer = malloc(GUARD_BUFFER_SIZE);
+
 	m_impl = new Impl();
 
 #ifdef WIN32
@@ -403,6 +438,9 @@ bool StreamElementsCrashContext::ShouldReport() const
 
 StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 {
+	// First thing, before anything below asks the allocator for a byte.
+	ReleaseGuardBuffer();
+
 	Result result;
 
 	const size_t BUF_LEN = 2048;

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -899,7 +899,7 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		}
 	}
 
-	GetAsyncCallContextStack([&](const StreamElementsAsyncCallContextStack_t
+	TryGetAsyncCallContextStack([&](const StreamElementsAsyncCallContextStack_t
 					     *asyncCallContextStack) {
 		if (!asyncCallContextStack->size())
 			return;
@@ -979,7 +979,7 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 
 	result.attributes.push_back({"product", "SE.Live"});
 
-	GetApiContext([&](StreamElementsApiContext_t *apiContext) {
+	TryGetApiContext([&](StreamElementsApiContext_t *apiContext) {
 		auto apiContextList = CefListValue::Create();
 
 		{

--- a/streamelements/StreamElementsCrashContext.hpp
+++ b/streamelements/StreamElementsCrashContext.hpp
@@ -83,7 +83,26 @@ public:
 
 	// Called from the exception path with the process already dying. Does no
 	// allocation it can avoid, touches no Qt, and must not throw.
+	//
+	// Releases the guard buffer on entry -- see ReleaseGuardBuffer.
 	Result Collect();
+
+	//
+	// Hands a block of memory reserved at startup back to the allocator, so
+	// that collection has headroom on a process that crashed because it ran
+	// out of it. BugSplat reserved 1MB for the same reason
+	// (setGuardByteBufferSize); this is the equivalent for the Sentry path,
+	// which otherwise has none.
+	//
+	// Safe to call more than once; the second call does nothing.
+	//
+	// This helps with out-of-memory crashes and only those. It does nothing
+	// for a corrupted heap: the allocator is already unsound, and free()
+	// itself may be what faults. Collection still runs entirely on the
+	// process heap, so that crash class remains unserved -- addressing it
+	// means not using the heap at all.
+	//
+	static void ReleaseGuardBuffer();
 
 private:
 	struct Impl;

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -13,9 +13,13 @@
 #include <string>
 #include <vector>
 
+#include <util/platform.h>
+
 #include <signal.h>
 #include <dlfcn.h>
 #include <execinfo.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <mach-o/dyld.h>
 
 // Empty means crash reporting is inert: sentry_init() is skipped entirely rather
@@ -51,6 +55,11 @@ static volatile sig_atomic_t s_handledCrash = 0;
 // Owns the stack walker and the remote module-of-interest list. Built at
 // startup, because building it fetches that list over HTTP.
 static StreamElementsCrashContext *s_crashContext = nullptr;
+
+// Marker left behind when a crash could not be consented to at the time --
+// see ChainedSignalHandler. Resolved once at init so the signal handler only
+// has to open a path that already exists as a string.
+static char s_pendingMarkerPath[512] = {0};
 
 /* ================================================================= */
 
@@ -233,15 +242,39 @@ static sentry_value_t OnCrash(const sentry_ucontext_t *uctx,
 // written, which is what makes this ordering possible at all -- dump first, ask
 // second. Its Windows counterpart never does this.
 //
+//
+// Restores the default disposition for `signum` and re-raises it, which
+// terminates the process the way the signal would have.
+//
+// Returning from a handler for a fault signal does not: the faulting
+// instruction simply re-executes, faults again, and the process spins forever.
+// Every path out of the handler below that cannot hand the signal on has to
+// come through here instead.
+//
+static void DieWithSignal(int signum)
+{
+	struct sigaction dfl = {};
+
+	dfl.sa_handler = SIG_DFL;
+	sigemptyset(&dfl.sa_mask);
+
+	sigaction(signum, &dfl, NULL);
+
+	raise(signum);
+}
+
 static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 {
-	// One crash only. A fault raised while the prompt is up must not
-	// re-enter this.
-	if (s_handledCrash) {
+	// One crash only, and only one thread's. A plain read-then-write would
+	// let two threads faulting at once both pass, and put up two dialogs.
+	if (!__sync_bool_compare_and_swap(&s_handledCrash, 0, 1)) {
+		// Another thread is already handling a crash. Do not return:
+		// this thread's fault is unresolved, so returning would spin on
+		// the faulting instruction.
+		DieWithSignal(signum);
+
 		return;
 	}
-
-	s_handledCrash = 1;
 
 	if (s_initialized) {
 		const auto consent = StreamElementsCrashConsentDialog::Prompt(
@@ -270,13 +303,40 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 			// call the envelope sits in the cache unsent, which is
 			// what makes "Don't send" mean it.
 			sentry_user_consent_give();
-		} else {
+		} else if (consent.prompted) {
+			// An actual "Don't send". Drop it.
 			sentry_user_consent_revoke();
+		} else {
+			// We could not ask -- the crash was off the main
+			// thread, where AppKit cannot be driven. Revoking here
+			// would discard the report, and since most crashes
+			// happen on worker threads that would silently throw
+			// away the majority of them.
+			//
+			// Leave consent untouched so the envelope stays cached,
+			// and drop a marker for the next launch to notice and
+			// ask about. open/write/close are async-signal-safe;
+			// the path was resolved at init precisely so nothing
+			// here has to build it.
+			if (s_pendingMarkerPath[0]) {
+				const int fd = open(
+					s_pendingMarkerPath,
+					O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+				if (fd >= 0)
+					close(fd);
+			}
 		}
 	}
 
 	// Hand on to whoever held this signal before we did, so OBS's own
 	// handling still runs.
+	//
+	// Normally this handler is not the one the kernel invoked: sentry's is,
+	// and it calls us back after the daemon has captured the dump, then
+	// re-raises once we return. But if sentry_init() failed we are still
+	// installed and there is nobody behind us, so every path that does not
+	// actually hand the signal on must terminate rather than return.
 	const size_t count = sizeof(s_signals) / sizeof(s_signals[0]);
 
 	for (size_t i = 0; i < count; ++i) {
@@ -285,16 +345,27 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 
 		struct sigaction *previous = &s_previousHandlers[i];
 
-		if (previous->sa_flags & SA_SIGINFO) {
-			if (previous->sa_sigaction)
-				previous->sa_sigaction(signum, info, context);
-		} else if (previous->sa_handler != SIG_DFL &&
-			   previous->sa_handler != SIG_IGN) {
+		if ((previous->sa_flags & SA_SIGINFO) &&
+		    previous->sa_sigaction) {
+			previous->sa_sigaction(signum, info, context);
+
+			return;
+		}
+
+		if (!(previous->sa_flags & SA_SIGINFO) &&
+		    previous->sa_handler != SIG_DFL &&
+		    previous->sa_handler != SIG_IGN) {
 			previous->sa_handler(signum);
+
+			return;
 		}
 
 		break;
 	}
+
+	// Nothing to hand on to -- the previous disposition was SIG_DFL or
+	// SIG_IGN. Returning here would spin on the faulting instruction.
+	DieWithSignal(signum);
 }
 
 static void InstallChainedHandlers()
@@ -391,6 +462,51 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	}
 
 	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
+
+	// Resolved here, once, so the signal handler never has to build a path.
+	{
+		char configPath[512];
+
+		if (os_get_config_path(
+			    configPath, sizeof(configPath),
+			    "obs-studio/plugin_config/obs-streamelements") >
+		    0) {
+			os_mkdirs(configPath);
+
+			snprintf(s_pendingMarkerPath,
+				 sizeof(s_pendingMarkerPath),
+				 "%s/sentry-consent-pending", configPath);
+		}
+	}
+
+	//
+	// A crash from a previous run that we could not ask about at the time,
+	// because it happened off the main thread. Its envelope is still in the
+	// cache, unsent. We are on the main thread now, so ask.
+	//
+	// This is what keeps "could not ask" from meaning "silently dropped":
+	// most crashes happen on worker threads, so without this the majority
+	// of reports would never be offered to the user at all.
+	//
+	if (s_pendingMarkerPath[0] && os_file_exists(s_pendingMarkerPath)) {
+		os_unlink(s_pendingMarkerPath);
+
+		const auto consent = StreamElementsCrashConsentDialog::Prompt(
+			s_userName, s_userEmail, s_userDiscord);
+
+		if (consent.consented) {
+			PersistContactDetails(consent.name, consent.email,
+					      consent.discord);
+
+			SetSentryUser(consent.name, consent.email,
+				      consent.discord);
+
+			// Flushes whatever the previous run left cached.
+			sentry_user_consent_give();
+		} else {
+			sentry_user_consent_revoke();
+		}
+	}
 
 	// After sentry_init, and deliberately: constructing this fetches the
 	// remote module-of-interest list over HTTP, which is not something to

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -191,6 +191,20 @@ void GetApiContext(std::function<void(StreamElementsApiContext_t*)> callback)
 	callback(&s_apiContext);
 }
 
+// Non-blocking variant, for the crash path. Same reasoning as
+// TryGetAsyncCallContextStack.
+bool TryGetApiContext(std::function<void(StreamElementsApiContext_t *)> callback)
+{
+	std::shared_lock lock(s_apiContextMutex, std::try_to_lock);
+
+	if (!lock.owns_lock())
+		return false;
+
+	callback(&s_apiContext);
+
+	return true;
+}
+
 std::shared_ptr<StreamElementsApiContextItem> PushApiContext(CefString method, CefRefPtr<CefListValue> args)
 {
 	std::unique_lock lock(s_apiContextMutex);
@@ -221,11 +235,42 @@ void RemoveApiContext(std::shared_ptr<StreamElementsApiContextItem> item)
 static StreamElementsAsyncCallContextStack_t s_asyncCallContextStack;
 static std::shared_mutex s_asyncCallContextStackMutex;
 
-void GetAsyncCallContextStack(std::function<void(const StreamElementsAsyncCallContextStack_t *)> callback)
+void GetAsyncCallContextStack(
+	std::function<void(const StreamElementsAsyncCallContextStack_t *)>
+		callback)
 {
 	std::shared_lock lock(s_asyncCallContextStackMutex);
 
 	callback(&s_asyncCallContextStack);
+}
+
+//
+// As above, but never blocks. Returns false, without invoking the callback, if
+// the lock is held.
+//
+// For the crash path only. This lock is taken exclusively by
+// AsyncCallContextPush and AsyncCallContextRemove, which run on every
+// QtPostTask, QtExecSync and QtDelayTask -- hundreds of call sites, constantly.
+// A crashing thread that blocks on it waits on whichever thread holds it, and
+// that thread may itself be stuck or already gone; worse, std::shared_mutex is
+// not recursive, so a thread that faulted while holding it exclusively would
+// deadlock against itself.
+//
+// Losing this section of a crash report is a far better outcome than a handler
+// that never returns, which produces no report at all.
+//
+bool TryGetAsyncCallContextStack(
+	std::function<void(const StreamElementsAsyncCallContextStack_t *)>
+		callback)
+{
+	std::shared_lock lock(s_asyncCallContextStackMutex, std::try_to_lock);
+
+	if (!lock.owns_lock())
+		return false;
+
+	callback(&s_asyncCallContextStack);
+
+	return true;
 }
 
 std::shared_ptr<StreamElementsAsyncCallContextItem>

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -259,11 +259,24 @@ std::future<void> __QtDelayTask_Impl(std::function<void()> task, int delayMs,
 	QTimer::singleShot(std::chrono::milliseconds(delayMs), qApp, [=]() {
 		item->running = true;
 
-		task();
+		// Same reasoning as __QtPostTask_Impl: cleanup must survive a
+		// throwing task, or the context entry leaks into every later
+		// crash report.
+		auto finish = [=]() {
+			AsyncCallContextRemove(item);
 
-		AsyncCallContextRemove(item);
+			promise->set_value();
+		};
 
-		promise->set_value();
+		try {
+			task();
+		} catch (...) {
+			finish();
+
+			throw;
+		}
+
+		finish();
 	});
 
 	return promise->get_future();
@@ -278,13 +291,37 @@ std::future<void> __QtPostTask_Impl(std::function<void()> task,
 	auto item = AsyncCallContextPush(file, line, false);
 
 	auto executor = [=]() {
-		task();
-
+		// Before the task, not after.
+		//
+		// This flag is what tells a crash report which queued call was
+		// executing at the moment of the fault -- the crash handler
+		// writes it into async-context.json. Setting it afterwards meant
+		// the one task that actually was running reported running=false,
+		// which is precisely backwards, and on the macro used at most of
+		// the call sites in this codebase. QtDelayTask below has always
+		// had it the right way round.
 		item->running = true;
 
-		AsyncCallContextRemove(item);
+		// The entry has to come off the stack, and the waiter has to be
+		// released, even if the task throws. Otherwise the entry stays
+		// for the life of the process and appears in every later crash
+		// report, and any QtExecSync blocked on this never learns it
+		// finished.
+		auto finish = [=]() {
+			AsyncCallContextRemove(item);
 
-		promise->set_value();
+			promise->set_value();
+		};
+
+		try {
+			task();
+		} catch (...) {
+			finish();
+
+			throw;
+		}
+
+		finish();
 	};
 
 	QMetaObject::invokeMethod(qApp, executor, Qt::QueuedConnection);

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -100,6 +100,10 @@ public:
 };
 
 void GetApiContext(std::function<void(StreamElementsApiContext_t *)> callback);
+
+// Non-blocking variant for the crash path; false means the lock was held
+// and the callback did not run. See the definition for why.
+bool TryGetApiContext(std::function<void(StreamElementsApiContext_t *)> callback);
 std::shared_ptr<StreamElementsApiContextItem> PushApiContext(CefString method, CefRefPtr<CefListValue> args);
 void RemoveApiContext(std::shared_ptr<StreamElementsApiContextItem> item);
 
@@ -135,6 +139,12 @@ public:
 };
 
 void GetAsyncCallContextStack(
+	std::function<void(const StreamElementsAsyncCallContextStack_t *)>
+		callback);
+
+// Non-blocking variant for the crash path; false means the lock was held and
+// the callback did not run. See the definition for why.
+bool TryGetAsyncCallContextStack(
 	std::function<void(const StreamElementsAsyncCallContextStack_t *)>
 		callback);
 


### PR DESCRIPTION
Swept the crash handler for crash and deadlock bugs. **Four found, all on paths that only run while the process is already dying** — which is why none had surfaced. Builds verified on Windows and macOS.

## 1. A crash off the main thread discarded the report, silently

Severity: this would have thrown away **most** macOS crash reports while looking healthy.

The consent prompt cannot run off the main thread — AppKit is main-thread-only, and marshalling to the main thread from a signal handler risks deadlocking against the very thread that faulted. So `Prompt()` returned "not consented"… and the handler read that as a refusal and called `sentry_user_consent_revoke()`, discarding the report.

Most crashes happen on worker threads. Sentry would have received almost nothing, and nothing would have looked wrong.

`Result` now distinguishes **declined** from **could not ask**:

| Outcome | Action |
|---|---|
| Consented | `sentry_user_consent_give()` — flush |
| Declined (asked, said no) | `sentry_user_consent_revoke()` — drop |
| **Could not ask** | leave cached, drop a marker; **next launch asks** |

The next-launch prompt runs at init, which is on the main thread, and gives or revokes then. The marker is written with `open`/`close` — async-signal-safe — against a path resolved at init so the handler never builds one.

## 2. Two threads faulting at once could both handle the crash

The re-entry guard was a read-then-write on a `sig_atomic_t`. That is atomic *per access*, not as a test-and-set, so two simultaneous faults could both pass it and put up two dialogs. Now a compare-and-swap.

## 3. Returning from the handler could spin the process forever

Two paths returned without resolving the fault: the re-entry guard, and the case where the displaced disposition was `SIG_DFL`/`SIG_IGN`.

Normally harmless — sentry's handler is the one the kernel invoked, and it re-raises after calling us. **But if `sentry_init()` failed we are the top-level handler with nobody behind us**, and returning from a `SIGSEGV` handler just re-executes the faulting instruction: an infinite fault loop, a hung OBS rather than a crashed one. Both paths now restore the default disposition and re-raise.

## 4. Chaining fell through silently

A previous handler registered without `SA_SIGINFO` but with a null `sa_sigaction` (or the reverse) matched neither branch, fell out of the loop, and hit the bare return from bug 3. The branches now test the flag and the pointer together, and anything unhandled terminates.

## Noted, not changed

`PersistContactDetails` calls `StreamElementsConfig::GetInstance()`, which takes a `shared_mutex`. If the crashing thread already held it, that self-deadlocks — `std::shared_mutex` is not recursive. Narrow, and it only runs after the user consents, but it is a real deadlock window on a dying process. Fixing it properly means writing contact details without touching the config singleton; worth doing, but it is a change in how that state is stored rather than a bug fix.

#partial