### PR TITLE
fix(ci): the crash-handler flag was silently dropped on Windows (CORE-554)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 env:
   BASE_BUILD_NUMBER: 569
 
-  BUILD_OPTIONS: >
+  BUILD_OPTIONS: >-
     -DENABLE_DECKLINK=OFF
     -DENABLE_SYPHON=OFF
     -DENABLE_LIBFDK=OFF
@@ -325,7 +325,7 @@ jobs:
           copy C:\local\obs-studio\plugins\obs-streamelements-core\CMakeUserPresets.json C:\local\obs-studio\CMakeUserPresets.json
           del C:\local\obs-studio\plugins\obs-streamelements-core\CMakeUserPresets.json
           cd /d C:\local\obs-studio
-          cmake --preset=windows-x64-streamelements %BUILD_OPTIONS% -DSTREAMELEMENTS_CRASH_HANDLER=%SE_CRASH_HANDLER%
+          cmake --preset=windows-x64-streamelements -DSTREAMELEMENTS_CRASH_HANDLER=%SE_CRASH_HANDLER% %BUILD_OPTIONS%
 
       - name: Build
         shell: cmd


### PR DESCRIPTION
Every Windows build has compiled **BugSplat regardless of `SE_CRASH_HANDLER`** — including the one produced after flipping it to `sentry`.

## Evidence

The build log shows the variable arriving correctly and CMake ignoring it, forty lines apart:

```
20:59:11  SE_CRASH_HANDLER: sentry              <- env at the Configure step
21:01:02  crash handler backend: bugsplat       <- what CMake resolved
```

And the shipped `build64_qt6.zip` carries the BugSplat runtime with no daemon:

```
bin/64bit/BugSplat64.dll
bin/64bit/BugSplatHD64.exe
bin/64bit/BugSplatRc64.dll
obs-plugins/64bit/obs-streamelements-core.dll     <- and no sentry-crash.exe
```

## Cause

`BUILD_OPTIONS` is a folded YAML scalar written with `>`, which **clips** rather than strips — so the value ends with a newline. The runner's own env dump shows it as a blank line between `BUILD_OPTIONS` and `SE_CRASH_HANDLER`.

The configure line put the flag after it:

```
cmake --preset=... %BUILD_OPTIONS% -DSTREAMELEMENTS_CRASH_HANDLER=%SE_CRASH_HANDLER%
```

Once cmd expanded the variable, the command **ended at that newline**, and the flag landed on a line of its own. cmake ran without it and took the cache default, `bugsplat`.

It never failed, because dropping an argument is not an error and the step's exit code comes from the last command — a silent no-op, the same shape as the installer-glob and daemon-copy bugs.

## Fix

- `>-` instead of `>`, stripping the trailing newline at the root.
- The flag now **precedes** `%BUILD_OPTIONS%`, so a reintroduced newline cannot swallow it again.

macOS was never affected: it passes the flag before `$BUILD_OPTIONS` and bash word-splits the trailing newline harmlessly.

## Correction to the record

#101 claimed one variable feeds every configure site so a build's binary and symbols could not disagree. That was true of the YAML and false of the build — on Windows the value never reached cmake. This is also why crashing a recent build raised BugSplat's dialog: the switch *was* flipped, the flag just never arrived.

Verification after this merges is the zip itself — `sentry-crash.exe` present, BugSplat DLLs absent — before anyone spends time crashing it.