### PR TITLE
fix(ui): stop the shutdown double-delete of dock widgets (CORE-777)

### DIFF
--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -24,15 +24,33 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager()
 		     "[obs-streamelements-core]: destroying dock widget '%s'",
 		     pair.first.c_str());
 
-		m_parent->removeDockWidget(pair.second);
+		// QPointer, so a dock widget destroyed behind our back --
+		// by its QMainWindow parent, or by a deleteLater() posted
+		// from elsewhere -- reads back as null instead of dangling.
+		QPointer<QDockWidget> dock(pair.second);
 
-		// This causes a crash on shutdown, just delete below
-		// pair.second->deleteLater();
+		if (!dock)
+			continue;
 
-		// Drain event queue
-		QApplication::sendPostedEvents();
+		if (m_parent)
+			m_parent->removeDockWidget(dock);
 
-		delete pair.second;
+		// Deliberately NOT draining the event queue here (CORE-777).
+		// A QApplication::sendPostedEvents() at this point dispatches
+		// any DeferredDelete already posted for this very widget,
+		// destroying it, and the delete below then runs on an
+		// already-destructed object. That aborts inside Qt, where
+		// ~QObject deletes its QObjectData through a pure virtual
+		// destructor: the second pass finds the vtable degraded to
+		// QObjectData and lands in _purecall.
+		//
+		// Draining buys nothing anyway -- ~QObject discards the events
+		// posted to the object being destroyed.
+
+		if (!dock)
+			continue;
+
+		delete dock.data();
 	}
 
 	m_dockWidgets.clear();

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -181,6 +181,75 @@ static void check_menu_manager_update_guarded()
 	}
 }
 
+// --- CORE-777: ~StreamElementsWidgetManager must not drain the Qt event
+// queue while tearing down its dock widgets.
+//
+// The destructor used to call QApplication::sendPostedEvents() between
+// QMainWindow::removeDockWidget() and delete. That dispatches any
+// DeferredDelete already posted for the very widget about to be deleted,
+// so the delete lands on an already-destructed object and Qt aborts in
+// _purecall -- ~QObject deletes its QObjectData through a pure virtual
+// destructor, and on the second pass the vtable has degraded to
+// QObjectData, whose slot holds _purecall.
+//
+// Draining is unnecessary: ~QObject discards events posted to the object
+// being destroyed.
+static std::string strip_line_comments(const std::string &src)
+{
+	std::string out;
+	out.reserve(src.size());
+
+	for (std::size_t i = 0; i < src.size();) {
+		if (src[i] == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+			while (i < src.size() && src[i] != '\n')
+				++i;
+		} else {
+			out.push_back(src[i]);
+			++i;
+		}
+	}
+
+	return out;
+}
+
+static void check_widget_manager_dtor_does_not_drain_events()
+{
+	auto src = slurp("streamelements/StreamElementsWidgetManager.cpp");
+
+	// Isolate the destructor body: from its signature to the first
+	// closing brace in column 0. Scanning the whole file would trip over
+	// the deliberate drains in PushCentralWidget() and friends.
+	const std::string sig =
+		"StreamElementsWidgetManager::~StreamElementsWidgetManager()";
+
+	auto start = src.find(sig);
+	check(start != std::string::npos,
+	      "CORE-777: ~StreamElementsWidgetManager() not found -- update this invariant");
+	if (start == std::string::npos)
+		return;
+
+	auto end = src.find("\n}", start);
+	check(end != std::string::npos,
+	      "CORE-777: could not find the end of ~StreamElementsWidgetManager()");
+	if (end == std::string::npos)
+		return;
+
+	std::string body = src.substr(start, end - start);
+
+	// Comments are stripped first: the fix leaves a comment naming the
+	// call it must not make, and that must not satisfy the check either
+	// way round.
+	std::string code = strip_line_comments(body);
+
+	check(code.find("sendPostedEvents") == std::string::npos,
+	      "CORE-777: ~StreamElementsWidgetManager() must not call QApplication::sendPostedEvents() -- it turns a pending deleteLater() into a double delete");
+
+	// And the widget must be reached through a QPointer, so a dock
+	// destroyed behind our back reads back as null rather than dangling.
+	check(code.find("QPointer<QDockWidget>") != std::string::npos,
+	      "CORE-777: ~StreamElementsWidgetManager() must hold each dock widget in a QPointer before deleting it");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -189,6 +258,7 @@ int main()
 	check_c6_audio_encoder_bounds();
 	check_c10_no_duplicate_handler_setcurrentprofile();
 	check_menu_manager_update_guarded();
+	check_widget_manager_dtor_does_not_drain_events();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Fixes CORE-777

OBS aborted on shutdown with a pure virtual call. Found while verifying the CORE-735 fix locally — the update crash is gone, and this one was behind it.

```
obs_streamelements_core!handle_sigabrt
ucrtbase!abort
VCRUNTIME140!_purecall
Qt6Core!QObject::~QObject+0x876
Qt6Core!QObject::`scalar deleting destructor'
StreamElementsWidgetManager::~StreamElementsWidgetManager+0xc5
StreamElementsBrowserWidgetManager::~StreamElementsBrowserWidgetManager+0x19a
```

## Root cause

The destructor drained the Qt event queue between `removeDockWidget()` and `delete`:

```cpp
m_parent->removeDockWidget(pair.second);
QApplication::sendPostedEvents();   // <-- dispatches DeferredDelete for this widget
delete pair.second;                 // <-- double delete
```

`sendPostedEvents()` dispatches any `DeferredDelete` already posted for the very widget about to be deleted. The `delete` on the next line then runs on an already-destructed object, and Qt aborts: `~QObject` deletes its `QObjectData` through a **pure virtual destructor**, and on the second pass the vtable has degraded to `QObjectData`, whose slot holds `_purecall`.

## Evidence from the minidump

`sentry-minidump-50716-59356.dmp`, disassembled against our PDB:

* `+0xc5` is the return address of `call qword ptr [rax+18h]` with `edx=1` — the `delete pair.second`, **not** the `sendPostedEvents()` at `+0xaa`, which returned normally.
* The dock widget at `0x262'7904d2f0` has vptr `Qt6Core!QObject::'vftable'`, not `QDockWidget`'s — its derived destructors had already run.
* The vtable slot taken was therefore `QObject::'scalar deleting destructor'`, which calls `QObject::~QObject` directly, skipping `~QWidget` and `~QDockWidget`.
* Its `d_ptr` at `0x262'78eef450` has vptr `Qt6Core!QObjectData::'vftable'` — reachable only after `~QObjectPrivate` completed. `QObjectData::~QObjectData()` is pure virtual, so slot 0 is `_purecall`. That is the abort.
* `removeDockWidget()` on the preceding line succeeded, so the widget was alive going in. The drain is what killed it.

The OBS log for that session confirms the surroundings: shutdown is deep into OBS's own teardown (`Tried to call obs_frontend_get_main_window with no callbacks!`), the updater is running and pumping dialogs, and exactly one dock widget destruction was logged before the abort.

## Fix

Remove the drain, and hold each dock widget in a `QPointer` while tearing it down.

The drain was never needed: `~QObject` discards events posted to the object being destroyed, so a direct `delete` is safe on its own. The `QPointer` covers the remaining case — a dock destroyed behind our back, by its `QMainWindow` parent or by a `deleteLater()` posted elsewhere — which now reads back as null rather than dangling. `m_parent` is guarded too, since it is already a `QPointer`.

The commented-out `pair.second->deleteLater();` above it, with its `// This causes a crash on shutdown` note, was an earlier pass at this same bug: it swapped `deleteLater` for `delete` but left the drain in place.

## Relation to CORE-735

Same antipattern — pumping the Qt event loop in the middle of a lifecycle transition, running arbitrary code against a half-built or half-destroyed object. CORE-735 was a drain during `Initialize()`; this is a drain during destruction. Both feed CORE-757.

## Test

`tests/test_source_invariants.cpp` gains `check_widget_manager_dtor_does_not_drain_events()`, asserting on the destructor body only (the deliberate drains in `PushCentralWidget()` and friends are untouched) that it contains no `sendPostedEvents` and does hold a `QPointer<QDockWidget>`. Comments are stripped before the search, so the explanatory comment naming the call cannot satisfy or trip the check.

Verified in both directions locally — passes as committed, and fails with a named message when either half of the fix is reverted:

```
ctest --test-dir tests/build -C Release --output-on-failure
100% tests passed, 0 tests failed out of 2
```

CI does not run this suite yet, so that is a local gate. The plugin itself is not buildable on this machine (no obs-studio tree); the compile is proven by the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
