### PR TITLE
fix(ui): guard the borrowed-widget dereferences (CORE-635)

### DIFF
--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -1031,7 +1031,9 @@ void StreamElementsBrowserWidgetManager::SerializeNotificationBar(
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	if (m_notificationBarToolBar) {
+	// Both, not just the toolbar: the browser widget is dereferenced below
+	// and can be destroyed independently of its container. See CORE-635.
+	if (m_notificationBarToolBar && m_notificationBarBrowserWidget) {
 		CefRefPtr<CefDictionaryValue> rootDictionary =
 			CefDictionaryValue::Create();
 		output->SetDictionary(rootDictionary);

--- a/streamelements/StreamElementsNativeOBSControlsManager.cpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.cpp
@@ -255,7 +255,8 @@ void StreamElementsNativeOBSControlsManager::HidePreviewFrame()
 {
 	m_previewFrameVisible = false;
 
-	m_previewFrame->setStyleSheet(
+	if (m_previewFrame)
+		m_previewFrame->setStyleSheet(
 		"QFrame#streamelements_central_widget_frame { border: none; padding: 0; margin: 0; background-color: transparent;");
 
 	m_previewFrameSettings = CefDictionaryValue::Create();
@@ -323,6 +324,10 @@ void StreamElementsNativeOBSControlsManager::SerializePreviewTitleBar(
 
 void StreamElementsNativeOBSControlsManager::HidePreviewTitleBar()
 {
+	// Reparented into OBS's central widget, so Qt owns it. See CORE-635.
+	if (!m_previewTitleContainer)
+		return;
+
 	m_previewTitleContainer->hide();
 
 	QApplication::sendPostedEvents();
@@ -338,6 +343,27 @@ void StreamElementsNativeOBSControlsManager::HidePreviewTitleBar()
 	m_previewTitleSettings = CefDictionaryValue::Create();
 }
 #endif
+
+//
+// Clicks OBS's own start/stop streaming button, if it is still there.
+//
+// The button is found with findChild and belongs to OBS, so it is gone during
+// shutdown and after a UI reset. Three separate paths click it -- the UI
+// control, the hotkey and the timeout tracker -- and each one dereferenced it
+// unguarded. See CORE-635.
+//
+void StreamElementsNativeOBSControlsManager::ClickNativeStartStopStreamingButton()
+{
+	if (!m_nativeStartStopStreamingButton) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: native start/stop streaming button is unavailable; ignoring request");
+
+		return;
+	}
+
+	m_nativeStartStopStreamingButton->click();
+}
+
 
 void StreamElementsNativeOBSControlsManager::Reset()
 {
@@ -432,6 +458,9 @@ void StreamElementsNativeOBSControlsManager::SetStreamingTransitionStartingState
 void StreamElementsNativeOBSControlsManager::SetStreamingRequestedState()
 {
 	QtExecSync([&] {
+		if (!m_startStopStreamingButton)
+			return;
+
 		m_startStopStreamingButton->setText(obs_module_text("StreamElements.Action.StartStreaming.RequestInProgress"));
 		m_startStopStreamingButton->setEnabled(false);
 
@@ -467,7 +496,7 @@ void StreamElementsNativeOBSControlsManager::OnStartStopStreamingButtonClicked()
 		blog(LOG_INFO, "obs-streamelements-core: streaming stop requested by UI control");
 
 		// obs_frontend_streaming_stop();
-		m_nativeStartStopStreamingButton->click();
+		ClickNativeStartStopStreamingButton();
 	}
 	else {
 		blog(LOG_INFO, "obs-streamelements-core: streaming start requested by UI control");
@@ -518,6 +547,9 @@ void StreamElementsNativeOBSControlsManager::handle_obs_frontend_event(enum obs_
 
 void StreamElementsNativeOBSControlsManager::SetStreamingStyle(bool streaming)
 {
+	if (!m_startStopStreamingButton)
+		return;
+
 	if (streaming) {
 		m_startStopStreamingButton->setStyleSheet(QString(
 			"QPushButton { background-color: #823929; color: #ffffff; font-weight:600; } "
@@ -560,6 +592,7 @@ void StreamElementsNativeOBSControlsManager::hotkey_routing_func(void* data, obs
 	if (id == self->m_startStopStreamingHotkeyId) {
 		if (pressed &&
 			!obs_frontend_streaming_active() &&
+			self->m_startStopStreamingButton &&
 			self->m_startStopStreamingButton->isEnabled()) {
 			blog(LOG_INFO, "obs-streamelements-core: streaming start requested by hotkey");
 
@@ -617,7 +650,7 @@ void StreamElementsNativeOBSControlsManager::BeginStartStreaming()
 	switch (m_start_streaming_mode) {
 	case start:
 		// obs_frontend_streaming_start();
-		m_nativeStartStopStreamingButton->click();
+		ClickNativeStartStopStreamingButton();
 		break;
 
 	case request:
@@ -704,7 +737,7 @@ void StreamElementsNativeOBSControlsManager::StartTimeoutTracker()
 		SetStreamingInitialState();
 
 		// obs_frontend_streaming_start();
-		m_nativeStartStopStreamingButton->click();
+		ClickNativeStartStopStreamingButton();
 	});
 
 	QMetaObject::invokeMethod(m_timeoutTimer, "start", Qt::QueuedConnection, Q_ARG(int, m_startStreamingRequestAcknowledgeTimeoutSeconds * 1000));

--- a/streamelements/StreamElementsNativeOBSControlsManager.hpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.hpp
@@ -149,6 +149,7 @@ private:
 	void StopTimeoutTracker();
 
 protected:
+	void ClickNativeStartStopStreamingButton();
 	void BeginStartStreaming();
 
 private slots:

--- a/streamelements/StreamElementsSceneItemsMonitor.cpp
+++ b/streamelements/StreamElementsSceneItemsMonitor.cpp
@@ -1100,7 +1100,9 @@ deserializeSceneItemUISettings(StreamElementsSceneItemsMonitor *monitor,
 #if SE_ENABLE_SCENEITEM_UI_EXTENSIONS
 void StreamElementsSceneItemsMonitor::UpdateSceneItemsWidgets()
 {
-	if (!m_sceneItemsModel)
+	// All three belong to OBS -- found with findChild, destroyed with its UI
+	// and rebuilt on a reset. See CORE-635.
+	if (!m_sceneItemsModel || !m_sceneItemsListView || !m_sceneItemsToolBar)
 		return;
 
 	sceneitems_vector_t sceneItems;

--- a/streamelements/StreamElementsScenesListWidgetManager.cpp
+++ b/streamelements/StreamElementsScenesListWidgetManager.cpp
@@ -442,6 +442,11 @@ StreamElementsScenesListWidgetManager::StreamElementsScenesListWidgetManager(
 
 void StreamElementsScenesListWidgetManager::CheckViewMode()
 {
+	// OBS owns this list; it is gone during shutdown and rebuilt on a UI
+	// reset. See CORE-635.
+	if (!m_nativeWidget)
+		return;
+
 	QListWidget::ViewMode mode = m_nativeWidget->viewMode();
 
 	if (mode != m_prevViewMode) {
@@ -702,6 +707,10 @@ void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
 	if (!IsSupportedOBSVersion())
 		return;
 
+	// OBS owns the toolbar. See CORE-635.
+	if (!m_scenesToolBar)
+		return;
+
 	QWidget *widget = m_scenesToolBar->findChild<QWidget *>(
 		"streamelements_scenes_toolbar_aux_actions");
 
@@ -769,6 +778,10 @@ void StreamElementsScenesListWidgetManager::UpdateScenesToolbar()
 #if SE_ENABLE_SCENES_UI_EXTENSIONS
 void StreamElementsScenesListWidgetManager::UpdateWidgets()
 {
+	// Every row access below goes through the OBS-owned list. See CORE-635.
+	if (!m_nativeWidget)
+		return;
+
 	struct obs_frontend_source_list sources = {};
 
 	obs_frontend_get_scenes(&sources);


### PR DESCRIPTION
Part of CORE-635. Follow-up to #123 — this commit was written alongside it but never reached origin, so the merge went in without it.

#123 converted 33 borrowed Qt pointers to `QPointer`, which turned use-after-free into null dereference. Better — a deterministic crash with a usable stack beats corrupting the heap — but still a crash. These are the sites that had no check at all:

| file | functions |
|---|---|
| `StreamElementsNativeOBSControlsManager` | `HidePreviewFrame`, `HidePreviewTitleBar`, `SetStreamingRequestedState`, `SetStreamingStyle`, `hotkey_routing_func` |
| `StreamElementsScenesListWidgetManager` | `CheckViewMode`, `UpdateScenesToolbar`, `UpdateWidgets` |
| `StreamElementsSceneItemsMonitor` | `UpdateSceneItemsWidgets` |
| `StreamElementsBrowserWidgetManager` | `SerializeNotificationBar` |

Each guard is shaped to what the function does rather than dropped in uniformly: an early return where the whole body operates on the missing widget, an inline check where it is one step among several. `UpdateSceneItemsWidgets` already tested `m_sceneItemsModel` and now tests the list view and toolbar it also dereferences; `UpdateScenesToolbar` extends its existing version check.

The three paths that clicked OBS's native streaming button — the UI control, the hotkey, and the timeout tracker — now go through one guarded helper rather than repeating the check, and log when the button has gone instead of failing silently.

`SerializeNotificationBar` tested the toolbar and then dereferenced the browser widget, a *different* pointer that can be destroyed independently. It now tests both.

## Two corrections to the sweep reported on #123

`HasNotificationBar` and `HideNotificationBar` were already correct, and `RemoveDockWidget` does not dereference the toolbar at all — all three were false positives from a crude function-boundary scanner. Untouched here. The one real gap in that file, `SerializeNotificationBar`, was found by reading the code rather than by the scan.

## Verification

Builds clean on Windows with `/WX`.

The helper first landed inside an `#if SE_ENABLE_CENTRAL_WIDGET_DECORATIONS` block while its call sites sat outside it, so it compiled out and failed to link with `LNK2019`. Moved past the `#endif`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)