### PR TITLE
fix(crash): daemon spawn was broken by the handle-list patch (CORE-635)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,109 +216,50 @@ if (ENABLE_SENTRY)
 	# Stop the crash daemon inheriting every handle OBS happens to have open.
 	#
 	# sentry-native spawns sentry-crash.exe with CreateProcessW(...,
-	# bInheritHandles = TRUE, ...) and passes the two event handles it needs as
-	# numbers on the command line. Blanket inheritance is the only thing making
-	# those numbers valid in the child -- and it also hands the daemon every
-	# other inheritable handle in the process.
+	# bInheritHandles = TRUE, ...), commented upstream as "Inherit handles
+	# (for event_handle)". That comment is wrong, and the flag is the bug.
 	#
-	# Not theoretical. A frozen OBS 32.2.2 was traced to sentry-crash.exe holding
-	# the write end of win-capture's anonymous pipe: the get-graphics-offsets
-	# helper had already exited, but because the daemon still held the pipe open
-	# libobs never saw EOF, so load_graphics_offsets blocked in ReadFile forever,
-	# init_hooks never finished, and game_capture_create waited on it with an
-	# INFINITE timeout. Killing the daemon by hand released the pipe and OBS
-	# resumed immediately. The same daemon was also holding OBS's log file,
-	# obs-browser's debug log and mojo pipes, and three sockets.
+	# The daemon does not need a single inherited handle. It attaches to the
+	# IPC objects by name -- OpenFileMappingW(shm_name),
+	# OpenEventW(event_name), OpenEventW(ready_event_name) in
+	# sentry_crash_ipc.c -- and the events are created with a NULL
+	# SECURITY_ATTRIBUTES, i.e. non-inheritable, so the numeric handle values
+	# passed on its command line were never valid in the child anyway.
 	#
-	# PROC_THREAD_ATTRIBUTE_HANDLE_LIST is the documented fix: inheritance stays
-	# on, but only the listed handles cross into the child.
+	# What TRUE did do was hand the daemon every *other* inheritable handle in
+	# OBS. A frozen OBS 32.2.2 was traced to sentry-crash.exe holding the write
+	# end of win-capture's anonymous pipe: the get-graphics-offsets helper had
+	# exited, but with the daemon still holding the pipe open libobs never saw
+	# EOF, so load_graphics_offsets blocked in ReadFile forever, init_hooks
+	# never finished, and game_capture_create waited on it with an INFINITE
+	# timeout. Killing the daemon released the pipe and OBS resumed. The same
+	# daemon also held OBS's log file, obs-browser's debug log and mojo pipes,
+	# and three sockets.
 	#
-	# Bracket arguments throughout -- the C being matched is full of semicolons,
-	# and CMake's \; escape does not compare equal inside string(FIND).
+	# PROC_THREAD_ATTRIBUTE_HANDLE_LIST was tried first and is wrong here: a
+	# handle list may only contain inheritable handles, so adding the two
+	# events made CreateProcessW fail with ERROR_INVALID_PARAMETER and the
+	# daemon stopped spawning entirely. FALSE is both simpler and correct.
 	set(SENTRY_SPAWN_SOURCE
 		"${SENTRY_SOURCE_DIR}/src/backends/native/sentry_crash_daemon.c")
 
-	set(SENTRY_SPAWN_STOCK [==[    // Prepare process creation structures
-    STARTUPINFOW si;
-    PROCESS_INFORMATION pi;
-    ZeroMemory(&si, sizeof(si));
-    si.cb = sizeof(si);
-    // Hide console window for daemon
-    si.dwFlags = STARTF_USESHOWWINDOW;
-    si.wShowWindow = SW_HIDE;
-    ZeroMemory(&pi, sizeof(pi));]==])
+	set(SENTRY_SPAWN_STOCK [==[            TRUE, // Inherit handles (for event_handle)]==])
 
-	set(SENTRY_SPAWN_PATCHED [==[    // Prepare process creation structures -- SE.Live: patched, see CMakeLists
-    STARTUPINFOEXW si;
-    PROCESS_INFORMATION pi;
-    ZeroMemory(&si, sizeof(si));
-    si.StartupInfo.cb = sizeof(si);
-    // Hide console window for daemon
-    si.StartupInfo.dwFlags = STARTF_USESHOWWINDOW;
-    si.StartupInfo.wShowWindow = SW_HIDE;
-    ZeroMemory(&pi, sizeof(pi));
-
-    // Inherit ONLY these two handles. Without the list the daemon inherits
-    // every inheritable handle in the host, which has been observed
-    // deadlocking unrelated OBS plugins waiting on a pipe the daemon was
-    // silently holding open.
-    HANDLE inherit_handles[2] = { event_handle, ready_event_handle };
-    SIZE_T attr_size = 0;
-    InitializeProcThreadAttributeList(NULL, 1, 0, &attr_size);
-    si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)sentry_malloc(attr_size);
-    if (si.lpAttributeList
-        && (!InitializeProcThreadAttributeList(
-                si.lpAttributeList, 1, 0, &attr_size)
-            || !UpdateProcThreadAttribute(si.lpAttributeList, 0,
-                PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherit_handles,
-                sizeof(inherit_handles), NULL, NULL))) {
-        sentry_free(si.lpAttributeList);
-        si.lpAttributeList = NULL;
-    }
-    if (!si.lpAttributeList) {
-        // Fall back to stock behaviour rather than not reporting crashes.
-        SENTRY_WARN("could not restrict daemon handle inheritance");
-    }]==])
-
-	set(SENTRY_SPAWN_FLAGS_STOCK [==[            TRUE, // Inherit handles (for event_handle)
-            CREATE_NO_WINDOW | DETACHED_PROCESS, // Creation flags]==])
-
-	set(SENTRY_SPAWN_FLAGS_PATCHED [==[            TRUE, // Inherit, but only what lpAttributeList allows
-            CREATE_NO_WINDOW | DETACHED_PROCESS
-                | (si.lpAttributeList ? EXTENDED_STARTUPINFO_PRESENT : 0),]==])
-
-	set(SENTRY_SPAWN_CLEANUP_STOCK [==[    // Close thread handle (we don't need it)
-    CloseHandle(pi.hThread);]==])
-
-	set(SENTRY_SPAWN_CLEANUP_PATCHED [==[    if (si.lpAttributeList) {
-        DeleteProcThreadAttributeList(si.lpAttributeList);
-        sentry_free(si.lpAttributeList);
-    }
-
-    // Close thread handle (we don't need it)
-    CloseHandle(pi.hThread);]==])
+	set(SENTRY_SPAWN_PATCHED [==[            FALSE, // SE.Live: inherit nothing -- the daemon opens its IPC by name. See CMakeLists.]==])
 
 	file(READ "${SENTRY_SPAWN_SOURCE}" SENTRY_SPAWN_CONTENT)
 
 	string(FIND "${SENTRY_SPAWN_CONTENT}" "${SENTRY_SPAWN_STOCK}"
 		SENTRY_SPAWN_STOCK_POS)
-	string(FIND "${SENTRY_SPAWN_CONTENT}" "SE.Live: patched"
+	string(FIND "${SENTRY_SPAWN_CONTENT}" "${SENTRY_SPAWN_PATCHED}"
 		SENTRY_SPAWN_PATCHED_POS)
 
 	if (NOT SENTRY_SPAWN_STOCK_POS EQUAL -1)
 		string(REPLACE "${SENTRY_SPAWN_STOCK}" "${SENTRY_SPAWN_PATCHED}"
 			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
-		string(REPLACE "${SENTRY_SPAWN_FLAGS_STOCK}"
-			"${SENTRY_SPAWN_FLAGS_PATCHED}"
-			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
-		string(REPLACE "&si, // Startup info" "&si.StartupInfo, // Startup info"
-			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
-		string(REPLACE "${SENTRY_SPAWN_CLEANUP_STOCK}"
-			"${SENTRY_SPAWN_CLEANUP_PATCHED}"
-			SENTRY_SPAWN_CONTENT "${SENTRY_SPAWN_CONTENT}")
 		file(WRITE "${SENTRY_SPAWN_SOURCE}" "${SENTRY_SPAWN_CONTENT}")
 		message(STATUS
-			"obs-streamelements-core: patched sentry-crash spawn to restrict handle inheritance")
+			"obs-streamelements-core: patched sentry-crash spawn to inherit no handles")
 	elseif (SENTRY_SPAWN_PATCHED_POS EQUAL -1)
 		# As with the wait timeout above: a silently skipped patch reintroduces a
 		# bug whose only symptom is an unrelated OBS subsystem deadlocking.


### PR DESCRIPTION
Part of CORE-635. **Fixes a regression currently on master.**

The patch merged in #123 stops `sentry-crash.exe` spawning at all. Windows logs `sentry_init() failed` and there is no crash reporting whatsoever — strictly worse than the handle leak it was meant to fix. Found by finally running it rather than only building it.

## Why it broke

`PROC_THREAD_ATTRIBUTE_HANDLE_LIST` may only contain **inheritable** handles. The two events it was handed are created with a `NULL` `SECURITY_ATTRIBUTES`, so they are not inheritable, and `CreateProcessW` rejects the call outright.

## Why the premise was also wrong

The daemon needs nothing inherited. It attaches to its IPC objects **by name**, in `sentry_crash_ipc.c`:

```c
OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, ipc->shm_name);
OpenEventW(SYNCHRONIZE, FALSE, ipc->event_name);
OpenEventW(EVENT_MODIFY_STATE, FALSE, ipc->ready_event_name);
```

The numeric handle values passed on its command line were never valid in the child, precisely because those handles are non-inheritable. Upstream's `// Inherit handles (for event_handle)` comment is untrue — inheritance was never doing the job it claims.

So the fix is one line: **`bInheritHandles = FALSE`**. No `STARTUPINFOEXW`, no attribute list, no allocation, and it inherits *nothing* rather than a curated list.

## Verified on a real OBS restart

Daemon handles compared against the 183 it held before:

| leaked OBS object | before | after |
|---|---|---|
| obs-browser mojo IPC pipe | 1 | **0** |
| OBS log file | 1 | **0** |
| obs-browser debug log | 1 | **0** |
| sockets (`\Device\Afd`) | 3 | **0** |

183 → 168 total. It retains only its own `SentryCrash-<pid>` section, its two events, its daemon log and its run.lock — and those object names carry the *new* OBS pid, which is the by-name attach working with nothing inherited.

`WindowStation` (2) and `Desktop` (1) are unchanged and are **not** inherited handles — every GUI-capable process gets those from the session. Calling them eliminated would be wrong.

`Sentry initialized` is back in the log and the daemon spawns normally as a child of OBS.

## Note on the vendored tree

The corrected patch was validated against a **pristine re-extract** — the extracted SDK was deleted so CMake unpacked `deps/sentry-native.zip` fresh, then applied both patches (`SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS` and this one) from stock. That rules out the result depending on leftovers from the earlier bad patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)