### PR TITLE
fix(crash): wait for the crash upload instead of cancelling it (CORE-554) #partial

### DIFF
--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -425,6 +425,26 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	// browser sources is large enough to risk the upload cap; this is the
 	// SDK's recommended middle setting and the one to revisit if crashes
 	// turn out to need more.
+	//
+	// How long the SDK waits for in-flight uploads before forcing shutdown.
+	//
+	// Not a tuning knob: with the default, an observed crash produced a
+	// complete 1MB minidump on disk and then lost it. The daemon log read
+	//
+	//   WinHttpSendRequest failed with code 12017
+	//   background thread failed to shut down cleanly within timeout
+	//
+	// -- 12017 being ERROR_WINHTTP_OPERATION_CANCELLED, the request aborted
+	// mid-flight because teardown began underneath it. The crash envelope was
+	// not persisted for retry either, so the report was simply gone.
+	//
+	// 60s is deliberately generous. A minidump of this size on a slow or
+	// congested uplink takes seconds at best, and the cost of waiting too
+	// long is a delay in a process that is already terminating, against
+	// losing the report entirely.
+	//
+	sentry_options_set_shutdown_timeout(options, 60000);
+
 	sentry_options_set_minidump_mode(options, SENTRY_MINIDUMP_MODE_SMART);
 
 	// Client-side stackwalk as the primary event, with the minidump attached

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -440,6 +440,13 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve own module directory; falling back to the SDK's default sentry-crash lookup, which searches next to the host executable");
 	}
 
+	// 60s, for the reason documented in the Windows handler: with the default
+	// an observed crash wrote a complete minidump and then lost it when
+	// teardown cancelled the upload in flight. macOS has not been seen to do
+	// this, but the exposure is the same and the cost of waiting is a delay
+	// in a process that is already terminating.
+	sentry_options_set_shutdown_timeout(options, 60000);
+
 	sentry_options_set_minidump_mode(options, SENTRY_MINIDUMP_MODE_SMART);
 
 	sentry_options_set_crash_reporting_mode(


### PR DESCRIPTION
A real crash on `26.8.14.828` produced a **complete 1MB minidump on disk** and then lost it.

## Evidence

```
INFO initializing winhttp transport
WARN daemon could not acquire run folder lock
WARN `WinHttpSendRequest` failed with code `12017`
WARN background thread failed to shut down cleanly within timeout
WARN transport did not shut down cleanly
```

`12017` is `ERROR_WINHTTP_OPERATION_CANCELLED` — the upload was aborted **in flight** because shutdown began underneath it.

Worse, the crash envelope was never persisted for retry. The only thing left in the run folder was a 373-byte `{"type":"session"}` envelope, so a restart would not have flushed it. The minidump is still orphaned at the database root.

## Fix

`sentry_options_set_shutdown_timeout()` governs exactly this wait and was never set, leaving it on the default. Now **60s** on both platforms.

Deliberately generous: a 1MB dump takes seconds on a healthy link and considerably longer on a congested one. Overshooting costs a delay in a process that is already terminating; undershooting loses the report entirely, which is what happens today.

## What this is *not*

Distinct from `SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS` (10s, compile-time constant in the vendored SDK), which bounds how long the **crashing process** waits for the daemon to *capture* the dump. That part worked — the dump exists. The gap was everything after capture.

## What this crash already proved

Worth recording, because these were all unverified until now:

- the exception filter runs and reaches sentry's filter
- the daemon is found, launched, and does its job
- a real minidump is produced (1,024,205 bytes)
- `SMART` minidump mode yields a sane size

The only broken link was transmission.