### PR TITLE
fix(crash): stop crash reports being killed before they upload (CORE-554) #partial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,52 @@ if (ENABLE_SENTRY)
 			DESTINATION "${SENTRY_SOURCE_DIR}")
 	endif()
 
+	# Raise how long the crashing process waits for the crash daemon, 10s -> 60s.
+	#
+	# sentry-native hard-codes SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS as a
+	# compile-time #define with no sentry_options_* equivalent, so patching the
+	# source is the only way to reach it. At the stock 10s our exception filter
+	# gives up while the daemon is still uploading and returns
+	# EXCEPTION_CONTINUE_SEARCH; OBS's filter then terminates the process out
+	# from under the in-flight request. Observed as a complete 1MB minidump left
+	# on disk next to `WinHttpSendRequest failed with code 12017`
+	# (ERROR_WINHTTP_OPERATION_CANCELLED) in the daemon log, and nothing at all
+	# arriving in Sentry. See CORE-554.
+	#
+	# sentry_options_set_shutdown_timeout() does not cover this. It bounds how
+	# long the daemon waits for its own transport during teardown, which is moot
+	# once the process it belongs to has already been killed.
+	#
+	# Patched here rather than inside deps/sentry-native.zip so the divergence
+	# from upstream is visible in the build definition, and re-applied on every
+	# configure because the extract above is skipped once the tree exists.
+	set(SENTRY_WAIT_HEADER
+		"${SENTRY_SOURCE_DIR}/src/backends/native/sentry_crash_context.h")
+	set(SENTRY_WAIT_STOCK "10000 // 10s max wait for daemon")
+	set(SENTRY_WAIT_PATCHED "60000 // 60s max wait for daemon -- CORE-554")
+
+	file(READ "${SENTRY_WAIT_HEADER}" SENTRY_WAIT_CONTENT)
+
+	string(FIND "${SENTRY_WAIT_CONTENT}" "${SENTRY_WAIT_STOCK}"
+		SENTRY_WAIT_STOCK_POS)
+	string(FIND "${SENTRY_WAIT_CONTENT}" "${SENTRY_WAIT_PATCHED}"
+		SENTRY_WAIT_PATCHED_POS)
+
+	if (NOT SENTRY_WAIT_STOCK_POS EQUAL -1)
+		string(REPLACE
+			"${SENTRY_WAIT_STOCK}" "${SENTRY_WAIT_PATCHED}"
+			SENTRY_WAIT_CONTENT "${SENTRY_WAIT_CONTENT}")
+		file(WRITE "${SENTRY_WAIT_HEADER}" "${SENTRY_WAIT_CONTENT}")
+		message(STATUS
+			"obs-streamelements-core: patched SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS to 60s")
+	elseif (SENTRY_WAIT_PATCHED_POS EQUAL -1)
+		# Neither form present: the vendored SDK moved underneath us. Failing
+		# here is deliberate -- a silently skipped patch reintroduces a bug
+		# whose only symptom is that crash reports quietly never arrive.
+		message(FATAL_ERROR
+			"obs-streamelements-core: could not patch SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS in ${SENTRY_WAIT_HEADER} -- vendored sentry-native changed. Re-check the crash upload wait against CORE-554 before dropping this.")
+	endif()
+
 	# The `native` backend, not crashpad: it hands control back to WER rather than
 	# swallowing the host's crash handling, its hooks work on macOS, and it is the
 	# only backend offering sentry_options_set_minidump_flags. See CORE-554.

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -710,6 +710,39 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve own module directory; falling back to the SDK's default sentry-crash.exe lookup, which searches next to obs64.exe");
 	}
 
+	// Where the SDK queues envelopes and minidumps until they are sent.
+	//
+	// Left unset, sentry-native uses `.sentry-native` relative to the
+	// current working directory, which for an installed OBS is
+	// `Program Files\obs-studio\bin\64bit`. A non-elevated user cannot
+	// write there, so reports are lost before they are ever queued. This
+	// was observed on a machine where that directory happened to be
+	// writable: a complete minidump and its envelope sat in Program Files,
+	// never sent.
+	//
+	// The plugin config directory is per-user, writable without elevation,
+	// and already holds the rest of our state. The wide variant is
+	// deliberate -- the narrow one reads the path in the ANSI code page,
+	// which mangles a profile directory containing non-Latin characters.
+	char *databasePath = obs_module_config_path("sentry-db");
+
+	if (databasePath) {
+		sentry_options_set_database_pathw(
+			options, utf8_to_wstring(databasePath).c_str());
+
+		// Logged because a report that never arrives is diagnosed by
+		// looking for a stranded envelope, and that is only possible if
+		// the log says where to look.
+		blog(LOG_INFO,
+		     "obs-streamelements-core: StreamElements: Crash Handler: database path is %s",
+		     databasePath);
+
+		bfree(databasePath);
+	} else {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve the plugin config directory; falling back to the SDK's default database path, which is relative to the working directory");
+	}
+
 	// Stack plus heap around the crash site, roughly 5-10MB. BugSplat was
 	// configured for full memory dumps, which on an OBS process carrying
 	// browser sources is large enough to risk the upload cap; this is the


### PR DESCRIPTION
Nothing has ever reached the Sentry project — not a single event in 30 days, no issues in 90 — despite Sentry-enabled crashes that produced a complete 1MB minidump on disk, a well-formed envelope carrying the right DSN and release, and an OBS crash log proving the filter chain survived.

Two independent bugs, either of which loses the report on its own.

## The crashing process gives the daemon 10 seconds and no more

`SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS` is a compile-time `#define` in sentry-native with no `sentry_options_*` equivalent, so it cannot be raised without patching the source. When it expires the exception filter returns `EXCEPTION_CONTINUE_SEARCH`, OBS's own filter runs and terminates the process, and the daemon's in-flight upload dies with it. The daemon log records exactly that:

```
WinHttpSendRequest failed with code 12017
background thread failed to shut down cleanly within timeout
```

12017 is `ERROR_WINHTTP_OPERATION_CANCELLED`. Every timestamp lines up:

| time | event |
|---|---|
| 13:46:33 | crash; client notifies daemon, polls for `state >= CAPTURED` |
| 13:46:43 | the 10s cap expires → `EXCEPTION_CONTINUE_SEARCH` |
| 13:46:44 | OBS's filter writes its crash log, terminates the process |
| 13:46:46 | in-flight upload cancelled → 12017 |

**`sentry_options_set_shutdown_timeout(60000)` does not cover this**, which is why raising it in #114 changed nothing — it bounds how long the *daemon* waits for its own transport during teardown, moot once the process has been killed. **Nor does `SENTRY_CRASH_UPLOAD_MODE_ASYNC`**: it releases the client as soon as the data is durable, and the app then exits while the upload is still in flight — the same cancellation.

Patched to 60s at configure time rather than inside `deps/sentry-native.zip`, so the divergence from upstream is visible in the build definition. It fails the configure outright if a future SDK bump drops the pattern — a silently skipped patch would reintroduce a bug whose only symptom is that reports quietly never arrive.

## The database path was never set

sentry-native fell back to `.sentry-native` relative to the working directory. For an installed OBS that is `Program Files\obs-studio\bin\64bit`, which a non-elevated user cannot write — so reports would be dropped before they were ever queued, for every real user, regardless of the timeout. It happened to be writable on the dev box this was found on, which is the only reason there was a stranded minidump to find.

Now points at the plugin config directory, per-user and already home to the rest of our state. The wide variant is deliberate: the narrow one reads the path in the ANSI code page and mangles a profile directory containing non-Latin characters.

## Verification

Builds clean on Windows; `clang-format` leaves both files unchanged. The configure-time patch was confirmed applied to the extracted header, and the sentry sources recompiled against it.

**Not yet proven end to end** — that a report now actually lands in Sentry still needs a crash from a build carrying this, which is the remaining CORE-554 verification item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)