### PR TITLE
docs: rename the status page to status.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd build_macos_arm64 && xcodebuild -configuration RelWithDebInfo \
 | MacOS | `latest` | <img src="https://cdn.streamelements.com/obs/dist/obs-streamelements/macos/latest/obs-streamelements.version.svg" /> |
 | MacOS | `stable` | <img src="https://cdn.streamelements.com/obs/dist/obs-streamelements/macos/stable/obs-streamelements.version.svg" /> |
 
-<a href="https://streamelements.github.io/obs-streamelements-core/" target="_blank">Extended Status Page</a> — every channel on both platforms, with build dates, promotion drift and release notes, read live from the CDN manifests. Source: <a href="docs/index.html">docs/index.html</a>.
+<a href="https://streamelements.github.io/obs-streamelements-core/status.html" target="_blank">Extended Status Page</a> — every channel on both platforms, with build dates, promotion drift and release notes, read live from the CDN manifests. Source: <a href="docs/status.html">docs/status.html</a>.
 
 # Deployment
 

--- a/docs/status.html
+++ b/docs/status.html
@@ -184,7 +184,7 @@
   <footer>
     Replaces the hand-uploaded page at
     <a href="https://cdn.streamelements.com/obs/qa/status.html">cdn.streamelements.com/obs/qa/status.html</a>.
-    Source: <a href="https://github.com/StreamElements/obs-streamelements-core/blob/master/docs/index.html">docs/index.html</a>.
+    Source: <a href="https://github.com/StreamElements/obs-streamelements-core/blob/master/docs/status.html">docs/status.html</a>.
     Manifests are read cross-origin from the CDN, which serves
     <span style="font-family:var(--mono)">access-control-allow-origin: *</span>.
   </footer>


### PR DESCRIPTION
Renames `docs/index.html` to `docs/status.html`, keeping the name the page carried on the CDN for years so existing links and muscle memory still resolve to something recognisable. README updated to match.

**New URL:** https://streamelements.github.io/obs-streamelements-core/status.html

## The bare URL now 404s, deliberately

GitHub Pages serves `index.html` at a directory root and has **no server-side redirects**. With no `index.html`, https://streamelements.github.io/obs-streamelements-core/ returns the 404 page and the content lives only at `/status.html`.

I initially added a two-line `index.html` meta-refresh stub so both URLs stayed alive, and removed it on review: one canonical URL was preferred over two. Flagging it here so the 404 is a known consequence rather than a surprise — if anyone later wants the bare URL to work, a `docs/index.html` containing a `<meta http-equiv="refresh">` is the whole fix.

## Verification

Served `docs/` over local HTTP and confirmed `/status.html` returns 200 with the correct title and full 24,754-byte page. No stale `docs/index.html` references remain in the tree — the page's own footer self-link was updated too.

Rename is detected as such by git (99% similarity); the only content change is that footer link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)