### PR TITLE
ci: drop the VirusTotal prune from build.yml (CORE-700)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -841,13 +841,9 @@ jobs:
     # Note this job is now skipped entirely for a build with an empty RELEASE_NOTES.md:
     # it needs deploy-signed-*, those are gated on has_release_notes, and GitHub skips a
     # job whose dependencies were skipped. That is the intended outcome -- every step
-    # below is already individually gated on has_release_notes, with one exception, the
-    # VirusTotal prune. Losing the prune on notes-less builds is consistent rather than a
-    # gap: this workflow no longer submits anything to VirusTotal at all -- the upload
-    # moved to release.yml, which uploads and prunes together on every non-dry-run
-    # promotion -- so a skipped prune here leaves nothing unaccounted for. The same
-    # implicit skip already happens when SKIP_WINDOWS_SIGNING or
-    # SKIP_APPLE_SIGNING_AND_NOTARIZATION is set.
+    # below is individually gated on has_release_notes anyway. The same implicit skip
+    # already happens when SKIP_WINDOWS_SIGNING or SKIP_APPLE_SIGNING_AND_NOTARIZATION
+    # is set.
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     needs: [version, windows, macos, build-uninstaller, build-installer, deploy-signed-macos, deploy-signed-windows, summary]
     runs-on: ubuntu-latest
@@ -1023,40 +1019,3 @@ jobs:
           git add RELEASE_NOTES.history.md
           git commit -m "[WORKFLOW-AUTOMATION] ${{ needs.version.outputs.version_string }} finalize build"
           git push
-
-      - name: Prune old versions from VirusTotal Monitor
-        uses: streamelements/virustotal-monitor-action@v1
-        with:
-          # The action has no default and reads no environment variable — the key is always
-          # passed in. Point this at whatever your repo or org calls the secret.
-          api-key: ${{ secrets.VT_MONITOR_API_KEY }}
-          mode: prune
-          managed-prefixes: /obs-streamelements-core
-          quota-bytes: ${{ vars.VT_MONITOR_QUOTA_BYTES || '1GiB' }}
-          high-watermark: ${{ inputs.high-watermark || vars.VT_MONITOR_HIGH_WATERMARK || '80' }}
-          target-watermark: ${{ inputs.target-watermark || vars.VT_MONITOR_TARGET_WATERMARK || '60' }}
-          keep-versions: ${{ vars.VT_MONITOR_KEEP_VERSIONS || '3' }}
-          # Anything these point at is never deleted. If any of them cannot be fetched, the
-          # step fails rather than pruning with an incomplete picture of what is live.
-          #
-          # Each channel is its own directory holding one obs-streamelements.manifest; signed/
-          # additionally pins the most recent signed build. The channels disagree about
-          # installer filenames (signed/ uses -<version>.exe and -<version>-64bit.exe, qa/beta/
-          # latest use -x86-/-x64-, stable drops the version from the filename entirely), so
-          # matching keys off version_number, which all five carry.
-          manifest-urls: |
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/signed/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/qa/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/beta/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/latest/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/stable/obs-streamelements.manifest
-          # Public-API allowances by default. A prune walks the tree and deletes per version, so
-          # at 4/minute expect a few minutes of wall clock; raise these if the key allows more.
-          rate-limit-per-minute: ${{ vars.VT_MONITOR_RATE_PER_MINUTE || '4' }}
-          rate-limit-per-day: ${{ vars.VT_MONITOR_RATE_PER_DAY || '500' }}
-          rate-limit-per-month: ${{ vars.VT_MONITOR_RATE_PER_MONTH || '15500' }}
-          # Scheduled runs default to enforcing; manual runs default to previewing.
-          dry-run: false
-          # Storage housekeeping must never take a release down with it.
-          on-error: warn
-          verbose: true


### PR DESCRIPTION
Fixes CORE-700

Follow-up to #126, which moved the VirusTotal **upload** out of `build.yml` and into `release.yml`. This removes the **prune** that stayed behind, so `build.yml` no longer references VirusTotal at all.

## Why

`build.yml` submits nothing to VirusTotal any more, so it had no reason to keep reconciling what is stored there. `release.yml` prunes on every promotion, immediately after the upload — one workflow now both adds and reconciles versions, rather than adding in one and reconciling in another.

Nothing is lost by removing it: both steps are the same action in `mode: prune` against the same `managed-prefixes` and the same five channel manifests, and pruning is idempotent housekeeping. The `release.yml` copy runs at least as often as this one did — every non-dry-run Windows promotion, versus only master builds that produced release notes.

## Two things this also clears up

**The `finalize` job comment had to carve out an exception for it.** The prune was the only step in that job not gated on `has_release_notes`, and the comment spent five lines explaining why losing it on notes-less builds was acceptable. Every remaining step is gated, so the comment now just says so.

**It referenced inputs that do not exist.** The step read `inputs.high-watermark` and `inputs.target-watermark`, but `build.yml`'s `on:` block declares `workflow_dispatch:` with no inputs whatsoever — there is no `workflow_call` either. Both always evaluated empty and fell through to the `vars.*` fallbacks, so the behaviour was correct by accident. Dead references, gone with the step.

## Verification

- `build.yml` parses as YAML after the change.
- `grep -i virustotal .github/workflows/build.yml` now returns nothing.
- The `release.yml` prune is untouched and still carries the wider gate (`dry-run == false && platform == windows`), deliberately unlike the upload steps beside it, which #126 narrowed to `signed -> qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
