### PR TITLE
ci: SHA-pin the third-party actions in release.yml (CORE-414)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           filter: blob:none
 
       - name: Auth Google API
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # v2
         with:
           project_id: streamelements-core
           workload_identity_provider: ${{ vars.GCS_WORKLOAD_ID_PROVIDER }}
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload Manifests to CDN Google Storage
         if: ${{ github.event.inputs.dry-run == 'false' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -273,7 +273,7 @@ jobs:
       # has moved on.
       - name: Upload release notes to CDN Google Storage
         if: ${{ github.event.inputs.dry-run == 'false' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -289,7 +289,7 @@ jobs:
       # the upload action.
       - name: Upload SVGs to CDN Google Storage
         if: ${{ github.event.inputs.dry-run == 'false' && steps.download.outputs.has_version_svg == 'true' }}
-        uses: 'google-github-actions/upload-cloud-storage@v3'
+        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a' # v3
         with:
           parent: false
           process_gcloudignore: false
@@ -372,7 +372,7 @@ jobs:
         id: linear_sync
         if: env.SE_HAS_LINEAR == 'true' && env.SE_LINEAR_BETA == 'true' && steps.linear_checkout.outputs.ok == 'true'
         continue-on-error: true
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
@@ -406,7 +406,7 @@ jobs:
       - name: Move Linear release to the beta stage
         if: env.SE_HAS_LINEAR == 'true' && env.SE_LINEAR_BETA == 'true' && vars.LINEAR_BETA_STAGE != '' && steps.linear_sync.outcome == 'success'
         continue-on-error: true
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: update
@@ -421,7 +421,7 @@ jobs:
       - name: Complete Linear release
         if: env.SE_HAS_LINEAR == 'true' && env.SE_PROMOTE == 'true'
         continue-on-error: true
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete
@@ -496,7 +496,7 @@ jobs:
       - name: Upload signed installers to VirusTotal Monitor
         if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows'
           && github.event.inputs.from == 'signed' && github.event.inputs.to == 'qa' }}
-        uses: StreamElements/virustotal-monitor-action@v1
+        uses: StreamElements/virustotal-monitor-action@9c7f2ad235cf0b1f7d5975ad1e0eccb4210f4d71 # v1
         with:
           # The action has no default and reads no environment variable — the key is always
           # passed in. Point this at whatever your repo or org calls the secret.
@@ -512,7 +512,7 @@ jobs:
           verbose: true
 
       - name: Prune old versions from VirusTotal Monitor
-        uses: streamelements/virustotal-monitor-action@v1
+        uses: StreamElements/virustotal-monitor-action@9c7f2ad235cf0b1f7d5975ad1e0eccb4210f4d71 # v1
         if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
         with:
           # The action has no default and reads no environment variable — the key is always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,7 +496,7 @@ jobs:
       - name: Upload signed installers to VirusTotal Monitor
         if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows'
           && github.event.inputs.from == 'signed' && github.event.inputs.to == 'qa' }}
-        uses: StreamElements/virustotal-monitor-action@9c7f2ad235cf0b1f7d5975ad1e0eccb4210f4d71 # v1
+        uses: StreamElements/virustotal-monitor-action@v1
         with:
           # The action has no default and reads no environment variable — the key is always
           # passed in. Point this at whatever your repo or org calls the secret.
@@ -512,7 +512,7 @@ jobs:
           verbose: true
 
       - name: Prune old versions from VirusTotal Monitor
-        uses: StreamElements/virustotal-monitor-action@9c7f2ad235cf0b1f7d5975ad1e0eccb4210f4d71 # v1
+        uses: StreamElements/virustotal-monitor-action@v1
         if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
         with:
           # The action has no default and reads no environment variable — the key is always


### PR DESCRIPTION
Fixes CORE-414

Extends #128 to the fourth workflow. CORE-414 scoped itself to the three build files because those hold the Azure signing credentials — but `release.yml` holds the GCS service account and the Linear workspace key, and it is the workflow that decides what reaches users. A hijacked tag there moves a *channel* rather than a build.

Nothing in this file is a one-liner worth inlining the way `build-number` and the tagger were, so this is pins only — seven references:

| action | pinned to | was |
|---|---|---|
| `google-github-actions/auth` | `c200f36` | v2 |
| `google-github-actions/upload-cloud-storage` | `6397bd7` (×3) | v3 |
| `linear/linear-release-action` | `17b8c24` (×3) | v0 |

## Our own action stays on its tag

`StreamElements/virustotal-monitor-action@v1` is deliberately **not** pinned, for the same reason `actions/checkout` is not: anyone able to move that tag could push to this repository directly, so a SHA buys no protection here and would only stop fixes arriving through `v1`.

## Incidental fix

The two VirusTotal steps disagreed on the org's casing — one `StreamElements/`, one `streamelements/`. GitHub resolves both, but pinning normalizes them on the repo's own spelling.

## Verification

- `release.yml` parses as YAML.
- Only `actions/checkout@v4`, `StreamElements/virustotal-monitor-action@v1` (both by design) and the four local `./.github/actions/se-release` references remain unpinned.
- Every SHA was resolved through the API against the tag it replaces, not copied from anywhere.
- The incidental casing fix is unaffected by the unpinning — both steps still spell the org `StreamElements/`.

**Not exercised by CI.** `release.yml` is `workflow_dispatch`-only, so no PR check touches it. The first real proof is the next promotion; if a SHA were wrong the step would fail immediately with an unresolvable action reference rather than doing anything subtle.

## Still open

There is no `dependabot.yml` in this repo, so these pins — and the six in #128 — will not update themselves. A `dependabot.yml` with `package-ecosystem: github-actions` is the standard fix and remains a separate PR.

After this, the only unpinned third-party action left anywhere is `anthropics/claude-code-action@v1` in `claude.yml` and `claude-code-review.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
