### PR TITLE
fix(crash): make macOS crash reporting actually report (CORE-554) #partial

### DIFF
--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -242,6 +242,26 @@ bool StreamElementsApiMessageHandler::OnProcessMessageReceived(
 						return;
 					}
 
+					// The crash consent prompt is modal, and a
+					// modal loop keeps draining this queue --
+					// so without this, calls posted before
+					// the fault run inside the crash handler,
+					// on the thread that crashed. See
+					// IsCrashReportingInProgress().
+					if (IsCrashReportingInProgress()) {
+						blog(LOG_ERROR,
+						     "obs-streamelements-core[%s %s]: API: a crash is being reported; refusing call to '%s', callback id %d",
+						     context->target->m_target
+							     .c_str(),
+						     context->target->m_unique_id
+							     .c_str(),
+						     context->id.c_str(),
+						     context->cef_app_callback_id);
+
+						context->complete();
+						return;
+					}
+
 					if (IsTraceLogLevel()) {
 						blog(LOG_INFO,
 						     "obs-streamelements-core[%s %s]: API: performing call to '%s', callback id %d",

--- a/streamelements/StreamElementsBugSplatCrashHandler.cpp
+++ b/streamelements/StreamElementsBugSplatCrashHandler.cpp
@@ -184,6 +184,15 @@ static void HangDetectionThread()
 				return;
 			}
 
+			// The user agreed to interrupt OBS and report. From
+			// here the process is being torn down around a report,
+			// so nothing new should be dispatched into it if the UI
+			// thread happens to come unstuck mid-collection. Unlike
+			// the exception filter this MessageBox runs on the hang
+			// detection thread, so it is not itself pumping the
+			// app's queue -- but the outcome is the same.
+			SetCrashReportingInProgress();
+
 			CreateMessageWindow(true);
 
 			std::time_t hangTimestamp = std::time(nullptr);
@@ -385,6 +394,13 @@ static LONG CALLBACK CustomExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 
 	if (s_crashContext)
 		s_crashContext->WalkStack(pExceptionInfo->ContextRecord);
+
+	// Stops host API calls from running once we are on the crash path.
+	// BugSplat's own submit prompt is modal, and a modal message loop keeps
+	// dispatching to this process -- including Qt's posted events, and so
+	// the API calls queued before the fault. See
+	// IsCrashReportingInProgress().
+	SetCrashReportingInProgress();
 
 	if (InterlockedIncrement(&s_insideExceptionFilter) == 1L) {
 #if HANG_DETECTION_ENABLED

--- a/streamelements/StreamElementsCrashConsentDialog.mm
+++ b/streamelements/StreamElementsCrashConsentDialog.mm
@@ -4,6 +4,7 @@
 #import <Foundation/Foundation.h>
 
 #include <string>
+#include <float.h>
 
 /* ================================================================= */
 
@@ -100,8 +101,17 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 	@autoreleasepool {
 		const CGFloat width = 420;
 
+		// Room for several lines of description. People answering "what
+		// were you doing" write sentences, not words, and a box one line
+		// tall says the opposite -- the Windows dialog has always given
+		// this field ES_MULTILINE and four lines of height.
+		const CGFloat descriptionHeight = 96;
+
+		const CGFloat descriptionTop = 178 + descriptionHeight;
+
 		NSView *accessory = [[NSView alloc]
-			initWithFrame:NSMakeRect(0, 0, width, 210)];
+			initWithFrame:NSMakeRect(0, 0, width,
+						 descriptionTop + 4)];
 
 		// Laid out from the bottom up: AppKit's origin is bottom-left,
 		// so the first control added sits lowest on screen.
@@ -116,11 +126,28 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 			AddField(accessory, @"Name:", name, 148, width);
 
 		NSScrollView *scroll = [[NSScrollView alloc]
-			initWithFrame:NSMakeRect(0, 178, width, 28)];
+			initWithFrame:NSMakeRect(0, 178, width,
+						 descriptionHeight)];
 		NSTextView *description = [[NSTextView alloc]
-			initWithFrame:NSMakeRect(0, 0, width, 28)];
+			initWithFrame:NSMakeRect(0, 0, width,
+						 descriptionHeight)];
 
 		[description setRichText:NO];
+
+		// Without these an NSTextView in a scroll view neither wraps nor
+		// grows: the text container keeps its initial size, so typing
+		// runs off the right edge on a single line and the extra height
+		// above buys nothing.
+		[description setMinSize:NSMakeSize(0, descriptionHeight)];
+		[description setMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
+		[description setVerticallyResizable:YES];
+		[description setHorizontallyResizable:NO];
+		[description setAutoresizingMask:NSViewWidthSizable];
+
+		[[description textContainer]
+			setContainerSize:NSMakeSize(width, FLT_MAX)];
+		[[description textContainer] setWidthTracksTextView:YES];
+
 		[scroll setDocumentView:description];
 		[scroll setHasVerticalScroller:YES];
 		[scroll setBorderType:NSBezelBorder];

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -596,6 +596,13 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 	if (s_crashContext)
 		s_crashContext->WalkStack(pExceptionInfo->ContextRecord);
 
+	// Stops host API calls from running once we are on the crash path. The
+	// consent prompt below is modal, and a modal message loop keeps
+	// dispatching to this process -- including Qt's posted events, and so
+	// the API calls queued before the fault. See
+	// IsCrashReportingInProgress().
+	SetCrashReportingInProgress();
+
 	if (InterlockedIncrement(&s_insideExceptionFilter) == 1L) {
 		// The gate. A stack that never passed through our code is not
 		// ours to report: we skip sentry's filter entirely, so no event

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -495,6 +495,38 @@ static void DieWithSignal(int signum)
 	raise(signum);
 }
 
+//
+// Leaves a note for the next launch that a crash is still sitting in the cache
+// unsent, either because we could not ask about it or because the upload did
+// not finish. The contents are the crash's event id, so the deferred prompt can
+// attach what the user types to the right crash; an empty marker is still a
+// valid marker, it just means feedback has nowhere to point.
+//
+// Called from the signal handler, so nothing here does more than open/write/
+// close: the path was resolved at init and the id formatted in OnCrash exactly
+// so this function has neither to build.
+//
+static void WritePendingConsentMarker()
+{
+	if (!s_pendingMarkerPath[0])
+		return;
+
+	const int fd =
+		open(s_pendingMarkerPath, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+	if (fd < 0)
+		return;
+
+	if (s_crashEventIdString[0]) {
+		const ssize_t ignored = write(fd, s_crashEventIdString,
+					      strlen(s_crashEventIdString));
+
+		UNUSED_PARAMETER(ignored);
+	}
+
+	close(fd);
+}
+
 static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 {
 	// One crash only, and only one thread's. A plain read-then-write would
@@ -558,7 +590,15 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 			// window, which has nothing else to cover, was on
 			// screen for microseconds. Same 60s budget and the same
 			// reasoning as the Windows handler's shutdown timeout.
-			sentry_flush(60000);
+			if (sentry_flush(60000) != 0) {
+				// Timed out: the envelope is still cached and
+				// this process is about to die. Consent is reset
+				// at every startup (see the constructor), so
+				// without a marker nothing would ever pick this
+				// up again and the report would be stranded on
+				// disk forever.
+				WritePendingConsentMarker();
+			}
 		} else if (consent.prompted) {
 			// An actual "Don't send". Drop it.
 			sentry_user_consent_revoke();
@@ -571,34 +611,8 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 			//
 			// Leave consent untouched so the envelope stays cached,
 			// and drop a marker for the next launch to notice and
-			// ask about. open/write/close are async-signal-safe;
-			// the path was resolved at init, and the id was
-			// formatted in OnCrash, precisely so nothing here has
-			// to build either.
-			//
-			// The marker carries the event id as its contents so
-			// the deferred prompt can still attach what the user
-			// types to the right crash. An empty marker is still a
-			// valid marker -- it just means feedback has nowhere to
-			// point.
-			if (s_pendingMarkerPath[0]) {
-				const int fd = open(
-					s_pendingMarkerPath,
-					O_WRONLY | O_CREAT | O_TRUNC, 0600);
-
-				if (fd >= 0) {
-					if (s_crashEventIdString[0]) {
-						const ssize_t ignored = write(
-							fd,
-							s_crashEventIdString,
-							strlen(s_crashEventIdString));
-
-						UNUSED_PARAMETER(ignored);
-					}
-
-					close(fd);
-				}
-			}
+			// ask about.
+			WritePendingConsentMarker();
 		}
 	}
 
@@ -876,16 +890,39 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 						&pendingEventId));
 			}
 
-			// Releases whatever the previous run left cached. No
-			// flush here, deliberately: this runs during startup on
-			// the main thread, and blocking the UI for up to a
-			// minute to push an old report would be worse than
-			// letting the retry queue carry it in the background.
+			// Releases whatever the previous run left cached, and
+			// then pushes it while we still hold consent -- the
+			// revoke below is unconditional, so leaving this to the
+			// background retry queue would race it and strand the
+			// report. Shorter budget than the crash path: the user
+			// is looking at a working OBS, not a dying one.
+			StartCrashProgress(CRASH_PROGRESS_UPLOADING);
+
 			sentry_user_consent_give();
-		} else {
-			sentry_user_consent_revoke();
+			sentry_flush(30000);
+
+			StopCrashProgress();
 		}
 	}
+
+	//
+	// Consent is per crash, never a standing preference. Unconditional, and
+	// last, so it covers both branches above.
+	//
+	// sentry-native persists the answer to <database>/user-consent and
+	// treats it as a global gate, which means a "yes" given for one crash
+	// silently pre-authorises the next one: the daemon uploads the moment
+	// the fault happens, before the dialog is on screen and regardless of
+	// what the user then clicks. Observed exactly that -- a second crash
+	// produced no "caching envelope" line at all, and the report was gone
+	// before it could be declined or described.
+	//
+	// Resetting here means every crash is answered on its own terms, with
+	// its own description, which is the only reading of "consent" that
+	// means anything. Note revoking does not touch anything already in the
+	// cache; it only closes the gate.
+	//
+	sentry_user_consent_revoke();
 
 	// After sentry_init, and deliberately: constructing this fetches the
 	// remote module-of-interest list over HTTP, which is not something to

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -410,6 +410,12 @@ static sentry_value_t OnCrash(const sentry_ucontext_t *uctx,
 	UNUSED_PARAMETER(uctx);
 	UNUSED_PARAMETER(user_data);
 
+	// First thing, and before anything below can run a nested run loop.
+	// See IsCrashReportingInProgress() -- without this a host API call
+	// queued before the fault gets delivered into the consent dialog's
+	// modal loop and faults again on the already-crashed thread.
+	SetCrashReportingInProgress();
+
 	//
 	// Deliberately not the place to filter. Discarding here would suppress
 	// the event but not the minidump: the daemon notify that follows is
@@ -501,6 +507,11 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 
 		return;
 	}
+
+	// Also set in OnCrash, which normally runs first. Repeated here because
+	// this handler still runs when sentry_init() failed and there is no
+	// OnCrash to reach.
+	SetCrashReportingInProgress();
 
 	if (s_initialized) {
 		const auto consent = StreamElementsCrashConsentDialog::Prompt(

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -16,6 +16,7 @@
 #include <util/platform.h>
 
 #include <signal.h>
+#include <string.h>
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <fcntl.h>
@@ -63,6 +64,22 @@ static StreamElementsCrashContext *s_crashContext = nullptr;
 // see ChainedSignalHandler. Resolved once at init so the signal handler only
 // has to open a path that already exists as a string.
 static char s_pendingMarkerPath[512] = {0};
+
+// Identity of the crash event, stamped by OnCrash.
+//
+// The prompt runs after the envelope has been written, so nothing the user
+// types can be added to the event itself -- see the note in OnCrash. What we
+// can do is send their answer as a separate User Feedback item pointing back at
+// this id, which is why the id has to be chosen by us rather than left to
+// sentry__ensure_event_id.
+static sentry_uuid_t s_crashEventId;
+static bool s_haveCrashEventId = false;
+
+// The same id, pre-formatted. The signal handler writes it into the pending
+// marker for the next launch to pick up, and formatting it there would mean
+// calling sentry_uuid_as_string from a signal handler; doing it in OnCrash
+// leaves that path with nothing but open/write/close.
+static char s_crashEventIdString[37] = {0};
 
 /* ================================================================= */
 
@@ -406,6 +423,23 @@ static sentry_value_t OnCrash(const sentry_ucontext_t *uctx,
 	// public API to add to one that already exists. So the whole payload is
 	// gathered here rather than alongside the prompt.
 	//
+	// Which is also why the event id is assigned here. Left alone,
+	// sentry__ensure_event_id picks one a moment later, inside the envelope
+	// the daemon writes, and we never see it -- sentry_handle_exception
+	// returns void. Setting it first means the prompt still has something to
+	// attach the user's description to. ensure_event_id keeps any non-nil
+	// value already present, so this simply wins.
+	{
+		s_crashEventId = sentry_uuid_new_v4();
+		sentry_uuid_as_string(&s_crashEventId, s_crashEventIdString);
+
+		sentry_value_set_by_key(
+			event, "event_id",
+			sentry_value_new_string(s_crashEventIdString));
+
+		s_haveCrashEventId = true;
+	}
+
 	if (s_crashContext) {
 		// Up before the slow part, not after: this hook runs ahead of
 		// the consent dialog, so without it the whole of WalkStack and
@@ -478,25 +512,42 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 			PersistContactDetails(consent.name, consent.email,
 					      consent.discord);
 
-			SetSentryUser(consent.name, consent.email,
-				      consent.discord);
-
-			if (consent.description.size()) {
-				sentry_value_t report =
-					sentry_value_new_object();
-
-				sentry_value_set_by_key(
-					report, "description",
-					sentry_value_new_string(
-						consent.description.c_str()));
-
-				sentry_set_context("user_report", report);
+			// Deliberately NOT sentry_set_user() here. The crash
+			// envelope was sealed by the daemon before this prompt
+			// ever appeared, so a scope change now reaches no
+			// event at all -- it would only apply to some later
+			// one, and this process is about to die. The identity
+			// that travels with the crash is the one set at init;
+			// what the user typed just now travels as feedback.
+			if (consent.description.size() && s_haveCrashEventId) {
+				sentry_capture_feedback(
+					sentry_value_new_feedback(
+						consent.description.c_str(),
+						consent.email.size()
+							? consent.email.c_str()
+							: nullptr,
+						consent.name.size()
+							? consent.name.c_str()
+							: nullptr,
+						&s_crashEventId));
 			}
 
 			// Releases what the daemon already wrote. Until this
 			// call the envelope sits in the cache unsent, which is
 			// what makes "Don't send" mean it.
 			sentry_user_consent_give();
+
+			// And this is what actually pushes it out.
+			//
+			// Consent only moves the envelope into the retry queue;
+			// the upload itself happens on the background worker.
+			// Without a flush we returned immediately, chained to
+			// OBS's handler, and the process died with the report
+			// still queued -- and the "Uploading the crash report"
+			// window, which has nothing else to cover, was on
+			// screen for microseconds. Same 60s budget and the same
+			// reasoning as the Windows handler's shutdown timeout.
+			sentry_flush(60000);
 		} else if (consent.prompted) {
 			// An actual "Don't send". Drop it.
 			sentry_user_consent_revoke();
@@ -510,15 +561,32 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 			// Leave consent untouched so the envelope stays cached,
 			// and drop a marker for the next launch to notice and
 			// ask about. open/write/close are async-signal-safe;
-			// the path was resolved at init precisely so nothing
-			// here has to build it.
+			// the path was resolved at init, and the id was
+			// formatted in OnCrash, precisely so nothing here has
+			// to build either.
+			//
+			// The marker carries the event id as its contents so
+			// the deferred prompt can still attach what the user
+			// types to the right crash. An empty marker is still a
+			// valid marker -- it just means feedback has nowhere to
+			// point.
 			if (s_pendingMarkerPath[0]) {
 				const int fd = open(
 					s_pendingMarkerPath,
 					O_WRONLY | O_CREAT | O_TRUNC, 0600);
 
-				if (fd >= 0)
+				if (fd >= 0) {
+					if (s_crashEventIdString[0]) {
+						const ssize_t ignored = write(
+							fd,
+							s_crashEventIdString,
+							strlen(s_crashEventIdString));
+
+						UNUSED_PARAMETER(ignored);
+					}
+
 					close(fd);
+				}
 			}
 		}
 	}
@@ -620,12 +688,32 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	//
 	// This is what lets the prompt run after the dump and still mean
 	// something: the daemon reads consent out of shared memory rather than
-	// uploading blindly, so a refusal still stops the minidump. Envelopes
-	// captured while consent is withheld are cached, and flushed if consent
-	// is given later -- possibly not until the next launch, since a dying
-	// process may not survive long enough to finish the upload.
+	// uploading blindly, so a refusal still stops the minidump.
 	//
 	sentry_options_set_require_user_consent(options, 1);
+
+	//
+	// ...and these two are what make the sentence above true.
+	//
+	// require_user_consent ON ITS OWN DISCARDS the report. In
+	// sentry__capture_envelope, a withheld-consent envelope is only written
+	// to the cache when cache_keep or http_retry is set; otherwise it is
+	// dropped on the spot. A live crash test logged
+	//
+	//   INFO discarding envelope due to missing user consent
+	//
+	// about a second after the fault -- while the consent dialog was still
+	// on screen, and therefore long before it was answered. The whole
+	// dump-first-ask-second design rests on the envelope surviving until the
+	// answer, so without these the prompt could never deliver anything and
+	// "Send report" was a button that did nothing.
+	//
+	// http_retry additionally means a report that could not go out now --
+	// consent given too late, network down, process dying mid-upload -- is
+	// picked up on a later run instead of being lost.
+	//
+	sentry_options_set_cache_keep(options, SENTRY_CACHE_KEEP_OFFLINE);
+	sentry_options_set_http_retry(options, 1);
 
 	std::string moduleDirectory;
 
@@ -636,6 +724,45 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	} else {
 		blog(LOG_WARNING,
 		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve own module directory; falling back to the SDK's default sentry-crash lookup, which searches next to the host executable");
+	}
+
+	// Where the SDK queues envelopes and minidumps until they are sent.
+	//
+	// Left unset, sentry-native uses `.sentry-native` *relative to the
+	// current working directory*, and a macOS app launched the way users
+	// launch one -- Finder, Dock, `open` -- has a working directory of `/`.
+	// That is the sealed system volume: `mkdir /.sentry-native` fails with
+	// "Read-only file system" for root, never mind a normal user.
+	// sentry__path_create_dir_all then fails, sentry_init() returns
+	// non-zero, and crash reporting is off for the whole session:
+	//
+	//   Crash Handler: backend is Sentry
+	//   Crash Handler: sentry_init() failed
+	//
+	// It looked fine in development only because a build launched from a
+	// shell inherits that shell's writable working directory. Verified both
+	// ways on 2026-08-17: via `open` it fails, and with the identical binary
+	// started from a writable directory it logs "Sentry initialized".
+	//
+	// The plugin config directory is per-user, writable without elevation,
+	// and already holds the rest of our state. Same choice as the Windows
+	// handler, which hit the same bug with `Program Files` in place of `/`.
+	char *databasePath = obs_module_config_path("sentry-db");
+
+	if (databasePath) {
+		sentry_options_set_database_path(options, databasePath);
+
+		// Logged because a report that never arrives is diagnosed by
+		// looking for a stranded envelope, and that is only possible if
+		// the log says where to look.
+		blog(LOG_INFO,
+		     "obs-streamelements-core: StreamElements: Crash Handler: database path is %s",
+		     databasePath);
+
+		bfree(databasePath);
+	} else {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve the plugin config directory; falling back to the SDK's default database path, which is relative to the working directory and therefore unwritable under Finder");
 	}
 
 	// 60s, for the reason documented in the Windows handler: with the default
@@ -694,6 +821,21 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	// of reports would never be offered to the user at all.
 	//
 	if (s_pendingMarkerPath[0] && os_file_exists(s_pendingMarkerPath)) {
+		// The marker holds the id of the crash it stands for, so the
+		// answer can be attached to that event rather than floating
+		// free. Read before unlinking, obviously.
+		char *markerContents =
+			os_quick_read_utf8_file(s_pendingMarkerPath);
+
+		sentry_uuid_t pendingEventId = sentry_uuid_nil();
+
+		if (markerContents) {
+			pendingEventId =
+				sentry_uuid_from_string(markerContents);
+
+			bfree(markerContents);
+		}
+
 		os_unlink(s_pendingMarkerPath);
 
 		const auto consent = StreamElementsCrashConsentDialog::Prompt(
@@ -703,10 +845,31 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 			PersistContactDetails(consent.name, consent.email,
 					      consent.discord);
 
+			// Unlike the crash-time path, this one is a fresh
+			// process: setting the user here is worth doing because
+			// everything this session reports will carry it.
 			SetSentryUser(consent.name, consent.email,
 				      consent.discord);
 
-			// Flushes whatever the previous run left cached.
+			if (consent.description.size() &&
+			    !sentry_uuid_is_nil(&pendingEventId)) {
+				sentry_capture_feedback(
+					sentry_value_new_feedback(
+						consent.description.c_str(),
+						consent.email.size()
+							? consent.email.c_str()
+							: nullptr,
+						consent.name.size()
+							? consent.name.c_str()
+							: nullptr,
+						&pendingEventId));
+			}
+
+			// Releases whatever the previous run left cached. No
+			// flush here, deliberately: this runs during startup on
+			// the main thread, and blocking the UI for up to a
+			// minute to push an old report would be worse than
+			// letting the retry queue carry it in the background.
 			sentry_user_consent_give();
 		} else {
 			sentry_user_consent_revoke();

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -13,6 +13,7 @@
 #define GLOBAL_ENV_CONFIG_FILE_NAME "obs-studio/streamelements-env.ini"
 
 #include <cstdint>
+#include <atomic>
 #include <vector>
 #include <regex>
 #include <unordered_map>
@@ -92,6 +93,22 @@ static inline const char *safe_str(const char *s, const char *defaultValue = "(N
 		return defaultValue;
 	else
 		return s;
+}
+
+/* ========================================================= */
+
+// Written from a signal handler / exception filter, so std::atomic rather than
+// a plain bool. One-way: nothing clears it.
+static std::atomic<bool> s_crashReportingInProgress(false);
+
+void SetCrashReportingInProgress()
+{
+	s_crashReportingInProgress.store(true);
+}
+
+bool IsCrashReportingInProgress()
+{
+	return s_crashReportingInProgress.load();
 }
 
 /* ========================================================= */

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -47,6 +47,27 @@ bool IsTraceLogLevel();
 
 /* ========================================================= */
 
+//
+// Set by the crash handler for as long as it is reporting a crash, and never
+// cleared -- a process that has faulted is not going back to normal service.
+//
+// The consent prompt is modal, and a modal dialog on either platform runs a
+// nested message loop that keeps draining this process's own event queue. So
+// work queued before the fault -- including host API calls -- executes inside
+// the crash handler, on the thread that just crashed. Observed on macOS: a
+// second `crashProgram` call was delivered into the NSAlert's modal loop,
+// faulted again, and because the SDK's signal handler ignores a re-entrant
+// crash the faulting instruction simply re-executed forever. OBS hung at 100%
+// CPU with the dialog frozen behind a spinning beachball.
+//
+// Anything that can run application code from an event loop should consult
+// this and decline.
+//
+void SetCrashReportingInProgress();
+bool IsCrashReportingInProgress();
+
+/* ========================================================= */
+
 std::string wstring_to_utf8(const std::wstring wstr);
 std::wstring utf8_to_wstring(const std::string str);
 


### PR DESCRIPTION
Part of CORE-554. `#partial` — CORE-554 is not finished by this PR.

Verified end to end on a Mac against a real crash. The chain always worked — fault reaches sentry's handler, the daemon writes a 6.5MB SMART minidump, the consent dialog comes up on top of it — and then nothing was ever sent. Four separate reasons, each sufficient on its own, plus two problems found by testing the fix.

## 1. `sentry_init()` failed on every real launch

The Windows handler sets a database path; the `.mm` never did, so sentry-native fell back to `.sentry-native` **relative to the working directory** — and a Mac app launched from Finder, the Dock or `open` has a working directory of `/`:

```
$ mkdir /.sentry-native
mkdir: /.sentry-native: Read-only file system
/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
```

`sentry__path_create_dir_all` fails → `goto fail` → `sentry_init` returns non-zero. It looked fine in development only because a shell-launched build inherits the shell's writable directory. Proven both ways with the same binary:

| launch | result |
|---|---|
| `open -a OBS` | `Crash Handler: sentry_init() failed` |
| `cd /tmp/x && OBS` | `Crash Handler: Sentry initialized` |

Now uses `obs_module_config_path("sentry-db")`, as Windows does after #116.

## 2. The consent gate discarded the report instead of holding it

`require_user_consent` alone does not cache. `sentry__capture_envelope` only writes to the cache when `cache_keep` or `http_retry` is set; otherwise it drops the envelope where it stands. The daemon log, about a second after the fault and long before the dialog was answered:

```
INFO discarding envelope due to missing user consent
```

The entire dump-first-ask-second design rests on the envelope outliving the question, so "Send report" was a button that did nothing. Now sets `SENTRY_CACHE_KEEP_OFFLINE` + `http_retry`, and the same test logs `caching envelope due to missing user consent`.

## 3. Consent released the report but never pushed it

`sentry_user_consent_give()` moves the envelope to the retry queue; the upload runs on the background worker. We returned immediately, chained to OBS's handler, and died with the report still queued. That is also **why the "Uploading the crash report" window was invisible** — nothing between `StartCrashProgress` and `StopCrashProgress` blocked, so it existed for microseconds. `sentry_flush(60000)` now sits there, same budget as the Windows shutdown timeout.

## 4. What the user types was thrown away

The prompt runs after the envelope is sealed, so `sentry_set_context("user_report", …)` could never reach the crash event — it applied to a future event in a process about to exit. The description now goes out as a User Feedback item pointing at the crash, which means knowing the event id: `OnCrash` assigns one itself rather than leaving it to `sentry__ensure_event_id`, which picks it *after* the hook and never tells us (`sentry_handle_exception` returns `void`). The deferred next-launch prompt gets the same treatment, with the id carried in the pending-consent marker file.

`sentry_set_user` is dropped from the crash-time path for the same reason and kept in the startup path, where the process does go on to report more.

## 5. Found by testing: OBS hung on a beachball after "Send report"

Not the flush. The consent prompt is modal, and a modal loop — `_doModalLoop` on macOS, an ordinary message pump on Windows — keeps draining this process's own event queue, Qt's posted events included. So a host API call queued before the fault runs **inside the crash handler, on the thread that just crashed**. In the test that call was `crashProgram` itself: it faulted again, sentry's signal handler ignores a re-entrant crash, so the handler returned and the faulting instruction re-executed. Forever — 565 of 565 samples on that instruction, process pinned at 101% CPU, dialog frozen behind it. Our own second-crash path (`DieWithSignal`) never got a look in, because sentry's handler is in front of it and never called back.

Fix: a one-way `SetCrashReportingInProgress()` flag, set at the top of the crash path in all four handlers (Sentry ×2, BugSplat Windows exception filter, BugSplat hang-report consent), checked where the API dispatcher already checks `IsPluginInitialized()` and `m_runtimeStatus->m_running`. BugSplat is included because it is still the default backend and has the identical exposure.

## 6. Found by inspection: the description box was one line tall

Windows has always given this field `ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL` over four lines. macOS had a 28pt scroll view — one line. Now 96pt, with the `setVerticallyResizable` / `widthTracksTextView` settings an `NSTextView` actually needs; without them the extra height buys nothing and typing runs off the right edge.

## Verification

Built and run on macOS 26.5 / arm64 against OBS 32.2.1, crashed through the `crashProgram` host API:

- `Crash Handler: database path is …/plugin_config/obs-streamelements-core/sentry-db` then `Sentry initialized`, launched via `open`
- `caching envelope due to missing user consent`, envelope + 6.5MB minidump on disk
- after "Send report": `user-consent` = `1`, **cache directory empty** — the envelope left the machine
- re-run after the guard: 11.4% CPU instead of 101%, no re-entrant frame under the dialog, dialog answerable

**The report still does not appear in Sentry, for a reason outside this repo.** A hand-built envelope posted straight at the DSN returns:

```
HTTP/2 429
x-sentry-rate-limits: 60:default;error;security;attachment:organization:error_usage_exceeded
{"detail":"Sentry dropped data due to a quota or internal rate limit being reached."}
```

The newest event anywhere in the `streamelements` org is **2026-08-12T17:07:59Z** — nothing has been ingested for five days, across all projects. The org error quota needs raising before any client-side change can be confirmed at the far end.

Not built on Windows by me; the Windows changes here are the shared flag plus four call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)