### PR TITLE
feat(installer): require OBS Studio 32.2.0+ and install 32.2.1 when missing (CORE-600)

### DIFF
--- a/CI/obs-streamelements-installer/common.nsh
+++ b/CI/obs-streamelements-installer/common.nsh
@@ -10,13 +10,17 @@
 # !define OBS_DOWNLOAD_VERSION "27.2.4"
 #!define OBS_DOWNLOAD_URL_64 "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-${OBS_DOWNLOAD_VERSION}-Full-Installer-x64.exe"
 #!define OBS_DOWNLOAD_URL_32 "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-${OBS_DOWNLOAD_VERSION}-Full-Installer-x86.exe"
-!define OBS_DOWNLOAD_VERSION ""
-!define OBS_DOWNLOAD_URL_64 "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-31.1.2-Windows-x64-Installer.exe"
+!define OBS_DOWNLOAD_VERSION "32.2.1"
+!define OBS_DOWNLOAD_URL_64 "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-${OBS_DOWNLOAD_VERSION}-Windows-x64-Installer.exe"
+# OBS Studio has published no 32-bit build since 27.2.4, which cannot satisfy
+# OBS_REQUIRE_VERSION. This URL is only ever reached on a 32-bit host, or beside
+# an existing 32-bit install -- see DownloadAndInstallOBS. It is deliberately
+# NOT ${OBS_DOWNLOAD_VERSION}: no such file exists.
 !define OBS_DOWNLOAD_URL_32 "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-27.2.4-Full-Installer-x86.exe"
 !define MSVC_REDIST_X64_URL "https://cdn.streamelements.com/obs/dist/third-party/microsoft/vs2019/vcredist_x64.exe"
 !define MSVC_REDIST_X86_URL "https://cdn.streamelements.com/obs/dist/third-party/microsoft/vs2019/vcredist_x86.exe"
 
-!define OBS_REQUIRE_VERSION "31.1.0"
+!define OBS_REQUIRE_VERSION "32.2.0"
 
 !define MSG_DOWNLOAD_ERROR_RETRY "Failed downloading installation package.$\r$\n$\r$\nClick Retry to resume downloading or Cancel to abort."
 !define MSG_DOWNLOAD_CANCEL_CONFIRM "Are you sure that you want to stop download and abort ${PRODUCT_SHORT_NAME} setup?"

--- a/CI/obs-streamelements-installer/macos_distribution.xml
+++ b/CI/obs-streamelements-installer/macos_distribution.xml
@@ -27,7 +27,7 @@ https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/I
         function check_obs_present() {
             system.log("check_obs_present: START");
 
-            const MIN_OBS_VERSION = "31.1.0";
+            const MIN_OBS_VERSION = "32.2.0";
 
             system.log("check_obs_present: MIN_OBS_VERSION: " + MIN_OBS_VERSION);
 
@@ -52,7 +52,7 @@ https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/I
                 system.log("check_obs_present: obsInfo is null");
 
                 my.result.title = "OBS Studio not found.";
-                my.result.message = "Please install the latest version of OBS Studio from https://obsproject.com before installing SE.Live.";
+                my.result.message = "SE.Live requires OBS Studio " + MIN_OBS_VERSION + " or newer. Please install it from https://obsproject.com before installing SE.Live.";
                 my.result.type = "Fatal";
 
                 return true;
@@ -66,7 +66,7 @@ https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/I
                 system.log("check_obs_present: obsVersion < MIN_OBS_VERSION");
 
                 my.result.title = "OBS Studio is too old.";
-                my.result.message = "Please install the latest version of OBS Studio from https://obsproject.com before installing SE.Live.";
+                my.result.message = "SE.Live requires OBS Studio " + MIN_OBS_VERSION + " or newer, but this Mac has " + obsVersion + ". Please update OBS Studio from https://obsproject.com before installing SE.Live.";
                 my.result.type = "Fatal";
 
                 return true;

--- a/CI/obs-streamelements-installer/main.nsi
+++ b/CI/obs-streamelements-installer/main.nsi
@@ -929,7 +929,9 @@ get_obs_32:
     StrCpy $g_obsTempPath32 "$g_obsTempPath32.exe"
 
     StrCpy $g_downloadTargetPath $g_obsTempPath32
-    StrCpy $g_downloadText "OBS Studio (Win32) ${OBS_DOWNLOAD_VERSION}"
+    ; No version in this caption on purpose: the 32-bit URL is the last x86 build
+    ; OBS ever shipped, not ${OBS_DOWNLOAD_VERSION}.
+    StrCpy $g_downloadText "OBS Studio (Win32)"
     StrCpy $g_downloadUrl "${OBS_DOWNLOAD_URL_32}"
     Call DownloadRequiredFile
 


### PR DESCRIPTION
Fixes CORE-600

Raises the minimum supported OBS Studio to **32.2.0** in both installers, and points the Windows installer's OBS download at **32.2.1**.

## Why

`build.yml` already pins `CHECKOUT: 32.2.1`, so the shipped plugin is built against OBS 32.2.x while both installers still accepted 31.1.0. That gap fails silently in the worst way: the installer places the binary, OBS refuses to load it over a missing export, and the user just finds SE.Live absent. We hit exactly this shape of failure today on macOS — a plugin built against Qt 6.11 dropped into an OBS carrying Qt 6.8 gave `dlopen … Symbol not found` and `Module … not loaded`, with nothing user-visible.

## Windows — `common.nsh`

| | before | after |
|---|---|---|
| `OBS_REQUIRE_VERSION` | `31.1.0` | `32.2.0` |
| `OBS_DOWNLOAD_VERSION` | `""` | `32.2.1` |
| `OBS_DOWNLOAD_URL_64` | hardcoded 31.1.2 | derived from `OBS_DOWNLOAD_VERSION` |

No new machinery. `VerifyObsStudioInstalled` already probes libobs, compares against `OBS_REQUIRE_VERSION`, and force-selects `section_download_obs_studio` (flags `17` = selected + readonly) when OBS is absent or too old — which is what runs `DownloadAndInstallOBS`. Only the constants move.

## macOS — `macos_distribution.xml`

`MIN_OBS_VERSION` → `32.2.0`, and both `installation-check` failure messages now name the required version; the "too old" branch also names the version actually found. This installer can't install OBS for the user — it's a `Fatal` stop — so the message has to be actionable on its own.

## Left alone on purpose

`OBS_DOWNLOAD_URL_32` still points at OBS **27.2.4**, the last x86 build OBS ever published, which cannot satisfy a 32.2.0 minimum. It couldn't satisfy the old 31.1.0 minimum either, so this PR doesn't make it worse, and retiring 32-bit is its own change. The one thing corrected is the Win32 download caption, which interpolated `OBS_DOWNLOAD_VERSION` and would now have claimed to fetch 32.2.1 while fetching 27.2.4.

## Verification

- `OBS-Studio-32.2.1-Windows-x64-Installer.exe` on the obsproject CDN returns **HTTP 200** (`32.2.0` too; the `-Full-Installer-x64.exe` naming used by the commented-out 27.2.4 lines is 404 for these versions, hence the `-Windows-x64-Installer` form).
- `${VersionCompare} "${OBS_REQUIRE_VERSION}" "$g_obsVersion" $R0` with `$R0 == 1` meaning "required is newer than installed" — semantics unchanged, only the constant moves.
- `$g_obsVersion` comes from `obs-probe-libobs-version-{32,64}.exe`, reporting the libobs version on the same numbering scale as the constant.

Not built: NSIS compilation happens in the installer pipeline, not in this repo's `build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)