### PR TITLE
feat(crash): plugin binaries, machine id, backend cleanup and a dark consent dialog (CORE-554) #partial

### DIFF
--- a/CI/obs-streamelements-installer/main.nsi
+++ b/CI/obs-streamelements-installer/main.nsi
@@ -584,6 +584,25 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
 !ifndef SKIP_64BIT_CONTENT
     SetOutPath $INSTDIR\bin\64bit
 
+    # Clear BOTH crash backends before laying down whichever this build carries.
+    #
+    # The File lines below are /nonfatal precisely because only one backend is
+    # ever present, which means an upgrade that switches backends used to leave
+    # the previous one on disk untouched -- observed after installing a Sentry
+    # build over a BugSplat one: BugSplat64.dll, BugSplatHD64.exe and
+    # BugSplatRc64.dll were all still in bin\64bit. Nothing loads them, but they
+    # are dead weight that survives every future upgrade, and the uninstaller is
+    # no help because nobody uninstalls between upgrades.
+    #
+    # Deleting first and restoring from the package is simpler than teaching the
+    # installer which backend it is carrying, and is correct in both directions.
+    # The sentry daemon lives in obs-plugins\64bit, so it is cleared there.
+    Delete "$INSTDIR\bin\64bit\BsSndRpt64.exe"
+    Delete "$INSTDIR\bin\64bit\BugSplat64.dll"
+    Delete "$INSTDIR\bin\64bit\BugSplatHD64.exe"
+    Delete "$INSTDIR\bin\64bit\BugSplatRc64.dll"
+    Delete "$INSTDIR\obs-plugins\64bit\sentry-crash.exe"
+
     # /nonfatal on the crash-reporting runtime: which of these exists depends on
     # STREAMELEMENTS_CRASH_HANDLER at build time, and the installer has no way to
     # know which backend was compiled. A Sentry build ships no BugSplat DLLs, a
@@ -635,6 +654,11 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
 
 !ifndef SKIP_32BIT_CONTENT
     SetOutPath $INSTDIR\bin\32bit
+
+    # Same clean-then-restore as the 64-bit section above. No 32-bit Sentry
+    # build exists today, so only the daemon line is speculative -- but it
+    # removes what a previous install left, which is the whole point.
+    Delete "$INSTDIR\obs-plugins\32bit\sentry-crash.exe"
 
     File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BsSndRpt.exe
     File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BugSplat.dll

--- a/CI/obs-streamelements-uninstaller/main.nsi
+++ b/CI/obs-streamelements-uninstaller/main.nsi
@@ -223,6 +223,9 @@ Section "section_main" section_main
     Delete "$INSTDIR\bin\32bit\BugSplat.dll"
     Delete "$INSTDIR\bin\32bit\BugSplatHD.exe"
     Delete "$INSTDIR\bin\32bit\BugSplatRc.dll"
+    # No 32-bit Sentry build exists, but these lines exist to clean up what a
+    # *previous* install left behind, so the pair stays symmetrical with 64-bit.
+    Delete "$INSTDIR\obs-plugins\32bit\sentry-crash.exe"
 
     Delete "$DESKTOP\${PRODUCT_NAME}.lnk"
     DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_CODE_NAME}"

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -5,6 +5,15 @@
 #include <vector>
 
 #include <windows.h>
+#include <dwmapi.h>
+#include <uxtheme.h>
+#include <commctrl.h>
+
+// Linked here rather than in CMakeLists: both are needed only by the dark
+// theming below, and this file is the only Windows-only consumer of either.
+#pragma comment(lib, "dwmapi.lib")
+#pragma comment(lib, "uxtheme.lib")
+#pragma comment(lib, "comctl32.lib")
 
 /* ================================================================= */
 
@@ -161,6 +170,439 @@ static std::wstring GetControlText(HWND dialog, int id)
 	return buffer.data();
 }
 
+//
+// Dark theme, unconditionally -- not "follow the system".
+//
+// This dialog appears in front of a dying OBS, whose own UI is dark in every
+// theme it ships. A light system dialog in front of that does not read as part
+// of the same application, which matters here more than usual: the user is
+// being asked to send us their configuration and a picture of their screen, and
+// anything that looks like it came from somewhere else is a reason to say no.
+//
+static const COLORREF kDarkBackground = RGB(32, 32, 32);
+static const COLORREF kDarkControl = RGB(45, 45, 45);
+static const COLORREF kDarkText = RGB(255, 255, 255);
+static const COLORREF kDarkButtonFace = RGB(86, 132, 253);
+static const COLORREF kFieldBorder = RGB(80, 80, 80);
+static const COLORREF kDarkButtonHover = RGB(64, 104, 214);
+static const COLORREF kDarkButtonPressed = RGB(52, 86, 180);
+static const COLORREF kOutlineHover = RGB(52, 52, 52);
+static const COLORREF kOutlinePressed = RGB(64, 64, 64);
+static const COLORREF kDarkButtonEdge = RGB(90, 90, 90);
+static const COLORREF kDarkButtonFocusEdge = RGB(0, 120, 212);
+static const COLORREF kAcceptGlyph = RGB(64, 200, 96);
+static const COLORREF kDeclineGlyph = RGB(232, 92, 92);
+
+//
+// One padding value and one corner radius, used by everything drawn here so the
+// buttons and the field outlines stay visually of a piece.
+//
+static const int kPadding = 8;
+static const int kCornerRadius = 4;   // field outlines
+static const int kButtonRadius = 16; // buttons
+static const int kGlyphBox = 16;     // circle / cross, both buttons
+
+// Inside a button: 24px from the left and right edges to the glyph and the
+// caption, 8px above and below. kPadding stays the gap between the glyph and
+// the caption, and between the two buttons.
+static const int kButtonPaddingH = 24;
+static const int kButtonPaddingV = 8;
+
+//
+// Which button the pointer is over, or null.
+//
+// A BS_OWNERDRAW button is not repainted by the system when the pointer enters
+// or leaves it -- the theme engine that would normally do the hot-tracking is
+// exactly what we opted out of -- so the two buttons are subclassed to track it
+// themselves. One static is enough: the pointer can only be over one of them.
+//
+static HWND s_hotButton = nullptr;
+
+static LRESULT CALLBACK ConsentButtonProc(HWND button, UINT message,
+					  WPARAM wParam, LPARAM lParam,
+					  UINT_PTR id, DWORD_PTR data)
+{
+	UNREFERENCED_PARAMETER(id);
+	UNREFERENCED_PARAMETER(data);
+
+	switch (message) {
+	case WM_MOUSEMOVE:
+		if (s_hotButton != button) {
+			HWND previous = s_hotButton;
+
+			s_hotButton = button;
+
+			if (previous)
+				::InvalidateRect(previous, NULL, FALSE);
+
+			::InvalidateRect(button, NULL, FALSE);
+
+			// Without this there is no WM_MOUSELEAVE, and the button
+			// stays lit after the pointer has gone.
+			TRACKMOUSEEVENT track = {sizeof(track), TME_LEAVE, button,
+						 0};
+			::TrackMouseEvent(&track);
+		}
+		break;
+
+	case WM_MOUSELEAVE:
+		if (s_hotButton == button) {
+			s_hotButton = nullptr;
+
+			::InvalidateRect(button, NULL, FALSE);
+		}
+		break;
+
+	case WM_NCDESTROY:
+		::RemoveWindowSubclass(button, ConsentButtonProc, 1);
+
+		if (s_hotButton == button)
+			s_hotButton = nullptr;
+
+		break;
+	}
+
+	return ::DefSubclassProc(button, message, wParam, lParam);
+}
+
+//
+// Arial, bold, and a couple of points up from the dialog body font.
+//
+// Sized from the DC rather than as a fixed pixel height so it follows the
+// display DPI -- a hardcoded height is legible on the machine it was written on
+// and small everywhere else. Cached and leaked for the same reason as the
+// brushes below.
+//
+static HFONT GetButtonFont(HDC hdc)
+{
+	static HFONT font = nullptr;
+
+	if (!font) {
+		LOGFONTW lf = {};
+
+		lf.lfHeight = -::MulDiv(10, ::GetDeviceCaps(hdc, LOGPIXELSY), 72);
+		lf.lfWeight = FW_BOLD;
+		lf.lfCharSet = DEFAULT_CHARSET;
+		lf.lfQuality = CLEARTYPE_QUALITY;
+
+		::wcscpy_s(lf.lfFaceName, L"Arial");
+
+		font = ::CreateFontIndirectW(&lf);
+	}
+
+	return font;
+}
+
+//
+// Deliberately leaked, both of them. They live as long as the dialog, the
+// process is terminating behind it, and a brush destroyed while the dialog is
+// still painting is a far worse outcome than one that is never freed.
+//
+static HBRUSH GetDarkBackgroundBrush()
+{
+	static HBRUSH brush = ::CreateSolidBrush(kDarkBackground);
+
+	return brush;
+}
+
+static HBRUSH GetDarkControlBrush()
+{
+	static HBRUSH brush = ::CreateSolidBrush(kDarkControl);
+
+	return brush;
+}
+
+//
+// The title bar, which no amount of WM_CTLCOLOR* reaches -- it is drawn by the
+// desktop compositor, not by us.
+//
+static void ApplyDarkTitleBar(HWND window)
+{
+	// 20 on Windows 10 2004 and later, 19 on the builds before it. Trying
+	// the current one and falling back is cheaper and more honest than
+	// sniffing the build number, and both simply fail on older systems.
+	const DWORD kUseImmersiveDarkMode = 20;
+	const DWORD kUseImmersiveDarkModeBefore20H1 = 19;
+
+	BOOL enabled = TRUE;
+
+	if (FAILED(::DwmSetWindowAttribute(window, kUseImmersiveDarkMode,
+					   &enabled, sizeof(enabled)))) {
+		::DwmSetWindowAttribute(window, kUseImmersiveDarkModeBefore20H1,
+					&enabled, sizeof(enabled));
+	}
+}
+
+//
+// Edit borders and button faces are drawn by the theme engine, which ignores
+// the colours we hand back below. "DarkMode_Explorer" is undocumented but has
+// been what File Explorer itself uses since Windows 10 1809. If it fails the
+// dialog is still readable -- the handlers below have already painted the
+// backgrounds and the text.
+//
+static BOOL CALLBACK ApplyDarkThemeToChild(HWND child, LPARAM)
+{
+	::SetWindowTheme(child, L"DarkMode_Explorer", nullptr);
+
+	return TRUE;
+}
+
+//
+// Paints an owner-drawn push button, since the theme engine will not do it in
+// our colours.
+//
+// The two are deliberately not equal weight. "Send report" is the outcome the
+// dialog is asking for and is drawn as a filled blue button; "Don't send" is an
+// outline on the dialog face. Both keep the same size, font and text colour --
+// the declining button is secondary, not discouraged or hidden, and a user who
+// wants it has to be able to find it immediately.
+//
+// The glyphs are drawn with lines rather than set as font characters. A tick
+// and a cross are two and four segments respectively, and drawing them avoids
+// depending on a font lookup and its fallback chain inside a process that has
+// already crashed.
+//
+//
+// The width a button needs to hold its glyph and caption at 8px padding.
+//
+// Measured rather than guessed: the caption is set in bold uppercase Arial at a
+// size derived from the display DPI, so the only honest way to size the button
+// is to ask the DC how wide the string actually is. A fixed width was clipping
+// "SEND REPORT" mid-word.
+//
+static SIZE MeasureConsentButton(HDC hdc, const wchar_t *caption)
+{
+	HGDIOBJ previousFont = ::SelectObject(hdc, GetButtonFont(hdc));
+
+	SIZE text = {0, 0};
+	::GetTextExtentPoint32W(hdc, caption, (int)wcslen(caption), &text);
+
+	::SelectObject(hdc, previousFont);
+
+	SIZE result;
+
+	// padding | glyph | padding | text | padding
+	result.cx = kButtonPaddingH + kGlyphBox + kPadding + text.cx +
+		    kButtonPaddingH;
+	result.cy = text.cy + kButtonPaddingV * 2;
+
+	return result;
+}
+
+static void DrawConsentButton(const DRAWITEMSTRUCT *item)
+{
+	const bool primary = item->CtlID == IDOK;
+	const bool pressed = (item->itemState & ODS_SELECTED) != 0;
+	const bool focused = (item->itemState & (ODS_FOCUS | ODS_DEFAULT)) != 0;
+	const bool hot = item->hwndItem == s_hotButton;
+
+	RECT rc = item->rcItem;
+
+	// The dialog face first. RoundRect leaves the four corners outside its
+	// path untouched, and without this they keep whatever was there before,
+	// which reads as chipped rather than rounded.
+	::FillRect(item->hDC, &rc, GetDarkBackgroundBrush());
+
+	// Hover moves the filled button darker and the outline button lighter.
+	// Both end up closer to the other in tone, which is what makes the
+	// pointer feel like it is resting on something.
+	COLORREF faceColor;
+
+	if (primary) {
+		if (pressed)
+			faceColor = kDarkButtonPressed;
+		else if (hot)
+			faceColor = kDarkButtonHover;
+		else
+			faceColor = kDarkButtonFace;
+	} else {
+		if (pressed)
+			faceColor = kOutlinePressed;
+		else if (hot)
+			faceColor = kOutlineHover;
+		else
+			faceColor = kDarkBackground;
+	}
+
+	HBRUSH face = ::CreateSolidBrush(faceColor);
+
+	// Brighter edge when the button is the keyboard target, so the focused
+	// control stays obvious without the theme's focus ring. The filled button
+	// draws its edge in its own colour, so it reads as one solid shape.
+	HPEN edge = ::CreatePen(PS_SOLID, 1,
+				focused ? kDarkButtonFocusEdge
+					: (primary ? faceColor : kDarkButtonEdge));
+
+	HGDIOBJ previousBrush = ::SelectObject(item->hDC, face);
+	HGDIOBJ previousPen = ::SelectObject(item->hDC, edge);
+
+	::RoundRect(item->hDC, rc.left, rc.top, rc.right, rc.bottom,
+		    kButtonRadius * 2, kButtonRadius * 2);
+
+	::SelectObject(item->hDC, previousBrush);
+	::SelectObject(item->hDC, previousPen);
+	::DeleteObject(face);
+	::DeleteObject(edge);
+
+	const int glyphLeft = rc.left + kButtonPaddingH;
+	const int glyphTop = (rc.top + rc.bottom) / 2 - kGlyphBox / 2;
+
+	HPEN pen = ::CreatePen(PS_SOLID, 2,
+			       primary ? kAcceptGlyph : kDeclineGlyph);
+	previousPen = ::SelectObject(item->hDC, pen);
+	previousBrush = ::SelectObject(item->hDC, ::GetStockObject(NULL_BRUSH));
+
+	if (primary) {
+		// A tick inside a ring, so the accepting action reads as a
+		// deliberate mark rather than a stray stroke on the blue face.
+		::Ellipse(item->hDC, glyphLeft, glyphTop, glyphLeft + kGlyphBox,
+			  glyphTop + kGlyphBox);
+
+		const int inset = 4;
+
+		POINT tick[3] = {{glyphLeft + inset,
+				  glyphTop + kGlyphBox / 2},
+				 {glyphLeft + kGlyphBox / 2 - 1,
+				  glyphTop + kGlyphBox - inset},
+				 {glyphLeft + kGlyphBox - inset,
+				  glyphTop + inset + 1}};
+
+		::Polyline(item->hDC, tick, 3);
+	} else {
+		const int inset = 2;
+
+		::MoveToEx(item->hDC, glyphLeft + inset, glyphTop + inset, NULL);
+		::LineTo(item->hDC, glyphLeft + kGlyphBox - inset,
+			 glyphTop + kGlyphBox - inset);
+
+		::MoveToEx(item->hDC, glyphLeft + kGlyphBox - inset,
+			   glyphTop + inset, NULL);
+		::LineTo(item->hDC, glyphLeft + inset,
+			 glyphTop + kGlyphBox - inset);
+	}
+
+	::SelectObject(item->hDC, previousPen);
+	::SelectObject(item->hDC, previousBrush);
+	::DeleteObject(pen);
+
+	// Uppercased at draw time rather than in the template, so the control's
+	// own text -- what the accessibility tree and any automation read --
+	// stays the sentence-case string it was created with.
+	wchar_t caption[64] = {0};
+	::GetWindowTextW(item->hwndItem, caption, ARRAYSIZE(caption));
+	::CharUpperBuffW(caption, (DWORD)wcslen(caption));
+
+	RECT caption_rc = rc;
+	caption_rc.left = glyphLeft + kGlyphBox + kPadding;
+	caption_rc.right -= kButtonPaddingH;
+
+	HGDIOBJ previousFont =
+		::SelectObject(item->hDC, GetButtonFont(item->hDC));
+
+	::SetBkMode(item->hDC, TRANSPARENT);
+	::SetTextColor(item->hDC, kDarkText);
+	::DrawTextW(item->hDC, caption, -1, &caption_rc,
+		    DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+
+	::SelectObject(item->hDC, previousFont);
+}
+
+//
+// Sizes both buttons to their own content and right-aligns the pair.
+//
+// The template can only carry fixed sizes, and the caption width is not known
+// until the font has been created against a real DC. So the template's numbers
+// are a placeholder and this replaces them at WM_INITDIALOG, keeping the right
+// edge flush with the fields above and kPadding between the two.
+//
+static void LayoutConsentButtons(HWND dialog)
+{
+	HWND accept = ::GetDlgItem(dialog, IDOK);
+	HWND decline = ::GetDlgItem(dialog, IDCANCEL);
+	HWND field = ::GetDlgItem(dialog, IDC_DESCRIPTION);
+
+	if (!accept || !decline || !field)
+		return;
+
+	HDC hdc = ::GetDC(dialog);
+
+	if (!hdc)
+		return;
+
+	wchar_t acceptText[64] = {0};
+	wchar_t declineText[64] = {0};
+
+	::GetWindowTextW(accept, acceptText, ARRAYSIZE(acceptText));
+	::GetWindowTextW(decline, declineText, ARRAYSIZE(declineText));
+
+	::CharUpperBuffW(acceptText, (DWORD)wcslen(acceptText));
+	::CharUpperBuffW(declineText, (DWORD)wcslen(declineText));
+
+	const SIZE acceptSize = MeasureConsentButton(hdc, acceptText);
+	const SIZE declineSize = MeasureConsentButton(hdc, declineText);
+
+	::ReleaseDC(dialog, hdc);
+
+	const int height = acceptSize.cy > declineSize.cy ? acceptSize.cy
+							  : declineSize.cy;
+
+	// Right edge and vertical position come from the template, so the layout
+	// above this row still decides where the row sits.
+	RECT fieldRect;
+	::GetWindowRect(field, &fieldRect);
+	::MapWindowPoints(NULL, dialog, (LPPOINT)&fieldRect, 2);
+
+	RECT acceptRect;
+	::GetWindowRect(accept, &acceptRect);
+	::MapWindowPoints(NULL, dialog, (LPPOINT)&acceptRect, 2);
+
+	const int top = acceptRect.top;
+	const int right = fieldRect.right;
+
+	const int declineLeft = right - declineSize.cx;
+	const int acceptLeft = declineLeft - kPadding - acceptSize.cx;
+
+	::SetWindowPos(accept, NULL, acceptLeft, top, acceptSize.cx, height,
+		       SWP_NOZORDER | SWP_NOACTIVATE);
+	::SetWindowPos(decline, NULL, declineLeft, top, declineSize.cx, height,
+		       SWP_NOZORDER | SWP_NOACTIVATE);
+
+	::SetWindowSubclass(accept, ConsentButtonProc, 1, 0);
+	::SetWindowSubclass(decline, ConsentButtonProc, 1, 0);
+}
+
+//
+// A flat, subtle outline around each entry field.
+//
+// The fields carry no WS_BORDER of their own: the border a themed Edit draws is
+// the system's, in the system's colour, and against a dark dialog it reads as a
+// bright groove. Drawing it here instead keeps it one grey hairline at the same
+// 4px radius as the buttons.
+//
+static void DrawFieldOutline(HWND dialog, HDC hdc, int controlId)
+{
+	HWND control = ::GetDlgItem(dialog, controlId);
+
+	if (!control)
+		return;
+
+	RECT rc;
+	::GetWindowRect(control, &rc);
+	::MapWindowPoints(NULL, dialog, (LPPOINT)&rc, 2);
+	::InflateRect(&rc, 2, 2);
+
+	HPEN pen = ::CreatePen(PS_SOLID, 1, kFieldBorder);
+	HGDIOBJ previousPen = ::SelectObject(hdc, pen);
+	HGDIOBJ previousBrush = ::SelectObject(hdc, ::GetStockObject(NULL_BRUSH));
+
+	::RoundRect(hdc, rc.left, rc.top, rc.right, rc.bottom,
+		    kCornerRadius * 2, kCornerRadius * 2);
+
+	::SelectObject(hdc, previousPen);
+	::SelectObject(hdc, previousBrush);
+	::DeleteObject(pen);
+}
+
 static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 					  WPARAM wParam, LPARAM lParam)
 {
@@ -169,6 +611,10 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 		auto *state = (DialogState *)lParam;
 
 		::SetWindowLongPtrW(dialog, GWLP_USERDATA, (LONG_PTR)state);
+
+		ApplyDarkTitleBar(dialog);
+		::EnumChildWindows(dialog, ApplyDarkThemeToChild, 0);
+		LayoutConsentButtons(dialog);
 
 		if (state) {
 			::SetDlgItemTextW(dialog, IDC_NAME,
@@ -213,6 +659,52 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 		::SetFocus(::GetDlgItem(dialog, IDC_DESCRIPTION));
 
 		return FALSE; // focus was set explicitly
+	}
+
+	// The dialog face, and the static text sitting on it.
+	case WM_CTLCOLORDLG:
+	case WM_CTLCOLORSTATIC:
+		::SetTextColor((HDC)wParam, kDarkText);
+		::SetBkColor((HDC)wParam, kDarkBackground);
+
+		return (INT_PTR)GetDarkBackgroundBrush();
+
+	// The four entry fields, a shade lighter so they still read as fields.
+	case WM_CTLCOLOREDIT:
+		::SetTextColor((HDC)wParam, kDarkText);
+		::SetBkColor((HDC)wParam, kDarkControl);
+
+		return (INT_PTR)GetDarkControlBrush();
+
+	case WM_PAINT: {
+		// The background has already been erased through
+		// WM_CTLCOLORDLG; this only adds the field outlines, which sit
+		// outside each control's rect and so are not painted over when
+		// the controls themselves repaint.
+		PAINTSTRUCT ps;
+		HDC hdc = ::BeginPaint(dialog, &ps);
+
+		if (hdc) {
+			DrawFieldOutline(dialog, hdc, IDC_DESCRIPTION);
+			DrawFieldOutline(dialog, hdc, IDC_NAME);
+			DrawFieldOutline(dialog, hdc, IDC_EMAIL);
+			DrawFieldOutline(dialog, hdc, IDC_DISCORD);
+		}
+
+		::EndPaint(dialog, &ps);
+
+		return TRUE;
+	}
+
+	case WM_DRAWITEM: {
+		const DRAWITEMSTRUCT *item = (const DRAWITEMSTRUCT *)lParam;
+
+		if (item->CtlType != ODT_BUTTON)
+			break;
+
+		DrawConsentButton(item);
+
+		return TRUE;
 	}
 
 	case WM_COMMAND: {
@@ -266,12 +758,17 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 	builder.AddWord(0); // default dialog class
 	builder.AddString(DIALOG_TITLE);
 
+	// Arial rather than MS Shell Dlg, so every string in the dialog -- the
+	// message, the labels, the field contents -- is the same face. The
+	// buttons take a bold, slightly larger Arial of their own.
 	builder.AddWord(8); // point size
-	builder.AddString(L"MS Shell Dlg");
+	builder.AddString(L"Arial");
 
 	const DWORD visibleChild = WS_CHILD | WS_VISIBLE;
-	const DWORD editStyle = visibleChild | WS_TABSTOP | WS_BORDER |
-				ES_AUTOHSCROLL;
+	// No WS_BORDER: DrawFieldOutline draws a flat grey hairline instead of
+	// the system's themed border, which against a dark dialog is too bright
+	// and still carries a groove.
+	const DWORD editStyle = visibleChild | WS_TABSTOP | ES_AUTOHSCROLL;
 
 	// The icon sizes itself to the system icon; cx/cy here are only a hint.
 	// The message clears it and both share a right edge with everything
@@ -310,11 +807,27 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 	AddControl(builder, visibleChild, 7, 170, 306, 30, (WORD)-1,
 		   ATOM_STATIC, PRIVACY_TEXT);
 
-	AddControl(builder, visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON, 185,
-		   208, 60, 16, IDOK, ATOM_BUTTON, L"Send report");
+	// BS_OWNERDRAW on both, so DrawConsentButton below paints them.
+	//
+	// A themed push button ignores WM_CTLCOLORBTN entirely -- the theme
+	// engine draws the face -- so on a dark dialog the buttons stay white
+	// unless we take them over. The documented alternative is the
+	// undocumented uxtheme ordinals (AllowDarkModeForWindow and friends),
+	// which is not a trade worth making on the crash path.
+	//
+	// BS_DEFPUSHBUTTON is kept: it no longer changes the drawing, but it
+	// still tells the dialog manager which control Enter activates.
+	// Placeholder geometry. LayoutConsentButtons measures the captions in
+	// the real button font at WM_INITDIALOG and resizes both to fit their
+	// own glyph and text, then right-aligns the pair -- only the vertical
+	// position below survives from here.
+	AddControl(builder,
+		   visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON | BS_OWNERDRAW,
+		   113, 204, 96, 20, IDOK, ATOM_BUTTON, L"Send report");
 
-	AddControl(builder, visibleChild | WS_TABSTOP | BS_PUSHBUTTON, 253, 208,
-		   60, 16, IDCANCEL, ATOM_BUTTON, L"Don't send");
+	AddControl(builder,
+		   visibleChild | WS_TABSTOP | BS_PUSHBUTTON | BS_OWNERDRAW, 217,
+		   204, 96, 20, IDCANCEL, ATOM_BUTTON, L"Don't send");
 }
 
 /* ================================================================= */

--- a/streamelements/StreamElementsCrashConsentDialog.mm
+++ b/streamelements/StreamElementsCrashConsentDialog.mm
@@ -164,6 +164,26 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 
 		[[alert window] setInitialFirstResponder:description];
 
+		//
+		// Dark, unconditionally -- not "follow the system".
+		//
+		// Matches the Windows dialog, and for the same reason: this
+		// appears in front of a dying OBS, whose own UI is dark in every
+		// theme it ships, and a light panel in front of that does not
+		// read as part of the same application. The user is being asked
+		// to send their configuration and a picture of their screen, so
+		// anything that looks like it came from somewhere else is a
+		// reason to say no.
+		//
+		// Setting it on the window is enough: the accessory view and its
+		// controls inherit, and the labels already use labelColor /
+		// secondaryLabelColor, which resolve per appearance.
+		//
+		[[alert window]
+			setAppearance:[NSAppearance
+					      appearanceNamed:
+						      NSAppearanceNameDarkAqua]];
+
 		// Nothing else will raise this: the app is dying behind it.
 		[NSApp activateIgnoringOtherApps:YES];
 

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -771,13 +771,32 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 	// Sized against the observed archive with the blacklist corrected (~5MB).
 	// Anything approaching these limits is a new cache directory to blacklist,
 	// not a budget to raise.
+	//
+	// Files under the auxiliary plugins folder are the one deliberate
+	// exception. They are third-party executables -- Sentry has no symbols
+	// for them, so their bytes are the only way to resolve a frame in
+	// someone else's plugin -- and a plugin binary legitimately runs to tens
+	// of megabytes, which the general per-file limit exists to reject. They
+	// get their own, much higher ceiling instead of being exempt outright, so
+	// one pathological file still cannot swallow the archive.
+	//
+	// The total is raised to match: shipping plugin binaries and then
+	// truncating them at 24MB would be the worst of both. It stays well
+	// inside Sentry's 40MB *compressed* envelope cap -- binaries compress
+	// roughly 2-3x, so a full 40MB of them lands near 16MB, leaving room for
+	// the ~6.5MB minidump.
 	const uintmax_t maxFileBytes = 4ull * 1024 * 1024;
-	const uintmax_t maxTotalBytes = 24ull * 1024 * 1024;
+	const uintmax_t maxPluginFileBytes = 32ull * 1024 * 1024;
+	const uintmax_t maxTotalBytes = 40ull * 1024 * 1024;
 
 	struct CandidateFile {
 		std::wstring localPath;
 		std::wstring zipPath;
 		uintmax_t size;
+
+		// Under the auxiliary plugins folder, so subject to
+		// maxPluginFileBytes and taken last -- see the sort below.
+		bool isPlugin;
 	};
 
 	std::vector<CandidateFile> candidates;
@@ -811,6 +830,28 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		// carries the ones before it. No trailing slash: the same prefix
 		// covers the timestamped copies left by a manual reset.
 		L"plugin_config/obs-streamelements-core/sentry-db",
+		// Our own binaries, and only ours.
+		//
+		// CI uploads obs-streamelements-core's symbols *and* its code
+		// file to Sentry, so Sentry resolves our frames on its own;
+		// shipping the bytes a second time buys nothing and costs
+		// megabytes. Third-party plugins are the opposite case -- Sentry
+		// holds no symbols for them, so the binary in this archive is
+		// the only way to resolve their frames by hand, which is why
+		// they are deliberately kept and exempted from the per-file
+		// limit below.
+		//
+		// This was previously true only by accident: our binary happens
+		// to exceed the per-file limit, so it was dropped as if it were
+		// a cache file. A stripped build coming in under the limit would
+		// silently have started shipping it.
+		//
+		// Both layouts of the auxiliary plugins folder. The Windows
+		// installer currently writes into the OBS install directory,
+		// which is outside this tree entirely, so that entry is only
+		// insurance against the layout changing.
+		L"plugins/obs-streamelements-core.plugin/contents/macos/",
+		L"plugins/obs-streamelements-core/bin/",
 		L"updates/",
 		L"profiler_data/",
 		L"obslive_restored_files/",
@@ -850,18 +891,44 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 				std::error_code ec;
 				const uintmax_t size = i.file_size(ec);
 
+				// The auxiliary plugins folder, which is inside
+				// the configuration tree on both platforms:
+				// ~/Library/Application Support/obs-studio/
+				// plugins on macOS, %APPDATA%\obs-studio\plugins
+				// on Windows. Ours is already excluded by the
+				// blacklist, so whatever is left here is a
+				// third-party plugin.
+				const std::wstring pluginsPrefix = L"plugins/";
+				const bool isPlugin =
+					zip_path_lcase.size() >=
+						pluginsPrefix.size() &&
+					zip_path_lcase.substr(
+						0, pluginsPrefix.size()) ==
+						pluginsPrefix;
+
 				candidates.push_back(
 					{local_path, L"obs-studio\\" + zip_path,
-					 ec ? 0 : size});
+					 ec ? 0 : size, isPlugin});
 			}
 		}
 	}
 
-	// Smallest first, so the budget buys the largest number of files and a
-	// single huge one can never crowd out the small text files that carry
-	// almost all of the diagnostic value.
+	// Everything else before the plugins, and smallest first within each, so
+	// the budget buys the largest number of files and a single huge one can
+	// never crowd out the small text files that carry almost all of the
+	// diagnostic value.
+	//
+	// Plugin binaries are the reason for the two tiers rather than one sort
+	// by size. They are wanted, but they are also the only things here large
+	// enough to exhaust the budget, so they take what is left after the
+	// configuration tree -- a few hundred KB -- rather than competing with
+	// it. Sorting purely by size would have let a handful of plugins push
+	// out the text files instead.
 	std::sort(candidates.begin(), candidates.end(),
 		  [](const CandidateFile &a, const CandidateFile &b) {
+			  if (a.isPlugin != b.isPlugin)
+				  return !a.isPlugin;
+
 			  return a.size < b.size;
 		  });
 
@@ -869,7 +936,11 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 	uintmax_t totalBytes = 0;
 
 	for (auto &candidate : candidates) {
-		const bool tooBig = candidate.size > maxFileBytes;
+		const uintmax_t fileLimit = candidate.isPlugin
+						    ? maxPluginFileBytes
+						    : maxFileBytes;
+
+		const bool tooBig = candidate.size > fileLimit;
 		const bool overBudget = totalBytes + candidate.size >
 					maxTotalBytes;
 
@@ -904,6 +975,9 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 				   std::to_string(omitted.size()));
 		manifest.push_back("Per-file limit: " +
 				   std::to_string(maxFileBytes) + " bytes");
+		manifest.push_back("Per-file limit (plugins): " +
+				   std::to_string(maxPluginFileBytes) +
+				   " bytes");
 		manifest.push_back("Archive budget: " +
 				   std::to_string(maxTotalBytes) + " bytes");
 		manifest.push_back("");

--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -418,6 +418,15 @@ void StreamElementsReportIssueDialog::accept()
 				// also permanently one Chromium release behind,
 				// since those directories arrive on demand.
 				L"plugin_config/obs-browser/",
+				// Our own binaries, and only ours. We build
+				// them, so their bytes tell us nothing we
+				// cannot get from the build. Third-party
+				// plugins in the same folder are kept
+				// deliberately -- they are the ones nobody
+				// else can hand us. Kept in step with
+				// StreamElementsCrashContext.cpp.
+				L"plugins/obs-streamelements-core.plugin/contents/macos/",
+				L"plugins/obs-streamelements-core/bin/",
 				L"updates/",
 				L"profiler_data/",
 				L"obslive_restored_files/",

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -18,6 +18,10 @@
 #include <wchar.h>
 
 #include <windows.h>
+#include <dwmapi.h>
+
+// Needed only by the dark title bar on the progress window below.
+#pragma comment(lib, "dwmapi.lib")
 
 // Empty means crash reporting is inert: sentry_init() is skipped entirely rather
 // than run against a bad DSN, so a build without the DSN behaves like
@@ -166,18 +170,54 @@ static HFONT CreateProgressFont(HDC hdc, int pointSize, int weight)
 	return CreateFontIndirectW(&lf);
 }
 
+//
+// Dark, unconditionally, matching StreamElementsCrashConsentDialog.cpp. This
+// window is shown immediately before that dialog and again immediately after
+// it, so a light panel beside a dark dialog reads as a glitch rather than a
+// theme.
+//
+// The system colours this replaced (COLOR_WINDOW, COLOR_WINDOWTEXT,
+// COLOR_BTNFACE, COLOR_HIGHLIGHT, COLOR_GRAYTEXT) follow the OS setting, which
+// on a default Windows install means a white panel over a dark OBS.
+//
+static const COLORREF kProgressBackground = RGB(32, 32, 32);
+static const COLORREF kProgressText = RGB(255, 255, 255);
+static const COLORREF kProgressDimText = RGB(160, 160, 160);
+static const COLORREF kProgressTrack = RGB(60, 60, 60);
+static const COLORREF kProgressChunk = RGB(0, 120, 212);
+
+//
+// Leaked deliberately, like the dialog's brushes: they live as long as the
+// window, the process is terminating behind it, and a brush destroyed mid-paint
+// is a worse outcome than one never freed.
+//
+static HBRUSH GetProgressBrush(COLORREF color)
+{
+	static HBRUSH background = CreateSolidBrush(kProgressBackground);
+	static HBRUSH track = CreateSolidBrush(kProgressTrack);
+	static HBRUSH chunk = CreateSolidBrush(kProgressChunk);
+
+	if (color == kProgressTrack)
+		return track;
+
+	if (color == kProgressChunk)
+		return chunk;
+
+	return background;
+}
+
 static void PaintCrashProgress(HDC hdc, const RECT &rc)
 {
 	const int width = rc.right - rc.left;
 	const int margin = 18;
 
-	FillRect(hdc, &rc, GetSysColorBrush(COLOR_WINDOW));
+	FillRect(hdc, &rc, GetProgressBrush(kProgressBackground));
 	SetBkMode(hdc, TRANSPARENT);
 
 	RECT line = {margin, margin, width - margin, margin + 24};
 
 	SelectObject(hdc, s_progressTitleFont);
-	SetTextColor(hdc, GetSysColor(COLOR_WINDOWTEXT));
+	SetTextColor(hdc, kProgressText);
 	DrawTextW(hdc, L"Sending your crash report", -1, &line,
 		  DT_LEFT | DT_SINGLELINE | DT_NOPREFIX);
 
@@ -206,7 +246,7 @@ static void PaintCrashProgress(HDC hdc, const RECT &rc)
 	// Indeterminate bar: there is no progress figure to report, so animate
 	// rather than invent a percentage.
 	RECT track = {margin, margin + 60, width - margin, margin + 68};
-	FillRect(hdc, &track, GetSysColorBrush(COLOR_BTNFACE));
+	FillRect(hdc, &track, GetProgressBrush(kProgressTrack));
 
 	const int trackWidth = track.right - track.left;
 	const int chunkWidth = trackWidth / 4;
@@ -225,12 +265,12 @@ static void PaintCrashProgress(HDC hdc, const RECT &rc)
 		chunk.right = track.right;
 
 	if (chunk.right > chunk.left)
-		FillRect(hdc, &chunk, GetSysColorBrush(COLOR_HIGHLIGHT));
+		FillRect(hdc, &chunk, GetProgressBrush(kProgressChunk));
 
 	line.top = margin + 82;
 	line.bottom = rc.bottom - margin;
 
-	SetTextColor(hdc, GetSysColor(COLOR_GRAYTEXT));
+	SetTextColor(hdc, kProgressDimText);
 	DrawTextW(hdc,
 		  L"This can take up to a minute. OBS will close by itself "
 		  L"once the report has been sent.",
@@ -322,7 +362,7 @@ static DWORD WINAPI CrashProgressThreadProc(LPVOID param)
 	wc.lpfnWndProc = CrashProgressWndProc;
 	wc.hInstance = GetModuleHandleW(NULL);
 	wc.hCursor = LoadCursorW(NULL, IDC_ARROW);
-	wc.hbrBackground = GetSysColorBrush(COLOR_WINDOW);
+	wc.hbrBackground = GetProgressBrush(kProgressBackground);
 	wc.lpszClassName = L"SELiveCrashProgress";
 
 	RegisterClassExW(
@@ -353,6 +393,25 @@ static DWORD WINAPI CrashProgressThreadProc(LPVOID param)
 
 	if (!hwnd)
 		return 0;
+
+	// WS_CAPTION means there is a title bar, and the title bar is drawn by
+	// the compositor rather than by PaintCrashProgress -- so without this it
+	// stays light above a dark panel. 20 on Windows 10 2004 and later, 19
+	// before it; try the current one and fall back rather than sniffing the
+	// build number. Both simply fail on older systems.
+	{
+		const DWORD kUseImmersiveDarkMode = 20;
+		const DWORD kUseImmersiveDarkModeBefore20H1 = 19;
+
+		BOOL enabled = TRUE;
+
+		if (FAILED(DwmSetWindowAttribute(hwnd, kUseImmersiveDarkMode,
+						 &enabled, sizeof(enabled)))) {
+			DwmSetWindowAttribute(hwnd,
+					      kUseImmersiveDarkModeBefore20H1,
+					      &enabled, sizeof(enabled));
+		}
+	}
 
 	InterlockedExchangePointer((PVOID volatile *)&s_progressWindow, hwnd);
 

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -301,6 +301,16 @@ static void StartCrashProgress(int phase)
 			[s_progressPanel setLevel:NSFloatingWindowLevel];
 			[s_progressPanel setHidesOnDeactivate:NO];
 
+			// Dark, to match the consent dialog. These two appear
+			// back to back in the same flow -- this one before it
+			// and again after -- so a light panel beside a dark
+			// dialog reads as a glitch rather than a theme.
+			[s_progressPanel
+				setAppearance:
+					[NSAppearance
+						appearanceNamed:
+							NSAppearanceNameDarkAqua]];
+
 			// Defaults to YES for a window created this way, which
 			// would have -close release it out from under the
 			// static below. We drop the panel by ordering it out.

--- a/streamelements/StreamElementsSentryCrashHandler.mm
+++ b/streamelements/StreamElementsSentryCrashHandler.mm
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include <util/platform.h>
 
@@ -80,6 +81,11 @@ static bool s_haveCrashEventId = false;
 // calling sentry_uuid_as_string from a signal handler; doing it in OnCrash
 // leaves that path with nothing but open/write/close.
 static char s_crashEventIdString[37] = {0};
+
+// <database>/cache, resolved at init so the decline path does not have to build
+// it. Empty if the database path could not be resolved, in which case there is
+// no cache to manage either.
+static std::string s_cacheDirectory;
 
 /* ================================================================= */
 
@@ -506,6 +512,54 @@ static void DieWithSignal(int signum)
 // close: the path was resolved at init and the id formatted in OnCrash exactly
 // so this function has neither to build.
 //
+//
+// Empties the SDK's envelope cache.
+//
+// "Don't send" has to delete, not merely withhold. sentry_user_consent_revoke()
+// only writes `0` to the consent file -- it leaves the cache alone -- while
+// sentry_user_consent_give() calls sentry_transport_retry(), which flushes the
+// *whole* cache directory. Consent is therefore all-or-nothing across every
+// envelope queued, so a single later "Send report" would ship every crash the
+// user had previously declined or never answered. Four such envelopes had
+// accumulated on the test machine before this was noticed.
+//
+// There is no API to drop one envelope, and no way to tell the SDK "this one
+// only", so the answer is to keep the cache empty of anything unconsented: the
+// only thing in it should be a report the user has just agreed to send.
+//
+// Called from the crash path, so it is deliberately plain unlink()s over a
+// directory listing. That is more than the open/write/close of the marker, but
+// this point is already past a full AppKit modal loop, so signal-safety was
+// spent long before here.
+//
+static void PurgeCachedEnvelopes(const char *reason)
+{
+	if (s_cacheDirectory.empty())
+		return;
+
+	std::error_code ec;
+	std::filesystem::directory_iterator it(s_cacheDirectory, ec);
+
+	if (ec)
+		return;
+
+	size_t dropped = 0;
+
+	for (const auto &entry : it) {
+		if (!entry.is_regular_file(ec))
+			continue;
+
+		if (os_unlink(entry.path().string().c_str()) == 0)
+			++dropped;
+	}
+
+	if (dropped) {
+		blog(LOG_INFO,
+		     "obs-streamelements-core: StreamElements: Crash Handler: dropped %zu cached crash report(s): %s",
+		     dropped, reason);
+	}
+}
+
 static void WritePendingConsentMarker()
 {
 	if (!s_pendingMarkerPath[0])
@@ -600,8 +654,11 @@ static void ChainedSignalHandler(int signum, siginfo_t *info, void *context)
 				WritePendingConsentMarker();
 			}
 		} else if (consent.prompted) {
-			// An actual "Don't send". Drop it.
+			// An actual "Don't send". Drop it -- and mean it:
+			// revoking alone leaves the envelope in the cache for
+			// the next "Send report" to flush along with its own.
 			sentry_user_consent_revoke();
+			PurgeCachedEnvelopes("declined by the user");
 		} else {
 			// We could not ask -- the crash was off the main
 			// thread, where AppKit cannot be driven. Revoking here
@@ -777,6 +834,11 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	if (databasePath) {
 		sentry_options_set_database_path(options, databasePath);
 
+		// Where the SDK parks envelopes it could not send. Remembered
+		// so the decline path can empty it -- see
+		// PurgeCachedEnvelopes().
+		s_cacheDirectory = std::string(databasePath) + "/cache";
+
 		// Logged because a report that never arrives is diagnosed by
 		// looking for a stranded envelope, and that is only possible if
 		// the log says where to look.
@@ -899,10 +961,33 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 			StartCrashProgress(CRASH_PROGRESS_UPLOADING);
 
 			sentry_user_consent_give();
-			sentry_flush(30000);
+
+			const bool flushed = sentry_flush(30000) == 0;
 
 			StopCrashProgress();
+
+			// Did not finish in time. Put the marker back so the
+			// next launch offers it again -- otherwise the orphan
+			// sweep below would drop it on that launch, throwing
+			// away a report the user had just agreed to send.
+			if (!flushed)
+				WritePendingConsentMarker();
+		} else {
+			// Declined. Same reasoning as the crash-time path:
+			// revoking withholds, it does not delete.
+			sentry_user_consent_revoke();
+			PurgeCachedEnvelopes("declined by the user");
 		}
+	} else {
+		//
+		// Nothing is awaiting an answer, so anything still in the cache
+		// is an orphan -- a run that died with the prompt still open, or
+		// one killed before it could be asked. Nobody consented to any
+		// of it, and consent is all-or-nothing across the cache, so
+		// leaving it would let some future "Send report" ship crashes
+		// the user was never shown.
+		//
+		PurgeCachedEnvelopes("never consented to");
 	}
 
 	//

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -1971,9 +1971,13 @@ bool WriteEnvironmentConfigString(const char *regValueName,
 #ifdef WIN32
 	std::string REG_KEY_PATH = GetEnvironmentConfigRegKeyPath(productName);
 
+	// +1 for the terminator. RegSetKeyValueA does not add one, and the docs
+	// are explicit that a REG_SZ written without it leaves readers to cope
+	// with an unterminated value.
 	LSTATUS lResult = RegSetKeyValueA(HKEY_LOCAL_MACHINE,
 					  REG_KEY_PATH.c_str(), regValueName,
-					  REG_SZ, regValue, strlen(regValue));
+					  REG_SZ, regValue,
+					  (DWORD)(strlen(regValue) + 1));
 
 	if (lResult != ERROR_SUCCESS) {
 		result = WriteEnvironmentConfigStrings(
@@ -2192,6 +2196,28 @@ std::string GetComputerSystemUniqueId()
 			    "WUID/00412F4E-0000-0000-0000-0000FFFFFFFF") { // Set by russian MS Office crack
 			result = "";
 		}
+	}
+
+	// ...and discard anything that is not even shaped like an id.
+	//
+	// Every id this function produces is "<4-letter tag>/<payload>" --
+	// WUID, SWID or SEID here, ALSU on macOS. The list above only rejects
+	// four exact strings, so a value that is merely malformed used to be
+	// accepted and, because it is written straight back to the registry,
+	// became that machine's permanent identity.
+	//
+	// Not hypothetical: a machine was found reporting a user id of literally
+	// "S" -- one character, REG_SZ, the first letter of an SWID/SEID value.
+	// Every crash from it was anonymous and none could be correlated with
+	// any other. Rejecting the value here regenerates a good one on the next
+	// call rather than requiring the registry to be cleaned by hand.
+	if (result.size() &&
+	    (result.size() < 16 || result.find('/') != 4)) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: discarding malformed machine unique id '%s'; a new one will be generated",
+		     result.c_str());
+
+		result = "";
 	}
 
 	if (!result.size()) {


### PR DESCRIPTION
Part of CORE-554. `#partial` — CORE-554 is not finished by this PR.

Five changes, all found by running the shipped build rather than by reading it. Each is a separate commit.

## Third-party plugin binaries are shipped; ours is excluded by name

Sentry holds no symbols for someone else's plugin, so the binary in the diagnostics archive is the only way to resolve a frame in it — take the debug id from the minidump's module list, find the matching binary, symbolicate offline. Our own binary is the opposite case: CI uploads its symbols *and* its code file, so shipping the bytes again buys nothing.

That was already the effect on macOS, but only by accident — our binary happens to exceed the 4MB per-file limit, so it was dropped as if it were a cache file, and a stripped build coming in under the limit would silently have started shipping it. Now excluded by name, in both layouts of the auxiliary plugins folder.

The limits stopped fighting the other half: files under `plugins/` get a 32MB ceiling instead of 4MB, the archive total moves 24MB → 40MB, and selection is two-tiered — configuration text first, then plugins compete for what is left, so a handful of plugins can no longer push out the text that carries most of the diagnostic value.

## "Don't send" now actually deletes the report

## A malformed machine id no longer becomes permanent

Every Sentry event from one machine carried `user.id: "S"` — one character. The registry really held that: `REG_SZ`, length 1, where the id should be `SWID/<guid>-<guid>-<random>`. Every crash from it was anonymous and uncorrelatable.

- `RegSetKeyValueA` was passed `strlen(regValue)` for a `REG_SZ`, excluding the terminator the type is defined to carry.
- `GetComputerSystemUniqueId()` rejected four exact known-bad strings, so a merely *malformed* value was accepted — and written straight back to the registry, becoming that machine's identity forever. It now also rejects anything not shaped like `<4-letter tag>/<payload>`, so a poisoned machine repairs itself on the next launch.

Verified: that machine logged `discarding malformed machine unique id 'S'; a new one will be generated` and now stores the full 87-character value.

## The installer clears the other crash backend

Installing a Sentry build over a BugSplat one left `BugSplat64.dll`, `BugSplatHD64.exe` and `BugSplatRc64.dll` in `bin4bit` — observed after installing the signed 26.8.17.851 package. Nothing loads them, but they survive every future upgrade, and the uninstaller is no help because nobody uninstalls between upgrades. Exactly the leftover the CORE-554 plan predicted.

Both backends are now deleted before the package is laid down, and whatever it carries is restored on top — one rule, correct in both directions, rather than teaching the installer which backend it holds (it cannot know; that is why the `File` lines are `/nonfatal`).

## The consent dialog is dark, always

Not "follow the system". It appears in front of a dying OBS, whose UI is dark in every shipped theme, and a white system dialog in front of that does not read as part of the same application — which matters here because the user is being asked to send their configuration and a picture of their screen.

Windows needed real work, the dialog being a hand-built `DLGTEMPLATE`: title bar via `DWMWA_USE_IMMERSIVE_DARK_MODE`, face and static text via `WM_CTLCOLORDLG`/`WM_CTLCOLORSTATIC`, fields stripped of `WS_BORDER` with a flat grey hairline drawn by the parent, and `BS_OWNERDRAW` buttons — a themed push button ignores `WM_CTLCOLORBTN` entirely, and the alternative is the undocumented uxtheme ordinals, not a trade worth making on the crash path.

The buttons are deliberately unequal: **Send report** filled in `rgb(86,132,253)` with a tick inside a ring, **Don't send** an outline on the dialog face with a red cross. Same size, same font, same text colour — the declining button is secondary, not discouraged or hidden. Bold uppercase Arial, 24px horizontal and 8px vertical padding, 16px radius, measured at `WM_INITDIALOG` and sized to their own content (a fixed width clipped "SEND REPORT" mid-word once the font grew). Glyphs are drawn with lines, not font characters, so the crash path depends on no font lookup.

macOS gets the same intent in one line — `NSAppearanceNameDarkAqua` on the alert window, inherited by the accessory view. The progress panel on both platforms goes dark too, since it appears immediately before and after the dialog.

Hover, measured off the rendered pixels on a real crash:

| | idle | hovered |
| --- | --- | --- |
| Send report | `86,132,253` | `64,104,214` (darker) |
| Don't send | `32,32,32` | `52,52,52` (lighter) |

That needs an explicit subclass: the system stops hot-tracking a button once its theme is gone.

## Verification

Windows: built with `/WX`, deployed into `C:\Program Files (x86)\obs-studio`, crashed through the `crashProgram` host API, dialog inspected and driven through UI Automation, colours sampled from the screen.

macOS verification of the merged result follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)