### PR TITLE
fix(release): prune VirusTotal storage before uploading, not after (CORE-700)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,14 +429,65 @@ jobs:
           dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
           log_level: verbose
 
+      # Runs BEFORE the upload, and the order is load-bearing.
+      #
+      # Monitor storage is a hard quota (1 GiB for this group). When it is full,
+      # VirusTotal rejects an upload with HTTP 429 QuotaExceededError -- the same status
+      # it uses for rate limits, so the action retries it five times and fails. With the
+      # prune ordered after the upload, a failed upload skipped the one step that frees
+      # space, so a full store stayed full and every later promotion failed identically.
+      # That is exactly what happened on the first real signed -> qa run: 1020264912 of
+      # 1048576000 bytes used, 27 MiB free, a 35.76 MiB installer to store.
+      #
+      # Pruning first cannot delete what is being promoted: the manifests below were
+      # uploaded earlier in this job, so the incoming version is already live on the
+      # destination channel and protected by manifest-urls.
+      - name: Prune old versions from VirusTotal Monitor
+        uses: StreamElements/virustotal-monitor-action@v1
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
+        with:
+          # The action has no default and reads no environment variable — the key is always
+          # passed in. Point this at whatever your repo or org calls the secret.
+          api-key: ${{ secrets.VT_MONITOR_API_KEY }}
+          mode: prune
+          managed-prefixes: /obs-streamelements-core
+          quota-bytes: ${{ vars.VT_MONITOR_QUOTA_BYTES || '1GiB' }}
+          high-watermark: ${{ vars.VT_MONITOR_HIGH_WATERMARK || '80' }}
+          target-watermark: ${{ vars.VT_MONITOR_TARGET_WATERMARK || '60' }}
+          keep-versions: ${{ vars.VT_MONITOR_KEEP_VERSIONS || '3' }}
+          # Anything these point at is never deleted. If any of them cannot be fetched, the
+          # step fails rather than pruning with an incomplete picture of what is live.
+          #
+          # Each channel is its own directory holding one obs-streamelements.manifest; signed/
+          # additionally pins the most recent signed build. The channels disagree about
+          # installer filenames (signed/ uses -<version>.exe and -<version>-64bit.exe, qa/beta/
+          # latest use -x86-/-x64-, stable drops the version from the filename entirely), so
+          # matching keys off version_number, which all five carry.
+          manifest-urls: |
+            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/signed/obs-streamelements.manifest
+            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/qa/obs-streamelements.manifest
+            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/beta/obs-streamelements.manifest
+            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/latest/obs-streamelements.manifest
+            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/stable/obs-streamelements.manifest
+          # Public-API allowances by default. A prune walks the tree and deletes per version, so
+          # at 4/minute expect a few minutes of wall clock; raise these if the key allows more.
+          rate-limit-per-minute: ${{ vars.VT_MONITOR_RATE_PER_MINUTE || '4' }}
+          rate-limit-per-day: ${{ vars.VT_MONITOR_RATE_PER_DAY || '500' }}
+          rate-limit-per-month: ${{ vars.VT_MONITOR_RATE_PER_MONTH || '15500' }}
+          # Scheduled runs default to enforcing; manual runs default to previewing.
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run || 'false' }}
+          # Storage housekeeping must never take a release down with it.
+          on-error: warn
+          verbose: true
+
       # Submitting the signed installers to VirusTotal Monitor, moved here from
       # build.yml's deploy-signed-windows job.
       #
       # Uploading at build time submitted every master build, including ones never
       # promoted to a channel any user sees. Doing it on promotion means the binaries AV
-      # vendors are shown are the ones actually being shipped, and it puts the upload
-      # immediately before the prune below, so the version being added is counted by the
-      # same watermark pass that decides what to delete.
+      # vendors are shown are the ones actually being shipped, and it puts the upload in
+      # the same job as the prune instead of adding in one workflow and reconciling in
+      # another. The prune runs first; see the ordering note on it above.
       #
       # Both the version key and the two installer URLs are read out of the manifest
       # downloaded above rather than reconstructed. The channels disagree about installer
@@ -449,12 +500,12 @@ jobs:
       # Only on signed -> qa, the first hop a build takes and the point it stops being
       # purely internal. Every later promotion moves the same bytes, so firing on any
       # non-dry-run Windows promotion would submit one release four times over and spend
-      # the rate limits documented on the prune below for nothing. is-rollback needs no
+      # the rate limits documented on the prune above for nothing. is-rollback needs no
       # mention: "Validate Input" above rejects `to == signed` outright and allows no
       # transition out of `signed` other than to `qa`, so this pair is only ever a
       # forward promotion.
       #
-      # The prune below deliberately keeps the wider gate: housekeeping should run on
+      # The prune above deliberately keeps the wider gate: housekeeping should run on
       # every promotion regardless of whether this hop submitted anything.
       - name: Download signed installers for VirusTotal
         id: vt_installers
@@ -511,40 +562,3 @@ jobs:
           on-error: fail
           verbose: true
 
-      - name: Prune old versions from VirusTotal Monitor
-        uses: StreamElements/virustotal-monitor-action@v1
-        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.platform == 'windows' }}
-        with:
-          # The action has no default and reads no environment variable — the key is always
-          # passed in. Point this at whatever your repo or org calls the secret.
-          api-key: ${{ secrets.VT_MONITOR_API_KEY }}
-          mode: prune
-          managed-prefixes: /obs-streamelements-core
-          quota-bytes: ${{ vars.VT_MONITOR_QUOTA_BYTES || '1GiB' }}
-          high-watermark: ${{ inputs.high-watermark || vars.VT_MONITOR_HIGH_WATERMARK || '80' }}
-          target-watermark: ${{ inputs.target-watermark || vars.VT_MONITOR_TARGET_WATERMARK || '60' }}
-          keep-versions: ${{ vars.VT_MONITOR_KEEP_VERSIONS || '3' }}
-          # Anything these point at is never deleted. If any of them cannot be fetched, the
-          # step fails rather than pruning with an incomplete picture of what is live.
-          #
-          # Each channel is its own directory holding one obs-streamelements.manifest; signed/
-          # additionally pins the most recent signed build. The channels disagree about
-          # installer filenames (signed/ uses -<version>.exe and -<version>-64bit.exe, qa/beta/
-          # latest use -x86-/-x64-, stable drops the version from the filename entirely), so
-          # matching keys off version_number, which all five carry.
-          manifest-urls: |
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/signed/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/qa/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/beta/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/latest/obs-streamelements.manifest
-            https://cdn.streamelements.com/obs/dist/obs-streamelements/windows/stable/obs-streamelements.manifest
-          # Public-API allowances by default. A prune walks the tree and deletes per version, so
-          # at 4/minute expect a few minutes of wall clock; raise these if the key allows more.
-          rate-limit-per-minute: ${{ vars.VT_MONITOR_RATE_PER_MINUTE || '4' }}
-          rate-limit-per-day: ${{ vars.VT_MONITOR_RATE_PER_DAY || '500' }}
-          rate-limit-per-month: ${{ vars.VT_MONITOR_RATE_PER_MONTH || '15500' }}
-          # Scheduled runs default to enforcing; manual runs default to previewing.
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run || 'false' }}
-          # Storage housekeeping must never take a release down with it.
-          on-error: warn
-          verbose: true


### PR DESCRIPTION
Fixes CORE-700

The first real `signed -> qa` promotion ([run 32263565265](https://github.com/StreamElements/obs-streamelements-core/actions/runs/32263565265/job/96102436490)) failed on the VirusTotal upload.

## What actually failed

Not a rate limit, despite what the action's warning said:

```
monitor_storage_bytes:  allowed 1,048,576,000   used 1,020,264,912   (97.3%)
HTTP 429  {"error": {"code": "QuotaExceededError", "message": "Quota exceeded"}}
```

27 MiB free, a 35.76 MiB installer to store. VirusTotal returns 429 for a full store as well as for throttling, so the action read it as throttling and retried five times at 60s intervals — retries that could never succeed, because storage does not free itself.

## The real defect is the step order from #126

The prune sat **after** the upload. A failed upload skips the only step that frees space, so a full store stays full and every subsequent promotion fails identically. This was one bad run away from being permanent.

The prune would have fixed it in a single pass: 97.3% is over the 80% high watermark, and pruning to the 60% target frees roughly 400 MB.

**Fix: prune first, then download and upload.**

Pruning first cannot delete the build being promoted — the manifest uploads run earlier in the same job, so the incoming version is already live on the destination channel and protected by `manifest-urls`.

The rationale I wrote in #126 for the old order ("the version being added is counted by the same watermark pass that decides what to delete") was a nicety; it does not survive contact with a store that can be full. The comment is corrected rather than left describing an order the file no longer has.

## Also in this PR

`inputs.high-watermark` and `inputs.target-watermark` are dropped. `release.yml` declares no such `workflow_dispatch` inputs, so both always evaluated empty and fell through to the `vars.*` fallbacks — the same dead-reference bug removed from `build.yml` in #127.

## Blast radius of the original failure

None user-facing. Manifests, release notes and SVGs all reached the CDN before the failing step, so `qa` correctly serves `20260819000884`. The Linear steps also precede it. Only the VirusTotal submission was lost; re-dispatching `signed -> qa` after this merges will prune, then submit.

## Verification

- `release.yml` parses as YAML; step order is now prune → download → upload.
- Quota figures above are read from the failing run's own `overall_quotas` responses, not estimated.
- **Not exercised by CI** — `release.yml` is `workflow_dispatch`-only. Proof is the next promotion, which should log a prune before the upload.

## Worth fixing separately

`StreamElements/virustotal-monitor-action` reports `QuotaExceededError` as *"VirusTotal rate-limited the upload … If this recurs, lower rate-limit-per-minute to match the key"* — which points at the wrong remedy and cost real time here. That action should distinguish a storage-quota 429 (never retryable) from a rate-limit 429 (retryable), and fail fast on the former.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
