### PR TITLE
fix(ui): guard m_menuManager across Initialize's event pump (CORE-735)

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -605,9 +605,21 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 		RestoreState();
 	}
 
+	// Draining the posted-event queue runs arbitrary code while this
+	// Initialize() is still on the stack and m_initialized is still false:
+	// deferred deletes, frontend callbacks, and any modal dialog's own event
+	// loop. Nothing constructed above may be assumed live below this point.
 	QApplication::sendPostedEvents();
 
-	m_menuManager->Update();
+	// Guarded because of the pump above, not out of caution. Observed: OBS
+	// held OBSInit open in its modal update dialog for ~5 minutes, and by the
+	// time this line ran m_menuManager was null. The fault then landed inside
+	// UpdateInternal's own `if (!m_menu)` guard -- SYNC_ACCESS() locks a
+	// static mutex, so it touches no member, which makes that guard the first
+	// read through `this` and therefore the crash site rather than the
+	// protection it looks like.
+	if (m_menuManager)
+		m_menuManager->Update();
 
 	{
 		json11::Json::object eventProps;

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -139,6 +139,48 @@ static void check_c10_no_duplicate_handler_setcurrentprofile()
 	}
 }
 
+// --- Menu manager must not be dereferenced unguarded in Initialize().
+//
+// Initialize() calls QApplication::sendPostedEvents() a few lines above,
+// which runs deferred deletes, frontend callbacks and any modal dialog's own
+// event loop while Initialize() is still on the stack. Observed in the field:
+// OBS held OBSInit open in its modal update dialog for minutes, and by the
+// time the next line ran m_menuManager was null. UpdateInternal then faulted
+// on a null `this` at its own `if (!m_menu)` guard -- SYNC_ACCESS() locks a
+// static mutex and touches no member, so that guard is the first read through
+// `this`, which makes the null check the crash site instead of the
+// protection.
+//
+// Minidump, pid 47436:
+//   UpdateInternal+0x54  mov rcx,[rsi+18h]  rsi=0  ->  read of 0x18
+static void check_menu_manager_update_guarded()
+{
+	auto src = slurp(
+		"streamelements/StreamElementsGlobalStateManager.cpp");
+
+	// Every occurrence must be the guarded one. Counting both forms and
+	// comparing is what distinguishes them: the call sits on its own line
+	// under the guard, so a pattern anchored on the call alone matches the
+	// guarded form too and proves nothing.
+	std::regex any_call(R"(m_menuManager->Update\(\);)");
+	std::regex guarded(
+		R"(if \(m_menuManager\)[\s]*m_menuManager->Update\(\);)");
+
+	std::size_t total = count_matches(src, any_call);
+	std::size_t safe = count_matches(src, guarded);
+
+	check(total > 0,
+	      "Initialize() must still call m_menuManager->Update(); the invariant cannot be satisfied by deleting the call");
+
+	if (total != safe) {
+		std::fprintf(
+			stderr,
+			"FAIL: %zu of %zu m_menuManager->Update() call(s) lack an if (m_menuManager) guard\n",
+			total - safe, total);
+		++failures;
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -146,6 +188,7 @@ int main()
 	check_c5_cefparsejson_null_guarded();
 	check_c6_audio_encoder_bounds();
 	check_c10_no_duplicate_handler_setcurrentprofile();
+	check_menu_manager_update_guarded();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Fixes CORE-735

OBS crashed with an access violation while applying an update — 2026-08-20 16:17:42, OBS 32.2.0.

## Root cause, from the minidump

Not inferred. pid 47436, with the matching PDB:

```
UpdateInternal+0x54   mov rcx,qword ptr [rsi+18h]   ds:0000000000000018=????????
rsi = 0000000000000000
```

`UpdateInternal`'s prologue is `mov rsi,rcx`, so **`rsi` is `this`**. The method was called on a null pointer: `m_menuManager` was null when `Initialize()` reached `m_menuManager->Update()`.

Two things made this look like something else entirely:

**The fault lands inside the null check.** `SYNC_ACCESS()` locks a `static` recursive mutex, so it touches no member. The first read through `this` is `UpdateInternal`'s own `if (!m_menu)` guard, which compiles to `QPointer::operator bool` → `QWeakPointer::isNull` → `[rsi+0x18]`. So the guard *is* the crash site. That also explains why the earlier `QPointer<QMenu>` conversion didn't help — it fixed the menu's lifetime, and nothing there can survive a null `this`.

**`QApplication::sendPostedEvents()` runs three lines earlier.** It drains deferred deletes, frontend callbacks, and any modal dialog's event loop while `Initialize()` is still on the stack and `m_initialized` is still false. OBS held `OBSInit` open in its modal update dialog for about five minutes (process uptime at the dump: 4:41), so `OnFirstLoad` — and this `Initialize` — ran long after the main window was up.

## The fix

Guard the call site, with a comment tying it to the pump above so it isn't later removed as redundant.

## Regression gate

A source invariant rather than a behavioural test: the unit is welded to Qt and libobs, and the defect is a call-site shape.

It counts every `m_menuManager->Update()` and every guarded one and requires them equal. That detail matters — my first attempt anchored on `\n[ \t]*m_menuManager->Update\(\);`, which matches the *guarded* form too (the call sits on its own line under the `if`) and reported a failure against already-fixed code. It also asserts at least one call exists, so the invariant can't be satisfied by deleting the call.

Verified both directions locally:

```
with the guard removed:  FAIL: 1 of 1 m_menuManager->Update() call(s) lack an if (m_menuManager) guard
with the guard:          100% tests passed, 0 tests failed out of 2   (0.68s)
```

## What this does not do

**It does not explain what nulls `m_menuManager`.** I ruled out the obvious candidate rather than assuming it: a re-entrant `Shutdown()` can't be responsible, because it early-returns on `!m_initialized` and `m_initialized = true` is set at line 639 — *after* the crashing call at 610. Something else clears it. The guard is correct regardless and stops a crash on the update path today, but the underlying cause deserves its own investigation.

**No full build or real OBS run.** There is no obs-studio tree on this machine, so the standalone ctest suite is the only local gate; CI is the first full compile. `clang-format` is not installed here either — both edits follow the surrounding style, but `CI/check-format.sh` is the arbiter and hasn't seen them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
