### PR TITLE
ci: submit installers to VirusTotal on release, not on every build (CORE-700)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -755,22 +755,6 @@ jobs:
           headers: |
             content-type: text/plain; charset=utf-8
 
-      - name: Upload signed installers to VirusTotal Monitor
-        uses: StreamElements/virustotal-monitor-action@v1
-        with:
-          # The action has no default and reads no environment variable — the key is always passed
-          # in. Point this at whatever your repo or org calls the secret.
-          api-key: ${{ secrets.VT_MONITOR_API_KEY }}
-          mode: upload
-          version: ${{ needs.version.outputs.version_encoded }}
-          path-prefix: /obs-streamelements-core/windows
-          files: |
-            ${{ github.workspace }}/obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}.exe
-            ${{ github.workspace }}/obs-streamelements-setup-${{ needs.version.outputs.version_encoded }}-64bit.exe
-          # Upload failures are loud: a release that AV vendors never see is the problem this solves.
-          on-error: fail
-          verbose: true
-
   deploy-signed-macos:
     needs: [ version, macos, build-installer ]
     runs-on: ubuntu-latest
@@ -859,10 +843,11 @@ jobs:
     # job whose dependencies were skipped. That is the intended outcome -- every step
     # below is already individually gated on has_release_notes, with one exception, the
     # VirusTotal prune. Losing the prune on notes-less builds is consistent rather than a
-    # gap: the matching VirusTotal upload lives in deploy-signed-windows and is skipped
-    # too, so no new files were submitted, and release.yml prunes again on every
-    # non-dry-run promotion. The same implicit skip already happens when
-    # SKIP_WINDOWS_SIGNING or SKIP_APPLE_SIGNING_AND_NOTARIZATION is set.
+    # gap: this workflow no longer submits anything to VirusTotal at all -- the upload
+    # moved to release.yml, which uploads and prunes together on every non-dry-run
+    # promotion -- so a skipped prune here leaves nothing unaccounted for. The same
+    # implicit skip already happens when SKIP_WINDOWS_SIGNING or
+    # SKIP_APPLE_SIGNING_AND_NOTARIZATION is set.
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     needs: [version, windows, macos, build-uninstaller, build-installer, deploy-signed-macos, deploy-signed-windows, summary]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,9 +445,21 @@ jobs:
       # package_url, package_url_64 and version_number. version_number is also what the
       # prune matches on, so the keys stay consistent with everything build.yml submitted
       # before this moved.
+      #
+      # Only on signed -> qa, the first hop a build takes and the point it stops being
+      # purely internal. Every later promotion moves the same bytes, so firing on any
+      # non-dry-run Windows promotion would submit one release four times over and spend
+      # the rate limits documented on the prune below for nothing. is-rollback needs no
+      # mention: "Validate Input" above rejects `to == signed` outright and allows no
+      # transition out of `signed` other than to `qa`, so this pair is only ever a
+      # forward promotion.
+      #
+      # The prune below deliberately keeps the wider gate: housekeeping should run on
+      # every promotion regardless of whether this hop submitted anything.
       - name: Download signed installers for VirusTotal
         id: vt_installers
-        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows'
+          && github.event.inputs.from == 'signed' && github.event.inputs.to == 'qa' }}
         run: |
           set -euo pipefail
 
@@ -482,7 +494,8 @@ jobs:
           echo "::notice::submitting $name_32 and $name_64 (version $version_number) to VirusTotal Monitor"
 
       - name: Upload signed installers to VirusTotal Monitor
-        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows'
+          && github.event.inputs.from == 'signed' && github.event.inputs.to == 'qa' }}
         uses: StreamElements/virustotal-monitor-action@v1
         with:
           # The action has no default and reads no environment variable — the key is always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,75 @@ jobs:
           dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
           log_level: verbose
 
+      # Submitting the signed installers to VirusTotal Monitor, moved here from
+      # build.yml's deploy-signed-windows job.
+      #
+      # Uploading at build time submitted every master build, including ones never
+      # promoted to a channel any user sees. Doing it on promotion means the binaries AV
+      # vendors are shown are the ones actually being shipped, and it puts the upload
+      # immediately before the prune below, so the version being added is counted by the
+      # same watermark pass that decides what to delete.
+      #
+      # Both the version key and the two installer URLs are read out of the manifest
+      # downloaded above rather than reconstructed. The channels disagree about installer
+      # filenames -- signed/ uses -<version>.exe and -<version>-64bit.exe, qa/beta/latest
+      # use -x86-/-x64-, stable drops the version entirely -- but every manifest carries
+      # package_url, package_url_64 and version_number. version_number is also what the
+      # prune matches on, so the keys stay consistent with everything build.yml submitted
+      # before this moved.
+      - name: Download signed installers for VirusTotal
+        id: vt_installers
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
+        run: |
+          set -euo pipefail
+
+          # The manifest is CRLF, so every value is stripped before use; a trailing
+          # carriage return silently corrupts both the URLs and the version key.
+          read_field() {
+            sed -n "s/^$1=//p" obs-streamelements.manifest | tr -d '\r' | head -1
+          }
+
+          version_number="$(read_field version_number)"
+          url_32="$(read_field package_url)"
+          url_64="$(read_field package_url_64)"
+
+          if [ -z "$version_number" ] || [ -z "$url_32" ] || [ -z "$url_64" ]; then
+            echo "::error::manifest on '${{ github.event.inputs.from }}' is missing version_number, package_url or package_url_64; cannot submit to VirusTotal"
+            exit 1
+          fi
+
+          # Keep the CDN's filenames: they are what shows up in VirusTotal Monitor, and
+          # renaming them would make a promoted build look unrelated to what build.yml
+          # used to submit. The query string is a cache-buster and is dropped.
+          name_32="$(basename "${url_32%%\?*}")"
+          name_64="$(basename "${url_64%%\?*}")"
+
+          curl -fsS --output "$name_32" "$url_32"
+          curl -fsS --output "$name_64" "$url_64"
+
+          echo "version_number=$version_number" >> "$GITHUB_OUTPUT"
+          echo "file_32=$name_32" >> "$GITHUB_OUTPUT"
+          echo "file_64=$name_64" >> "$GITHUB_OUTPUT"
+
+          echo "::notice::submitting $name_32 and $name_64 (version $version_number) to VirusTotal Monitor"
+
+      - name: Upload signed installers to VirusTotal Monitor
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
+        uses: StreamElements/virustotal-monitor-action@v1
+        with:
+          # The action has no default and reads no environment variable — the key is always
+          # passed in. Point this at whatever your repo or org calls the secret.
+          api-key: ${{ secrets.VT_MONITOR_API_KEY }}
+          mode: upload
+          version: ${{ steps.vt_installers.outputs.version_number }}
+          path-prefix: /obs-streamelements-core/windows
+          files: |
+            ${{ github.workspace }}/${{ steps.vt_installers.outputs.file_32 }}
+            ${{ github.workspace }}/${{ steps.vt_installers.outputs.file_64 }}
+          # Upload failures are loud: a release AV vendors never see is the problem this solves.
+          on-error: fail
+          verbose: true
+
       - name: Prune old versions from VirusTotal Monitor
         uses: streamelements/virustotal-monitor-action@v1
         if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}


### PR DESCRIPTION
Fixes CORE-700

Moves the **Upload signed installers to VirusTotal Monitor** step out of `build.yml`'s `deploy-signed-windows` job and into `release.yml`, next to the prune that was already there.

## Why

At build time it submitted **every** master build that produced release notes, including builds never promoted to a channel any user installs. The binaries AV vendors are shown should be the ones actually being shipped.

It also lands the upload immediately before the prune, so the version being added is counted by the same watermark pass that decides what to delete — instead of being added in one workflow and reconciled in another.

## How

`release.yml` promotes between channels and never had the installers locally; it downloads only the manifest, version SVG and release notes. Rather than reconstructing installer URLs, the version key and both installer URLs are read out of that same manifest:

| field | used for |
|---|---|
| `version_number` | the VirusTotal version key — also what the prune matches on, so keys stay identical to everything `build.yml` submitted before |
| `package_url`, `package_url_64` | the two installers |

That matters because the channels disagree about installer filenames — `signed/` uses `-<version>.exe` and `-<version>-64bit.exe`, `qa`/`beta`/`latest` use `-x86-`/`-x64-`, `stable` drops the version entirely — while every manifest carries all three fields, so this works from any source channel. CDN filenames are preserved on download, since those are what appear in VirusTotal Monitor; renaming would make a promoted build look unrelated to what was submitted before.

Gated to the `signed -> qa` hop only: `dry-run == false && platform == windows && from == 'signed' && to == 'qa'`. The prune beside it deliberately keeps the wider gate — housekeeping should run on every promotion regardless of whether that hop uploaded anything.

## Why only `signed -> qa`

Every promotion moves the same bytes, so gating on any non-dry-run Windows promotion would submit one release four times over as a build walks `signed -> qa -> beta -> latest -> stable`, spending the rate limits documented on the prune step (500/day, 15500/month) for nothing.

`signed -> qa` is the first hop a build takes and the point it stops being purely internal, so it is the one that should reach AV vendors.

`is-rollback` needs no mention in the condition: **Validate Input** rejects `to == signed` outright and permits no transition out of `signed` other than to `qa`, so this pair is only ever a forward promotion.

## Verification

- Both workflows parse as YAML after the change.
- The manifest-parsing logic was run against the **live** `signed/` manifest rather than assumed:

```
version_number = 20260818000865
url_32         = .../obs-streamelements-setup-20260818000865.exe?ts=...
url_64         = .../obs-streamelements-setup-20260818000865-64bit.exe?ts=...
  32-bit: HTTP 200  37483248 bytes
  64-bit: HTTP 200  25139680 bytes
```

- `read_field` strips CR explicitly — the manifest is CRLF, and a trailing carriage return would silently corrupt both the URLs and the version key.
- The `finalize` comment in `build.yml` that cross-referenced "the matching VirusTotal upload lives in deploy-signed-windows" was updated; it would otherwise describe a step that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
