### PR TITLE
ci: pin third-party actions by SHA, inline the three in the signing path (CORE-414)

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -352,7 +352,7 @@ jobs:
             makensis /V4 main.nsi
 
       - name: Sign Windows binaries
-        uses: azure/artifact-signing-action@v2
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         if: ${{ env.SIGN_WINDOWS_BINARIES == 'true'}}
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -367,11 +367,26 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-# Automatically finds signtool.exe and exposes its path
+      # Inlined from KamaranL/add-signtool-action@v1: find the newest signtool.exe
+      # for this runner's architecture under the Windows SDK and put its directory on
+      # PATH, which is all the verify step below needs. The action's `id: signtool`
+      # went with it -- nothing ever read its output. Same search the action did:
+      # recurse the SDK bin tree, keep the ones in an arch-named directory, take the
+      # highest path. Absent signtool is fatal rather than a silently unverified
+      # signature.
       - name: Find SignTool
         if: ${{ env.SIGN_WINDOWS_BINARIES == 'true'}}
-        uses: KamaranL/add-signtool-action@v1
-        id: signtool
+        shell: pwsh
+        run: |
+          $arch = $env:RUNNER_ARCH.ToLower()
+          $base = "${env:ProgramFiles(x86)}/Windows Kits/10/bin"
+          $tool = Get-ChildItem $base -Recurse -Force -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.Directory.Name -eq $arch } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $tool) { throw "signtool.exe ($arch) not found under $base" }
+          Write-Output "Using $($tool.FullName)"
+          $tool.Directory.FullName | Out-File $env:GITHUB_PATH -Append
 
       - name: Verify Windows binaries code signature
         if: ${{ env.SIGN_WINDOWS_BINARIES == 'true'}}
@@ -405,7 +420,7 @@ jobs:
 
       - name: Upload Binaries to Google Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -415,7 +430,7 @@ jobs:
 
       - name: Upload Text to Google Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -437,7 +452,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -748,7 +763,7 @@ jobs:
 
       - name: Upload Binaries to Google Storage
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -758,7 +773,7 @@ jobs:
 
       - name: Upload Text to Google Storage
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/build-obs-streamelements-uninstaller.yml
+++ b/.github/workflows/build-obs-streamelements-uninstaller.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -109,7 +109,7 @@ jobs:
           makensis /V4 main.nsi
 
       - name: Sign Windows binaries
-        uses: azure/artifact-signing-action@v2
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         if: ${{ env.SIGN_BINARIES == 'true' }}
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -124,11 +124,26 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-# Automatically finds signtool.exe and exposes its path
+      # Inlined from KamaranL/add-signtool-action@v1: find the newest signtool.exe
+      # for this runner's architecture under the Windows SDK and put its directory on
+      # PATH, which is all the verify step below needs. The action's `id: signtool`
+      # went with it -- nothing ever read its output. Same search the action did:
+      # recurse the SDK bin tree, keep the ones in an arch-named directory, take the
+      # highest path. Absent signtool is fatal rather than a silently unverified
+      # signature.
       - name: Find SignTool
         if: ${{ env.SIGN_BINARIES == 'true' }}
-        uses: KamaranL/add-signtool-action@v1
-        id: signtool
+        shell: pwsh
+        run: |
+          $arch = $env:RUNNER_ARCH.ToLower()
+          $base = "${env:ProgramFiles(x86)}/Windows Kits/10/bin"
+          $tool = Get-ChildItem $base -Recurse -Force -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.Directory.Name -eq $arch } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $tool) { throw "signtool.exe ($arch) not found under $base" }
+          Write-Output "Using $($tool.FullName)"
+          $tool.Directory.FullName | Out-File $env:GITHUB_PATH -Append
 
       - name: Verify Windows binaries code signature
         if: ${{ env.SIGN_BINARIES == 'true' }}
@@ -145,7 +160,7 @@ jobs:
 
       - name: Upload to Google Artifact Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -154,7 +169,7 @@ jobs:
 
       - name: Upload to CDN Signed Artifact Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -163,7 +178,7 @@ jobs:
 
       - name: Upload to CDN QA Artifact Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -172,7 +187,7 @@ jobs:
 
       - name: Upload to CDN Latest Artifact Storage
         if: ${{ env.UPLOAD_BINARIES == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,20 @@ jobs:
       has_release_notes: ${{ steps.has_release_notes_step.outputs.has_release_notes }}
 
     steps:
+      # Inlined from mlilback/build-number@v1, whose entire main.js was
+      # `core.exportVariable('BUILD_NUMBER', (base + run).toString())`. It ran before
+      # anything else in the pipeline and decided the version every artifact is named
+      # after, on a node12-era third-party tag -- the worst place in these workflows to
+      # trust a moving reference.
+      #
+      # The arithmetic is identical, and the sequence is verified unchanged against the
+      # last three releases: 569+302=871 (26.8.18.871), 569+289=858 (26.8.18.858),
+      # 569+282=851 (26.8.17.851). Keep it as base + run_number: the fleet updater
+      # compares version numbers, so a value that jumps backwards bricks self-update.
+      # se-release/lib.sh documents the same formula and reads it back out of tags.
       - name: Generate build number
-        uses: mlilback/build-number@v1
-        with:
-          base: ${{ env.BASE_BUILD_NUMBER }}
-          run-id: ${{ github.run_number }}
-          # Output: ${{ env.BUILD_NUMBER }} env var
+        # Output: ${{ env.BUILD_NUMBER }} env var
+        run: echo "BUILD_NUMBER=$(( ${{ env.BASE_BUILD_NUMBER }} + ${{ github.run_number }} ))" >> "$GITHUB_ENV"
 
       - name: Generate Version
         id: version_step
@@ -174,7 +182,7 @@ jobs:
         # GitHub event context and rejects anything it does not recognise -- here it
         # fails immediately with "Unsupported event type: push". The base action has no
         # such gate. Pinned exactly: it publishes no moving major tag.
-        uses: anthropics/claude-code-base-action@v0.0.63
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # v0.0.63
         # Force Task subagents to run in the foreground; same rationale as
         # claude-code-review.yml. Upstream: anthropics/claude-code-action#1499.
         env:
@@ -263,14 +271,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
       - name: Clone OBS Studio
         shell: cmd
@@ -403,7 +411,7 @@ jobs:
 
       - name: Upload 64bit build artifact to GCS
         if: github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -412,7 +420,7 @@ jobs:
 
       - name: Upload version header to GCS
         if: github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -437,7 +445,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -597,7 +605,7 @@ jobs:
 
       - name: Upload ARM64 build artifact to GCS
         if: github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -606,7 +614,7 @@ jobs:
 
       - name: Upload x86_64 build artifact to GCS
         if: github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -615,7 +623,7 @@ jobs:
 
       - name: Upload version header to GCS
         if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -665,14 +673,14 @@ jobs:
 
     steps:
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
 
       - name: Create Custom Status Badge
-        uses: emibcn/badge-action@v2.0.2
+        uses: emibcn/badge-action@4209421db54c8764d8932070ffd0f81715a629bf # v2.0.2
         with:
           label: 'Version'
           status: '${{ needs.version.outputs.version_string }}'
@@ -736,7 +744,7 @@ jobs:
             *.*.version.svg
 
       - name: Upload Binaries to CDN Google Storage
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -745,7 +753,7 @@ jobs:
           destination: 'cdn.streamelements.com/obs/dist/obs-streamelements/windows/signed'
 
       - name: Upload Manifests to CDN Google Storage
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -763,14 +771,14 @@ jobs:
 
     steps:
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCS_SERVICE_ACCOUNT }}
 
       - name: Create Custom Status Badge
-        uses: emibcn/badge-action@v2.0.2
+        uses: emibcn/badge-action@4209421db54c8764d8932070ffd0f81715a629bf # v2.0.2
         with:
           label: 'Version'
           status: '${{ needs.version.outputs.version_string }}'
@@ -818,7 +826,7 @@ jobs:
             *.manifest
           
       - name: Upload Binaries to CDN Google Storage
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -827,7 +835,7 @@ jobs:
           destination: 'cdn.streamelements.com/obs/dist/obs-streamelements/macos/signed'
 
       - name: Upload Manifests to CDN Google Storage
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -849,12 +857,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Inlined from tvdias/github-tagger@v0.0.1, which was one createRef call on
+      # github.context.sha -- reproduced exactly, including the failure on a tag that
+      # already exists (the action did not force-update either, so a re-run of an
+      # already-tagged version still stops here rather than silently moving a tag that
+      # a release points at). This runs before the checkout below, so it has to go
+      # through the API rather than `git tag`.
       - name: Tag master commit
-        uses: tvdias/github-tagger@v0.0.1
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ needs.version.outputs.version_string }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.version.outputs.version_string }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f "ref=refs/tags/$TAG" \
+            -f "sha=$GITHUB_SHA"
 
       - uses: actions/checkout@v4
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
@@ -955,7 +973,7 @@ jobs:
       # because the blurb does not exist until the step above has run.
       - name: Auth Google API
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -963,7 +981,7 @@ jobs:
 
       - name: Upload release notes to windows/signed
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -976,7 +994,7 @@ jobs:
 
       - name: Upload release notes to macos/signed
         if: needs.version.outputs.is_workflow_automation != 'true' && needs.version.outputs.has_release_notes == 'true'
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false


### PR DESCRIPTION
Fixes CORE-414

> **Note:** CORE-414 is currently **Canceled** in Linear (2026-08-17, no comment). Implemented on request; the issue needs reopening if this should land.

Three small third-party actions ran by tag inside jobs holding the Azure signing credentials and the release token. A hijacked tag ships whatever it wants into a signed build. Each turned out to be a few lines wrapped in a moving reference, so all three are inlined rather than pinned.

## Replaced

**`mlilback/build-number@v1`** — its entire `main.js`:

```js
core.exportVariable('BUILD_NUMBER', (base + run).toString());
```

A node12-era action, first step in the pipeline, deciding the version every artifact is named after. Now one line of shell.

This is the part that had to be exact — the fleet updater compares version numbers, so a value that jumps backwards bricks self-update. Verified against shipped releases rather than assumed:

| tag | commit | run_number | 569 + run_number |
|---|---|---|---|
| 26.8.18.871 | ae1fb92 | 302 | **871** ✓ |
| 26.8.18.858 | 4b71ad3 | 289 | **858** ✓ |
| 26.8.17.851 | f439fd5 | 282 | **851** ✓ |

The replacement was then run for those three `run_number`s and produced 871, 858 and 851. `se-release/lib.sh:121` independently documents the same formula and reads it back out of tags.

**`tvdias/github-tagger@v0.0.1`** — one `createRef` on `github.context.sha`, now the same call via `gh api`. It runs *before* the checkout in `finalize`, so it stays an API call rather than `git tag`. Behaviour on a tag that already exists is preserved deliberately: the action did not force-update either, so a re-run of an already-tagged version still fails there rather than silently moving a tag a published release points at.

**`KamaranL/add-signtool-action@v1`** — a pwsh script that finds the newest `signtool.exe` for the runner architecture and appends its directory to `GITHUB_PATH`. Inlined with the same search (recurse the SDK bin tree, keep arch-named directories, take the highest path). Its `id: signtool` went with it — nothing ever read the output.

Run against a real SDK tree on Windows, it picks correctly:

```
C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe   <- picked
C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe
C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe
```

A missing signtool is now fatal rather than a silently unverified signature.

## SHA-pinned

33 references across the three files, tag kept in a trailing comment so the intent stays readable:

| action | pinned to | was |
|---|---|---|
| `azure/artifact-signing-action` | `c7ab2a8` | v2 |
| `google-github-actions/auth` | `c200f36` | v2 |
| `google-github-actions/upload-cloud-storage` | `6397bd7` | v3 |
| `microsoft/setup-msbuild` | `30375c6` | v3 |
| `emibcn/badge-action` | `4209421` | v2.0.2 |
| `anthropics/claude-code-base-action` | `e8132bc` | v0.0.63 |

`actions/checkout` and `actions/upload-artifact` stay on tags deliberately — GitHub-owned, and pinning them defends against nothing that compromising GitHub itself would not already defeat.

## Two things worth deciding separately

**SHA pins do not update themselves, and there is no `dependabot.yml` in this repo.** The npm PRs that show up are Dependabot *security* updates, which need no config; version updates do. So these six actions are now frozen until someone bumps them by hand, security fixes included. The standard fix is a `dependabot.yml` with `package-ecosystem: github-actions`, which opens PRs that bump the SHA and rewrite the trailing tag comment. Say the word and it's a separate small PR.

**`release.yml` is untouched**, per the issue's "the three workflow files". It still tag-pins `linear/linear-release-action@v0`, `StreamElements/virustotal-monitor-action@v1` and the two `google-github-actions/*`. It holds the GCS credentials and the Linear key but does no signing, so it is a lesser exposure — worth doing, just not silently folded in here.

## Verification

- All three workflows parse as YAML.
- No tag-pinned third-party action remains in the three files (only `actions/*` and local `./` references).
- The build-number arithmetic and the signtool lookup were both executed, not just read — results above.
- Not exercised by CI: the tagger only runs in `finalize`, which is skipped on pull requests. First proof is the next master build that carries release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
