### PR TITLE
fix(ui): stop Initialize taking its own menu manager from the singleton (CORE-735)

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -638,12 +638,20 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 			->trackEvent("se_live_initialized", eventProps, fields);
 	}
 
-	//QtPostTask([]() {
-		// Update visible state
-		StreamElementsGlobalStateManager::GetInstance()
-			->GetMenuManager()
-			->Update();
-	//});
+	// Update visible state.
+	//
+	// Through m_menuManager, not GetInstance()->GetMenuManager(): this is a
+	// member function and the member is right here. Going through the singleton
+	// is what crashed. GetInstance() lazily constructs when s_instance is not
+	// this instance, and a freshly constructed manager has every shared_ptr
+	// member null -- so ->Update() ran on a null StreamElementsMenuManager.
+	//
+	// Confirmed from two minidumps of the same fault: UpdateInternal entered
+	// with this == nullptr, while this->m_menuManager on the instance running
+	// Initialize() was non-null. Two different objects; the singleton returned
+	// the empty one.
+	if (m_menuManager)
+		m_menuManager->Update();
 
 	streamelements_updater_init();
 


### PR DESCRIPTION
Fixes CORE-735

**The guard in #134 protected the wrong call.** `Initialize()` calls `MenuManager::Update()` twice, and the crashing one is the second:

```cpp
//QtPostTask([]() {
    // Update visible state
    StreamElementsGlobalStateManager::GetInstance()
        ->GetMenuManager()
        ->Update();
//});
```

## How this was settled

Disassembling the faulting return address:

```asm
call GetInstance()                    ; not this->m_menuManager
mov  rbx, qword ptr [rax]             ; instance the singleton returned
mov  rcx, qword ptr [rbx+0C8h]        ; that instance's m_menuManager.get()
```

`GetInstance()` lazily constructs:

```cpp
if (!s_instance)
    s_instance = std::make_shared<StreamElementsGlobalStateManager>(Private());
```

So when `s_instance` is not the instance running `Initialize()`, this line builds a **brand-new manager with every `shared_ptr` member null**, then calls `->Update()` on the null `MenuManager`. Deterministic, and reproduced twice.

## Where the first diagnosis went wrong

Both minidumps show `UpdateInternal` entered with `this == nullptr`. I concluded `m_menuManager` was null and guarded it. Reading the object properly says otherwise:

| | |
|---|---|
| `this` for `Initialize()` | `0x1e68ddc2be0` |
| `this->m_menuManager` | `0x1e68dbb65a0` — **non-null** |
| `this` for `Update`/`UpdateInternal` | **NULL** |

Two different objects. Two mistakes produced the wrong answer: inferring the field was null from the null `this` without reading it, and then reading it at an address taken from the **Arg0 column of OBS's crash log** — which on x64 is a raw stack word, not an argument. The correct `this` came from unwinding to the frame and letting the PDB name the local.

## The fix

Use the member. `Initialize()` is a member function; `m_menuManager` is right there and non-null at that point. The dead `//QtPostTask(...)` wrapper goes with it.

The guard from #134 stays on the first call site — harmless, and the source invariant now counts **both** calls and requires both guarded. Verified locally both ways:

```
guarded:    100% tests passed, 0 failed out of 2
unguarded:  FAIL: 1 of 2 m_menuManager->Update() call(s) lack an if (m_menuManager) guard
```

## The larger point

A member function reached through the global singleton for its own member, and the singleton silently manufactured a half-built object rather than failing. `GetInstance()` lazily constructing turns every `GetInstance()->X()` in the codebase into the same latent landmine. That is a design problem, not a line-level one, and is being taken up as a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)