### PR TITLE
fix: OBS freeze from inherited handles, and dangling Qt pointers (CORE-635)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,119 @@ if (ENABLE_SENTRY)
 			"obs-streamelements-core: could not patch SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS in ${SENTRY_WAIT_HEADER} -- vendored sentry-native changed. Re-check the crash upload wait against CORE-554 before dropping this.")
 	endif()
 
+	# Stop the crash daemon inheriting every handle OBS happens to have open.
+	#
+	# sentry-native spawns sentry-crash.exe with CreateProcessW(...,
+	# bInheritHandles = TRUE, ...) and passes the two event handles it needs as
+	# numbers on the command line. Blanket inheritance is the only thing making
+	# those numbers valid in the child -- and it also hands the daemon every
+	# other inheritable handle in the process.
+	#
+	# Not theoretical. A frozen OBS 32.2.2 was traced to sentry-crash.exe holding
+	# the write end of win-capture's anonymous pipe: the get-graphics-offsets
+	# helper had already exited, but because the daemon still held the pipe open
+	# libobs never saw EOF, so load_graphics_offsets blocked in ReadFile forever,
+	# init_hooks never finished, and game_capture_create waited on it with an
+	# INFINITE timeout. Killing the daemon by hand released the pipe and OBS
+	# resumed immediately. The same daemon was also holding OBS's log file,
+	# obs-browser's debug log and mojo pipes, and three sockets.
+	#
+	# PROC_THREAD_ATTRIBUTE_HANDLE_LIST is the documented fix: inheritance stays
+	# on, but only the listed handles cross into the child.
+	#
+	# Bracket arguments throughout -- the C being matched is full of semicolons,
+	# and CMake's \; escape does not compare equal inside string(FIND).
+	set(SENTRY_SPAWN_SOURCE
+		"${SENTRY_SOURCE_DIR}/src/backends/native/sentry_crash_daemon.c")
+
+	set(SENTRY_SPAWN_STOCK [==[    // Prepare process creation structures
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    // Hide console window for daemon
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+    ZeroMemory(&pi, sizeof(pi));]==])
+
+	set(SENTRY_SPAWN_PATCHED [==[    // Prepare process creation structures -- SE.Live: patched, see CMakeLists
+    STARTUPINFOEXW si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.StartupInfo.cb = sizeof(si);
+    // Hide console window for daemon
+    si.StartupInfo.dwFlags = STARTF_USESHOWWINDOW;
+    si.StartupInfo.wShowWindow = SW_HIDE;
+    ZeroMemory(&pi, sizeof(pi));
+
+    // Inherit ONLY these two handles. Without the list the daemon inherits
+    // every inheritable handle in the host, which has been observed
+    // deadlocking unrelated OBS plugins waiting on a pipe the daemon was
+    // silently holding open.
+    HANDLE inherit_handles[2] = { event_handle, ready_event_handle };
+    SIZE_T attr_size = 0;
+    InitializeProcThreadAttributeList(NULL, 1, 0, &attr_size);
+    si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)sentry_malloc(attr_size);
+    if (si.lpAttributeList
+        && (!InitializeProcThreadAttributeList(
+                si.lpAttributeList, 1, 0, &attr_size)
+            || !UpdateProcThreadAttribute(si.lpAttributeList, 0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherit_handles,
+                sizeof(inherit_handles), NULL, NULL))) {
+        sentry_free(si.lpAttributeList);
+        si.lpAttributeList = NULL;
+    }
+    if (!si.lpAttributeList) {
+        // Fall back to stock behaviour rather than not reporting crashes.
+        SENTRY_WARN("could not restrict daemon handle inheritance");
+    }]==])
+
+	set(SENTRY_SPAWN_FLAGS_STOCK [==[            TRUE, // Inherit handles (for event_handle)
+            CREATE_NO_WINDOW | DETACHED_PROCESS, // Creation flags]==])
+
+	set(SENTRY_SPAWN_FLAGS_PATCHED [==[            TRUE, // Inherit, but only what lpAttributeList allows
+            CREATE_NO_WINDOW | DETACHED_PROCESS
+                | (si.lpAttributeList ? EXTENDED_STARTUPINFO_PRESENT : 0),]==])
+
+	set(SENTRY_SPAWN_CLEANUP_STOCK [==[    // Close thread handle (we don't need it)
+    CloseHandle(pi.hThread);]==])
+
+	set(SENTRY_SPAWN_CLEANUP_PATCHED [==[    if (si.lpAttributeList) {
+        DeleteProcThreadAttributeList(si.lpAttributeList);
+        sentry_free(si.lpAttributeList);
+    }
+
+    // Close thread handle (we don't need it)
+    CloseHandle(pi.hThread);]==])
+
+	file(READ "${SENTRY_SPAWN_SOURCE}" SENTRY_SPAWN_CONTENT)
+
+	string(FIND "${SENTRY_SPAWN_CONTENT}" "${SENTRY_SPAWN_STOCK}"
+		SENTRY_SPAWN_STOCK_POS)
+	string(FIND "${SENTRY_SPAWN_CONTENT}" "SE.Live: patched"
+		SENTRY_SPAWN_PATCHED_POS)
+
+	if (NOT SENTRY_SPAWN_STOCK_POS EQUAL -1)
+		string(REPLACE "${SENTRY_SPAWN_STOCK}" "${SENTRY_SPAWN_PATCHED}"
+			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
+		string(REPLACE "${SENTRY_SPAWN_FLAGS_STOCK}"
+			"${SENTRY_SPAWN_FLAGS_PATCHED}"
+			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
+		string(REPLACE "&si, // Startup info" "&si.StartupInfo, // Startup info"
+			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
+		string(REPLACE "${SENTRY_SPAWN_CLEANUP_STOCK}"
+			"${SENTRY_SPAWN_CLEANUP_PATCHED}"
+			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
+		file(WRITE "${SENTRY_SPAWN_SOURCE}" "${SENTRY_SPAWN_CONTENT}")
+		message(STATUS
+			"obs-streamelements-core: patched sentry-crash spawn to restrict handle inheritance")
+	elseif (SENTRY_SPAWN_PATCHED_POS EQUAL -1)
+		# As with the wait timeout above: a silently skipped patch reintroduces a
+		# bug whose only symptom is an unrelated OBS subsystem deadlocking.
+		message(FATAL_ERROR
+			"obs-streamelements-core: could not patch daemon handle inheritance in ${SENTRY_SPAWN_SOURCE} -- vendored sentry-native changed. Re-check CreateProcessW bInheritHandles before dropping this.")
+	endif()
+
 	# The `native` backend, not crashpad: it hands control back to WER rather than
 	# swallowing the host's crash handling, its hooks work on macOS, and it is the
 	# only backend offering sentry_options_set_minidump_flags. See CORE-554.

--- a/streamelements/StreamElementsBrowserWidgetManager.hpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.hpp
@@ -157,6 +157,6 @@ public:
 private:
 	std::map<std::string, StreamElementsBrowserWidget*> m_browserWidgets;
 
-	QToolBar* m_notificationBarToolBar = nullptr;
-	StreamElementsBrowserWidget* m_notificationBarBrowserWidget = nullptr;
+	QPointer<QToolBar> m_notificationBarToolBar = nullptr;
+	QPointer<StreamElementsBrowserWidget> m_notificationBarBrowserWidget = nullptr;
 };

--- a/streamelements/StreamElementsGlobalStateManager.hpp
+++ b/streamelements/StreamElementsGlobalStateManager.hpp
@@ -255,8 +255,8 @@ protected:
 private:
 	bool m_persistStateEnabled = false;
 	bool m_initialized = false;
-	QMainWindow *m_mainWindow = nullptr;
-	QWidget *m_nativeCentralWidget = nullptr;
+	QPointer<QMainWindow> m_mainWindow = nullptr;
+	QPointer<QWidget> m_nativeCentralWidget = nullptr;
 	std::shared_ptr<StreamElementsBrowserWidgetManager> m_widgetManager =
 		nullptr;
 	std::shared_ptr<StreamElementsObsSceneManager> m_obsSceneManager =
@@ -328,6 +328,6 @@ private:
 		QTimer m_timer;
 	};
 
-	QDockWidget *m_themeChangeListener = nullptr;
+	QPointer<QDockWidget> m_themeChangeListener = nullptr;
 	ApplicationStateListener *m_appStateListener = nullptr;
 };

--- a/streamelements/StreamElementsMenuManager.cpp
+++ b/streamelements/StreamElementsMenuManager.cpp
@@ -30,7 +30,13 @@ StreamElementsMenuManager::StreamElementsMenuManager(QMainWindow *parent)
 StreamElementsMenuManager::~StreamElementsMenuManager()
 {
 	//mainWindow()->menuBar()->removeAction((QAction *)m_menu->menuAction()); // -> crash
-	m_menu->menuAction()->setVisible(false);
+
+	// Guarded: the menu bar owns the menu and may already have destroyed it
+	// by the time the plugin tears down. m_menu is a QPointer, so this is a
+	// real test rather than a stale-pointer read.
+	if (m_menu)
+		m_menu->menuAction()->setVisible(false);
+
 	m_menu = nullptr;
 }
 

--- a/streamelements/StreamElementsMenuManager.hpp
+++ b/streamelements/StreamElementsMenuManager.hpp
@@ -9,6 +9,7 @@
 #include <QMainWindow>
 #include <QMenuBar>
 #include <QMenu>
+#include <QPointer>
 
 #include <string>
 #include <vector>
@@ -49,7 +50,22 @@ private:
 
 private:
 	QMainWindow* m_mainWindow;
-	QMenu *m_menu;
+
+	//
+	// QPointer, not QMenu*, because we do not own this.
+	//
+	// The menu is created here but handed to the main window's menu bar via
+	// addMenu(), which reparents it -- so Qt destroys it when the main
+	// window goes down, on its own schedule rather than ours. A raw pointer
+	// is left dangling for the whole of shutdown, and UpdateInternal's
+	// `if (!m_menu) return;` guard sails straight past a stale one into
+	// m_menu->clear() on freed memory.
+	//
+	// Observed: a crash in UpdateInternal at the moment OBS restarted to
+	// apply an update. QPointer is zeroed by Qt when the object dies, which
+	// is what makes that guard mean what it says.
+	//
+	QPointer<QMenu> m_menu;
 
 	CefRefPtr<CefValue> m_auxMenuItems = CefValue::Create();
 	bool m_showBuiltInMenuItems = true;

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QPointer>
 #include <QPushButton>
 #include <QObject>
 #include <QTimer>
@@ -162,34 +163,34 @@ private:
 	static void hotkey_routing_func(void* data, obs_hotkey_id id, bool pressed);
 
 private:
-	QWidget *m_nativeCentralWidget = nullptr;
-	QMainWindow* m_mainWindow = nullptr;
-	QPushButton* m_startStopStreamingButton = nullptr;
-	QPushButton* m_nativeStartStopStreamingButton = nullptr;
+	QPointer<QWidget> m_nativeCentralWidget = nullptr;
+	QPointer<QMainWindow> m_mainWindow = nullptr;
+	QPointer<QPushButton> m_startStopStreamingButton = nullptr;
+	QPointer<QPushButton> m_nativeStartStopStreamingButton = nullptr;
 	std::shared_ptr<WidgetVisibilityChangeTracker>
 		m_nativeManageBroadcastButtonVisibilityChangeTracker = nullptr;
-	QPushButton* m_nativeManageBroadcastButton = nullptr;
+	QPointer<QPushButton> m_nativeManageBroadcastButton = nullptr;
 	obs_hotkey_id m_startStopStreamingHotkeyId = OBS_INVALID_HOTKEY_ID;
 	start_streaming_mode_t m_start_streaming_mode = start;
 	int m_startStreamingRequestAcknowledgeTimeoutSeconds = 5;
-	QTimer* m_timeoutTimer = nullptr;
+	QPointer<QTimer> m_timeoutTimer = nullptr;
 	std::recursive_mutex m_timeoutTimerMutex;
 
 	bool m_isStreamingTransitionState = false;
 
 	#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS
-	QFrame *m_previewFrame = nullptr;
-	QVBoxLayout *m_previewFrameLayout = nullptr;
-	QLayout *m_nativePreviewLayout = nullptr;
-	QLayout *m_nativePreviewLayoutParent = nullptr;
-	QWidget *m_nativePreviewWidget = nullptr;
+	QPointer<QFrame> m_previewFrame = nullptr;
+	QPointer<QVBoxLayout> m_previewFrameLayout = nullptr;
+	QPointer<QLayout> m_nativePreviewLayout = nullptr;
+	QPointer<QLayout> m_nativePreviewLayoutParent = nullptr;
+	QPointer<QWidget> m_nativePreviewWidget = nullptr;
 	bool m_previewFrameVisible = false;
 	CefRefPtr<CefDictionaryValue> m_previewFrameSettings =
 		CefDictionaryValue::Create();
 
-	QWidget *m_previewTitleContainer = nullptr;
-	QHBoxLayout *m_previewTitleLayout = nullptr;
-	StreamElementsBrowserWidget *m_previewTitleBrowser = nullptr;
+	QPointer<QWidget> m_previewTitleContainer = nullptr;
+	QPointer<QHBoxLayout> m_previewTitleLayout = nullptr;
+	QPointer<StreamElementsBrowserWidget> m_previewTitleBrowser = nullptr;
 	CefRefPtr<CefDictionaryValue> m_previewTitleSettings =
 		CefDictionaryValue::Create();
 	#endif

--- a/streamelements/StreamElementsSceneItemsMonitor.hpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.hpp
@@ -5,6 +5,7 @@
 #include "StreamElementsUtils.hpp"
 
 #include <QObject>
+#include <QPointer>
 #include <QMainWindow>
 #include <QListView>
 #include <QAbstractItemModel>
@@ -153,14 +154,14 @@ protected:
 	virtual void OnObsExit() override;
 
 private:
-	QMainWindow *m_mainWindow;
-	QListView *m_sceneItemsListView = nullptr;
-	QToolBar *m_sceneItemsToolBar = nullptr;
-	QAbstractItemModel *m_sceneItemsModel = nullptr;
+	QPointer<QMainWindow> m_mainWindow;
+	QPointer<QListView> m_sceneItemsListView = nullptr;
+	QPointer<QToolBar> m_sceneItemsToolBar = nullptr;
+	QPointer<QAbstractItemModel> m_sceneItemsModel = nullptr;
 	bool m_enableSignals = false;
 	StreamElementsDeferredExecutive
 		m_updateSceneItemsWidgetsThrottledExecutive;
-	QObject *m_eventFilter = nullptr;
+	QPointer<QObject> m_eventFilter = nullptr;
 	CefRefPtr<CefValue> m_sceneItemsToolBarActions = CefValue::Create();
-	QToolButton *m_nativeActionSourcePropertiesButton = nullptr;
+	QPointer<QToolButton> m_nativeActionSourcePropertiesButton = nullptr;
 };

--- a/streamelements/StreamElementsScenesListWidgetManager.hpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.hpp
@@ -8,6 +8,7 @@
 #include "cef-headers.hpp"
 
 #include <QMainWindow>
+#include <QPointer>
 #include <QListWidget>
 #include <QListView>
 #include <QToolBar>
@@ -102,14 +103,14 @@ private:
 	void UpdateScenesToolbar();
 
 private:
-	QMainWindow *m_mainWindow = nullptr;
-	QListWidget *m_nativeWidget = nullptr;
+	QPointer<QMainWindow> m_mainWindow = nullptr;
+	QPointer<QListWidget> m_nativeWidget = nullptr;
 	bool m_enableSignals = false;
 	StreamElementsDeferredExecutive m_updateWidgetsDeferredExecutive;
-	QAbstractItemDelegate *m_editDelegate;
-	QAbstractItemDelegate *m_prevEditDelegate;
+	QPointer<QAbstractItemDelegate> m_editDelegate;
+	QPointer<QAbstractItemDelegate> m_prevEditDelegate;
 	CefRefPtr<CefValue> m_scenesToolBarActions = CefValue::Create();
-	QToolBar *m_scenesToolBar = nullptr;
-	QObject *m_eventFilter = nullptr;
+	QPointer<QToolBar> m_scenesToolBar = nullptr;
+	QPointer<QObject> m_eventFilter = nullptr;
 	QListWidget::ViewMode m_prevViewMode = QListView::ListMode;
 };

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QPointer>
 #include <QDockWidget>
 #include <QMainWindow>
 #include <stack>
@@ -98,8 +99,8 @@ protected:
 	QMainWindow* mainWindow() { return m_parent; }
 
 private:
-	QMainWindow* m_parent;
-	QWidget* m_nativeCentralWidget = nullptr;
+	QPointer<QMainWindow> m_parent;
+	QPointer<QWidget> m_nativeCentralWidget = nullptr;
 	//QWidget* m_currentCentralWidget = nullptr;
 
 	std::map<std::string, QDockWidget*> m_dockWidgets;


### PR DESCRIPTION
Fixes CORE-635

Two unrelated defects, both surfaced by one OBS 32.2.2 update on one machine: one froze OBS at startup, the other crashed the instance that was shutting down.

## 1. `sentry-crash.exe` inherited every open handle — and froze OBS

Non-invasive `cdb` attach on the live hung process. UI thread:

```
ntdll!NtWaitForSingleObject          <- WaitForSingleObject(init_hooks_thread, INFINITE)
win_capture!game_capture_create
obs!obs_source_create_private
obs_streamelements_core!SerializeAvailableInputSourceTypes
obs_streamelements_core!__QtPostTask_Impl
  … nested event loop …
Qt6Widgets!QDialog::exec
obs_streamelements_core!ConfirmPendingUpdateDialog::ExecDialog
```

The thread it waits for:

```
ntdll!NtReadFile                     <- blocked forever
obs!os_process_pipe_read
win_capture!load_graphics_offsets
win_capture!init_hooks
```

`get-graphics-offsets64.exe` had already exited, yet the read never got EOF — so something still held the pipe's write end. libobs closes its own copy, but spawns with `CreateProcessW(bInheritHandles = TRUE)`, so anything spawned while that pipe is open inherits it.

`sentry-crash.exe` spawned at **14:32:30.982**, inside that window (`win-capture.dll` loaded at 14:32:30.211), holding **183 handles** — OBS's log file, obs-browser's debug log, obs-browser mojo IPC pipes, three sockets. **Killing the daemon by hand released the pipe and OBS resumed immediately.**

Upstream cause, `sentry_crash_daemon.c`:

```c
TRUE, // Inherit handles (for event_handle)
```

The two event handles are passed as numbers on the command line; blanket inheritance is the only thing making them valid in the child, and it hands over everything else too. `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` restricts it to exactly those two. If the attribute list can't be built we fall back to stock behaviour and warn — not reporting crashes is worse than inheriting too much.

Applied as a configure-time patch to the vendored SDK, same shape as the existing `SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS` patch: idempotent, `FATAL_ERROR` rather than a silent skip if upstream moves. Worth reporting to getsentry/sentry-native.

**Two aggravating factors on our side, deliberately not changed here** — they're design questions, not one-line fixes:

- `SerializeAvailableInputSourceTypes` enumerates source types by **instantiating one of each**, so any plugin whose `create` blocks takes the UI thread down with it. `game_capture_create` waits `INFINITE`.
- `ConfirmPendingUpdateDialog` is modal, and a modal loop drains the posted-event queue, so a queued host API call runs inside it. Same re-entrancy shape as the crash consent dialog; the `IsCrashReportingInProgress` guard added there only covers the crash path.

## 2. Dangling `QMenu*` crashed the outgoing instance

Reported as SELIVE-B, 45 seconds before the frozen instance started.

```cpp
m_menu = new QMenu("St&reamElements");
mainWindow()->menuBar()->addMenu(m_menu);   // reparents — Qt owns it now
```

Qt destroys it with the main window, on its own schedule. `m_menu` was raw and nulled only in our destructor, so through shutdown it dangles:

```cpp
if (!m_menu) return;   // passes: stale, not null
m_menu->clear();       // use-after-free
```

`QPointer<QMenu>` is zeroed by Qt on destruction, which makes that guard mean what it says. The destructor had the same bug — it dereferenced `m_menu` unconditionally, directly below a commented-out `removeAction` marked `// -> crash`.

### The sweep

Same shape audited across the plugin: **33 members in 6 more files**, several borrowed straight from OBS's UI via `findChild` — `m_sceneItemsListView`, `m_sceneItemsToolBar`, `m_sceneItemsModel`, `m_scenesToolBar`, `m_nativeWidget`, `m_nativeStartStopStreamingButton`, `m_nativePreviewLayout`, and more. OBS destroys and rebuilds those on shutdown, theme change and UI reset.

Guard density, counted:

| member | uses | guards |
|---|---|---|
| `m_sceneItemsToolBar` | 13 | 2 |
| `m_sceneItemsListView` | 15 | 2 |
| `m_scenesToolBar` | 11 | 1 |
| `m_nativeWidget` | 23 | 4 |

Against a raw stale pointer none of those did anything. All converted to `QPointer`: existing guards start working, and unguarded sites degrade from use-after-free to a deterministic null deref — still a crash, but one that yields a usable stack instead of corrupting the heap.

## Verification

- Patched daemon and full plugin build clean on Windows with `/WX`.
- Configure applies the patch and says so; reverting the vendored file and reconfiguring re-applies it; an unmatched pattern fails the configure rather than skipping. (The first attempt did trip that, because CMake's `\;` escape doesn't compare equal in `string(FIND)` — the check working as designed. Bracket arguments now.)
- The QPointer sweep compiled with zero fallout.

**Not verified at runtime:** that the patched daemon no longer inherits OBS's handles. That needs an OBS restart with the new binaries, and the reporter's OBS was in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)