### PR TITLE
fix(lifecycle): don't pump the event queue during Initialize (CORE-786)

### DIFF
--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -122,6 +122,12 @@ void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 
 		blog(LOG_INFO, "[obs-streamelements-core]: initializing");
 
+		// This event is emitted from OBSBasic::OnFirstLoad(), which
+		// runs inside OBSBasic::OBSInit(). Start watching for the
+		// moment control actually reaches OBS's own event loop --
+		// dock widget deletion is gated on it (CORE-786).
+		StreamElementsBeginObsInitWatch();
+
 		// Initialize StreamElements plug-in
 		StreamElementsGlobalStateManager::GetInstance()->Initialize(
 			static_cast<QMainWindow *>(obs_frontend_get_main_window()));

--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -156,6 +156,7 @@ MODULE_EXPORT bool obs_module_load(void)
 // exit would leak. Only a close that beats `init done` is poison.
 //
 static std::atomic<bool> s_initializeCompleted(false);
+static std::atomic<bool> s_initializeInProgress(false);
 static std::atomic<bool> s_closedBeforeInitCompleted(false);
 static std::atomic<bool> s_closeWatcherInstalled(false);
 
@@ -181,6 +182,42 @@ bool SEIsUiTeardownSafe()
 void SENoteInitializeCompleted()
 {
 	s_initializeCompleted.store(true);
+}
+
+//
+// Pumping the event queue while Initialize() is on the stack is what creates
+// the nesting: it delivers the update thread's queued close(), so
+// OBSBasic::closeEvent() -> OnEvent(EXIT) runs INSIDE the FINISHED_LOADING
+// dispatch. OBSStudioAPI::on_event() iterates `callbacks` with the size
+// captured once, every plug-in deregisters during the nested pass, and the
+// outer loop then indexes past the end of a shrunken vector and calls through
+// garbage -- an AV at on_event+0x4c with no plug-in frames on the stack.
+//
+// Gating the pump on the caught-close flag was not enough, and could not be:
+// that flag is only set while the close is being delivered, by the very pump
+// that delivers it. The pump has to be off for the whole of Initialize().
+//
+// Cost: the central-widget sizing hack in PushCentralWidget() /
+// DestroyCurrentCentralWidget() and the dock geometry save/restore rely on
+// draining to settle. Without it a dock may be sized wrong at startup. That is
+// cosmetic, and confined to initialization.
+//
+bool SEIsEventPumpAllowed()
+{
+	return !s_initializeInProgress.load() && SEIsUiTeardownSafe();
+}
+
+namespace {
+struct StreamElementsInitializeScope {
+	StreamElementsInitializeScope()
+	{
+		s_initializeInProgress.store(true);
+	}
+	~StreamElementsInitializeScope()
+	{
+		s_initializeInProgress.store(false);
+	}
+};
 }
 
 class StreamElementsObsCloseWatcher : public QObject {
@@ -236,10 +273,17 @@ void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 
 		blog(LOG_INFO, "[obs-streamelements-core]: initializing");
 
-		// Initialize StreamElements plug-in
-		StreamElementsGlobalStateManager::GetInstance()->Initialize(
-			static_cast<QMainWindow *>(
-				obs_frontend_get_main_window()));
+		// Initialize StreamElements plug-in.
+		//
+		// Scoped so that no event pump can run while this is on the
+		// stack; see SEIsEventPumpAllowed() above.
+		{
+			StreamElementsInitializeScope initializeScope;
+
+			StreamElementsGlobalStateManager::GetInstance()
+				->Initialize(static_cast<QMainWindow *>(
+					obs_frontend_get_main_window()));
+		}
 
 		blog(LOG_INFO, "[obs-streamelements-core]: init done");
 		break;

--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 #include "json11/json11.hpp"
 #include "obs-websocket-api/obs-websocket-api.h"
@@ -110,45 +111,89 @@ MODULE_EXPORT bool obs_module_load(void)
 	return true;
 }
 
+//
+// OBS emits OBS_FRONTEND_EVENT_FINISHED_LOADING from OBSBasic::OnFirstLoad(),
+// which runs INSIDE OBSBasic::OBSInit(). Initializing from that callback puts
+// our entire object hierarchy on OBSInit's stack, and if the user is held on
+// OBS's modal update dialog, OBS can emit FINISHED_LOADING and later EXIT from
+// two separate on_event() calls without ever reaching its own event loop. Our
+// Initialize() then stalls in an event pump, resumes minutes later, builds
+// widgets into a main window OBS is already dismantling, and teardown runs
+// against a half-built world with obs_frontend_get_main_window() already null.
+//
+// So: do not initialize from the callback. Wait until control has demonstrably
+// reached OBS's event loop, then initialize. If EXIT arrives first, never
+// initialize at all -- there is nothing to build for a session that is over
+// before it began (CORE-786).
+//
+static std::atomic<bool> s_isRunning(false);
+static std::atomic<bool> s_didInitialize(false);
+
+static void StreamElementsDeferredInitialize()
+{
+	if (!s_isRunning.load()) {
+		blog(LOG_INFO,
+		     "[obs-streamelements-core]: OBS exited before it finished initializing; skipping plug-in initialization");
+		return;
+	}
+
+	if (!IsObsInitFinished()) {
+		QtDelayTask([]() -> void { StreamElementsDeferredInitialize(); },
+			    250);
+		return;
+	}
+
+	auto mainWindow = static_cast<QMainWindow *>(
+		obs_frontend_get_main_window());
+
+	if (!mainWindow) {
+		blog(LOG_ERROR,
+		     "[obs-streamelements-core]: no OBS main window; skipping plug-in initialization");
+		return;
+	}
+
+	blog(LOG_INFO, "[obs-streamelements-core]: initializing");
+
+	s_didInitialize.store(true);
+
+	StreamElementsGlobalStateManager::GetInstance()->Initialize(mainWindow);
+
+	blog(LOG_INFO, "[obs-streamelements-core]: init done");
+}
+
 void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 {
 	SEAsyncCallContextMarker asyncMarker(__FILE__, __LINE__);
 
-	static bool isRunning = true;
-
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
-		isRunning = true;
+		s_isRunning.store(true);
 
-		blog(LOG_INFO, "[obs-streamelements-core]: initializing");
+		blog(LOG_INFO,
+		     "[obs-streamelements-core]: waiting for OBS to finish initializing");
 
-		// This event is emitted from OBSBasic::OnFirstLoad(), which
-		// runs inside OBSBasic::OBSInit(). Start watching for the
-		// moment control actually reaches OBS's own event loop --
-		// dock widget deletion is gated on it (CORE-786).
 		StreamElementsBeginObsInitWatch();
 
-		// Initialize StreamElements plug-in
-		StreamElementsGlobalStateManager::GetInstance()->Initialize(
-			static_cast<QMainWindow *>(obs_frontend_get_main_window()));
-
-		blog(LOG_INFO, "[obs-streamelements-core]: init done");
+		StreamElementsDeferredInitialize();
 		break;
 	case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
 	case OBS_FRONTEND_EVENT_EXIT:
-		if (!isRunning)
+		if (!s_isRunning.exchange(false))
 			return;
-
-		isRunning = false;
 
 		obs_frontend_remove_event_callback(handle_obs_frontend_event,
 						   nullptr);
 
+		if (!s_didInitialize.load()) {
+			blog(LOG_INFO,
+			     "[obs-streamelements-core]: shutting down before initialization completed; nothing to tear down");
+			StreamElementsGlobalStateManager::Destroy();
+			break;
+		}
+
 		// Shutdown StreamElements plug-in
 		blog(LOG_INFO, "[obs-streamelements-core]: shutting down");
 
-		//StreamElementsGlobalStateManager::GetInstance()
-		//	->Shutdown();
 		StreamElementsGlobalStateManager::Destroy();
 		break;
 	default:

--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -255,8 +255,18 @@ void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 		// `init done` means the same thing.
 		NoteObsCloseRequested("OBS_FRONTEND_EVENT_EXIT");
 
-		obs_frontend_remove_event_callback(handle_obs_frontend_event,
-						   nullptr);
+		// OBSStudioAPI::on_event() iterates `callbacks` with the size
+		// captured once, and obs_frontend_remove_event_callback()
+		// erases from that same vector. When EXIT is dispatched from
+		// inside another on_event() -- which is what the update-thread
+		// race produces -- removing here shrinks the vector under the
+		// outer loop, which then indexes past the end and calls through
+		// garbage. Leave the callback registered; `isRunning` above
+		// already makes any further event a no-op (CORE-786).
+		if (SEIsUiTeardownSafe()) {
+			obs_frontend_remove_event_callback(
+				handle_obs_frontend_event, nullptr);
+		}
 
 		if (!SEIsUiTeardownSafe()) {
 			blog(LOG_WARNING,

--- a/obs-streamelements-core-plugin.cpp
+++ b/obs-streamelements-core-plugin.cpp
@@ -12,6 +12,9 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <QMainWindow>
+#include <QObject>
+#include <QEvent>
 
 #include "json11/json11.hpp"
 #include "obs-websocket-api/obs-websocket-api.h"
@@ -112,82 +115,158 @@ MODULE_EXPORT bool obs_module_load(void)
 }
 
 //
-// OBS emits OBS_FRONTEND_EVENT_FINISHED_LOADING from OBSBasic::OnFirstLoad(),
-// which runs INSIDE OBSBasic::OBSInit(). Initializing from that callback puts
-// our entire object hierarchy on OBSInit's stack, and if the user is held on
-// OBS's modal update dialog, OBS can emit FINISHED_LOADING and later EXIT from
-// two separate on_event() calls without ever reaching its own event loop. Our
-// Initialize() then stalls in an event pump, resumes minutes later, builds
-// widgets into a main window OBS is already dismantling, and teardown runs
-// against a half-built world with obs_frontend_get_main_window() already null.
+// ---------------------------------------------------------------------------
+// The OBS update-thread race (CORE-786)
+// ---------------------------------------------------------------------------
 //
-// So: do not initialize from the callback. Wait until control has demonstrably
-// reached OBS's event loop, then initialize. If EXIT arrives first, never
-// initialize at all -- there is nothing to build for a session that is over
-// before it began (CORE-786).
+// OBSBasic::OBSInit() spawns the update checker BEFORE it tells us the UI is
+// ready, and the two are not ordered with respect to each other:
 //
-static std::atomic<bool> s_isRunning(false);
-static std::atomic<bool> s_didInitialize(false);
+//   OBSBasic.cpp:1307   TimedCheckForUpdates() -> new AutoUpdateThread; start()
+//   OBSBasic.cpp:1371   OnFirstLoad()          -> FINISHED_LOADING
+//
+// AutoUpdateThread then reaches back onto the main thread twice:
+//
+//   1. queryUpdate() does invokeMethod(this, "queryUpdateSlot",
+//      Qt::BlockingQueuedConnection), and `this` is the QThread OBJECT, which
+//      lives in the main thread. So the update dialog's exec() -- a nested,
+//      modal event loop -- runs on the main thread, dispatched by whichever
+//      event pump runs next. That pump is frequently one of ours, inside
+//      Initialize().
+//
+//   2. After launching the updater, run() finishes with
+//      invokeMethod(App()->GetMainWindow(), "close"), queued. The next pump --
+//      again, often ours -- delivers it, so OBSBasic::close() -> closeEvent()
+//      -> OBS_FRONTEND_EVENT_EXIT all run NESTED INSIDE our Initialize().
+//
+// We are then asked to tear down an object graph we are still building. Every
+// crash chased under this issue was a destructor touching something
+// Initialize() had just created: docks built at 02:48:17, destroyed at
+// 02:48:20, `init done` never reached.
+//
+// Detection: an event filter on the OBS main window watching QEvent::Close.
+// Filters on a widget run before that widget's own closeEvent(), and
+// closeEvent() is what fires EXIT -- so the flag is set before teardown
+// begins. QEvent::Close is the correct signal: the queued call arrives as a
+// private QMetaCallEvent carrying no readable method name, so it cannot be
+// told apart from any other invokeMethod on the main window.
+//
+// The flag is deliberately narrow. A close AFTER Initialize() completed is an
+// ordinary shutdown and must behave exactly as it always has, or every normal
+// exit would leak. Only a close that beats `init done` is poison.
+//
+static std::atomic<bool> s_initializeCompleted(false);
+static std::atomic<bool> s_closedBeforeInitCompleted(false);
+static std::atomic<bool> s_closeWatcherInstalled(false);
 
-static void StreamElementsDeferredInitialize()
+static void NoteObsCloseRequested(const char *source)
 {
-	if (!s_isRunning.load()) {
-		blog(LOG_INFO,
-		     "[obs-streamelements-core]: OBS exited before it finished initializing; skipping plug-in initialization");
+	if (s_initializeCompleted.load())
+		return; // ordinary shutdown
+
+	if (s_closedBeforeInitCompleted.exchange(true))
 		return;
-	}
 
-	if (!IsObsInitFinished()) {
-		QtDelayTask([]() -> void { StreamElementsDeferredInitialize(); },
-			    250);
+	blog(LOG_WARNING,
+	     "[obs-streamelements-core]: OBS was asked to close before initialization completed (%s); UI teardown will be suppressed",
+	     source);
+}
+
+// Declared in StreamElementsUtils.hpp; called from every UI teardown site.
+bool SEIsUiTeardownSafe()
+{
+	return !s_closedBeforeInitCompleted.load();
+}
+
+void SENoteInitializeCompleted()
+{
+	s_initializeCompleted.store(true);
+}
+
+class StreamElementsObsCloseWatcher : public QObject {
+public:
+	StreamElementsObsCloseWatcher(QObject *parent) : QObject(parent) {}
+
+protected:
+	bool eventFilter(QObject *watched, QEvent *event) override
+	{
+		if (event->type() == QEvent::Close)
+			NoteObsCloseRequested("QEvent::Close");
+
+		// Observe only. Never consume: OBS must close exactly as it
+		// would have without us.
+		return QObject::eventFilter(watched, event);
+	}
+};
+
+static void InstallObsCloseWatcher()
+{
+	if (s_closeWatcherInstalled.load())
 		return;
-	}
 
-	auto mainWindow = static_cast<QMainWindow *>(
-		obs_frontend_get_main_window());
+	auto mainWindow =
+		static_cast<QMainWindow *>(obs_frontend_get_main_window());
 
-	if (!mainWindow) {
-		blog(LOG_ERROR,
-		     "[obs-streamelements-core]: no OBS main window; skipping plug-in initialization");
-		return;
-	}
+	if (!mainWindow)
+		return; // not up yet; the caller tries again later
 
-	blog(LOG_INFO, "[obs-streamelements-core]: initializing");
+	s_closeWatcherInstalled.store(true);
 
-	s_didInitialize.store(true);
+	// Parented to the main window so it dies with it.
+	mainWindow->installEventFilter(
+		new StreamElementsObsCloseWatcher(mainWindow));
 
-	StreamElementsGlobalStateManager::GetInstance()->Initialize(mainWindow);
-
-	blog(LOG_INFO, "[obs-streamelements-core]: init done");
+	blog(LOG_INFO,
+	     "[obs-streamelements-core]: watching the OBS main window for close");
 }
 
 void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 {
 	SEAsyncCallContextMarker asyncMarker(__FILE__, __LINE__);
 
+	static bool isRunning = true;
+
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
-		s_isRunning.store(true);
+		isRunning = true;
 
-		blog(LOG_INFO,
-		     "[obs-streamelements-core]: waiting for OBS to finish initializing");
+		// Belt and braces: obs_module_post_load() usually gets this,
+		// but the main window certainly exists by now.
+		InstallObsCloseWatcher();
 
-		StreamElementsBeginObsInitWatch();
+		blog(LOG_INFO, "[obs-streamelements-core]: initializing");
 
-		StreamElementsDeferredInitialize();
+		// Initialize StreamElements plug-in
+		StreamElementsGlobalStateManager::GetInstance()->Initialize(
+			static_cast<QMainWindow *>(
+				obs_frontend_get_main_window()));
+
+		blog(LOG_INFO, "[obs-streamelements-core]: init done");
 		break;
 	case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
 	case OBS_FRONTEND_EVENT_EXIT:
-		if (!s_isRunning.exchange(false))
+		if (!isRunning)
 			return;
+
+		isRunning = false;
+
+		// Second, independent trigger: a quit path that never sends
+		// QEvent::Close still reaches here, and EXIT arriving before
+		// `init done` means the same thing.
+		NoteObsCloseRequested("OBS_FRONTEND_EVENT_EXIT");
 
 		obs_frontend_remove_event_callback(handle_obs_frontend_event,
 						   nullptr);
 
-		if (!s_didInitialize.load()) {
-			blog(LOG_INFO,
-			     "[obs-streamelements-core]: shutting down before initialization completed; nothing to tear down");
-			StreamElementsGlobalStateManager::Destroy();
+		if (!SEIsUiTeardownSafe()) {
+			blog(LOG_WARNING,
+			     "[obs-streamelements-core]: leaking plug-in state rather than tearing down a half-built object graph");
+
+			// Running the destructors is what corrupts the widget
+			// tree, so do not run them at all. The process is
+			// exiting and about to be replaced by the updater; a
+			// leak is strictly better than a crash.
+			StreamElementsGlobalStateManager::Leak();
 			break;
 		}
 
@@ -204,6 +283,11 @@ void handle_obs_frontend_event(enum obs_frontend_event event, void *data)
 MODULE_EXPORT void obs_module_post_load(void)
 {
 #if ENABLE_PLUGIN
+	// Earliest point the main window may exist. The update thread can in
+	// principle prompt before FINISHED_LOADING, so install as early as
+	// possible; the handler installs again if this was too early.
+	InstallObsCloseWatcher();
+
 	obs_frontend_add_event_callback(handle_obs_frontend_event, nullptr);
 
 	/*

--- a/streamelements/StreamElementsBrowserWidget.cpp
+++ b/streamelements/StreamElementsBrowserWidget.cpp
@@ -623,18 +623,24 @@ void StreamElementsBrowserWidget::RemoveVideoCompositionView()
 	if (!m_activeVideoCompositionViewWidget)
 		return;
 
+	// Both members are QPointer, so a widget Qt already destroyed -- these
+	// are children of this widget and of each other -- reads back null and
+	// is not deleted a second time (CORE-786). Destroy() still has to run
+	// deterministically, which is why these are deleted by hand rather than
+	// left to the parent.
 	m_activeVideoCompositionViewWidget->hide();
 	m_activeVideoCompositionViewWidget->Destroy();
 	m_activeVideoCompositionViewWidget->setParent(nullptr);
-	delete m_activeVideoCompositionViewWidget;
-	// m_activeVideoCompositionViewWidget->deleteLater();
+	delete m_activeVideoCompositionViewWidget.data();
 
 	m_activeVideoCompositionViewWidget = nullptr;
 
-	m_activeVideoCompositionViewWidgetContainer->hide();
-	m_activeVideoCompositionViewWidgetContainer->setParent(nullptr);
-	delete m_activeVideoCompositionViewWidgetContainer;
-	//m_activeVideoCompositionViewWidgetContainer->deleteLater();
+	if (m_activeVideoCompositionViewWidgetContainer) {
+		m_activeVideoCompositionViewWidgetContainer->hide();
+		m_activeVideoCompositionViewWidgetContainer->setParent(
+			nullptr);
+		delete m_activeVideoCompositionViewWidgetContainer.data();
+	}
 
 	m_activeVideoCompositionViewWidgetContainer = nullptr;
 }

--- a/streamelements/StreamElementsBrowserWidget.hpp
+++ b/streamelements/StreamElementsBrowserWidget.hpp
@@ -6,6 +6,7 @@
 #include "StreamElementsWebsocketApiServer.hpp"
 
 #include <QWidget>
+#include <QPointer>
 #include <QHideEvent>
 #include <QCloseEvent>
 
@@ -49,9 +50,12 @@ private:
 
 	bool m_isIncognito = false;
 
-	QWidget *m_activeVideoCompositionViewWidgetContainer = nullptr;
-	StreamElementsVideoCompositionViewWidget
-		*m_activeVideoCompositionViewWidget = nullptr;
+	// QPointer: both are Qt children of this widget, so Qt may destroy them
+	// first during teardown. RemoveVideoCompositionView() deletes them by
+	// hand and must not do so twice (CORE-786).
+	QPointer<QWidget> m_activeVideoCompositionViewWidgetContainer = nullptr;
+	QPointer<StreamElementsVideoCompositionViewWidget>
+		m_activeVideoCompositionViewWidget = nullptr;
 
 	bool m_isDestroyed = false;
 

--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -21,8 +21,13 @@ StreamElementsBrowserWidgetManager::StreamElementsBrowserWidgetManager(
 
 StreamElementsBrowserWidgetManager::~StreamElementsBrowserWidgetManager()
 {
-	// NOP
+	// This runs before the base destructor deletes any dock, so on the OBS
+	// teardown path every entry here may already have been destroyed by Qt
+	// along with its dock. QPointer makes that visible (CORE-786).
 	for (auto kv : m_browserWidgets) {
+		if (!kv.second)
+			continue;
+
 		kv.second->RemoveVideoCompositionView();
 	}
 
@@ -349,6 +354,10 @@ bool StreamElementsBrowserWidgetManager::SetWidgetUrlById(const char *const id,
 	if (!m_browserWidgets.count(id))
 		return false;
 
+	// Null when Qt destroyed the widget with its dock (CORE-786).
+	if (!m_browserWidgets[id])
+		return false;
+
 	m_browserWidgets[id]->BrowserLoadInitialPage(url);
 
 	return true;
@@ -369,7 +378,10 @@ bool StreamElementsBrowserWidgetManager::RemoveDockWidget(const char *const id)
 
 	if (StreamElementsWidgetManager::RemoveDockWidget(id)) {
 		if (m_browserWidgets.count(id)) {
-			m_browserWidgets[id]->RemoveVideoCompositionView();
+			if (m_browserWidgets[id])
+				m_browserWidgets[id]
+					->RemoveVideoCompositionView();
+
 			m_browserWidgets.erase(id);
 
 			return true;
@@ -397,6 +409,9 @@ StreamElementsBrowserWidgetManager::GetDockBrowserWidgetInfo(
 		return nullptr;
 
 	auto browser = m_browserWidgets[id];
+
+	if (!browser)
+		return nullptr;
 
 	StreamElementsBrowserWidgetManager::DockWidgetInfo *baseInfo =
 		GetDockWidgetInfo(id);

--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -603,10 +603,10 @@ void StreamElementsBrowserWidgetManager::DeserializeDockingWidgets(
 						mainWindow()->splitDockWidget(prev, curr, Qt::Vertical);
 					}
 
-					QApplication::sendPostedEvents();
+					SEDrainEventQueue();
 					prev->setMinimumSize(idToMinSizeMap[dockIds[i - 1]]);
 					prev->widget()->setMinimumSize(idToMinSizeMap[dockIds[i - 1]]);
-					QApplication::sendPostedEvents();
+					SEDrainEventQueue();
 				}
 				*/
 			}
@@ -982,7 +982,7 @@ bool StreamElementsBrowserWidgetManager::InsertDockingWidgetRelativeToId(
 		}
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	return true;
 }
@@ -1023,7 +1023,7 @@ void StreamElementsBrowserWidgetManager::HideNotificationBar()
 	if (m_notificationBarToolBar) {
 		m_notificationBarToolBar->setVisible(false);
 
-		QApplication::sendPostedEvents();
+		SEDrainEventQueue();
 
 		mainWindow()->removeToolBar(m_notificationBarToolBar);
 

--- a/streamelements/StreamElementsBrowserWidgetManager.hpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.hpp
@@ -6,6 +6,8 @@
 #include <map>
 #include <string>
 
+#include <QPointer>
+
 class StreamElementsBrowserWidgetManager
 	:
 	protected StreamElementsWidgetManager
@@ -155,7 +157,11 @@ public:
 
 
 private:
-	std::map<std::string, StreamElementsBrowserWidget*> m_browserWidgets;
+	// QPointer for the same reason as m_dockWidgets (CORE-786): each browser
+	// widget is a child of its dock, so it dies with the dock, and this map
+	// is not notified.
+	std::map<std::string, QPointer<StreamElementsBrowserWidget>>
+		m_browserWidgets;
 
 	QPointer<QToolBar> m_notificationBarToolBar = nullptr;
 	QPointer<StreamElementsBrowserWidget> m_notificationBarBrowserWidget = nullptr;

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -336,6 +336,18 @@ void StreamElementsGlobalStateManager::Destroy()
 	s_instance = nullptr;
 }
 
+void StreamElementsGlobalStateManager::Leak()
+{
+	// Heap-allocated and never freed, so the refcount never reaches zero
+	// and no destructor runs -- not now, and not during static destruction
+	// at process exit either.
+	if (s_instance.get())
+		new std::shared_ptr<StreamElementsGlobalStateManager>(
+			s_instance);
+
+	s_instance = nullptr;
+}
+
 bool StreamElementsGlobalStateManager::IsInstanceAvailable()
 {
 	if (!s_instance.get())
@@ -657,6 +669,10 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 
 	m_persistStateEnabled = true;
 	m_initialized = true;
+
+	// From here on an OBS close is an ordinary close, and teardown runs
+	// normally (CORE-786).
+	SENoteInitializeCompleted();
 
 	obs_frontend_add_event_callback(handle_obs_frontend_event, nullptr);
 }

--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -609,7 +609,7 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 	// Initialize() is still on the stack and m_initialized is still false:
 	// deferred deletes, frontend callbacks, and any modal dialog's own event
 	// loop. Nothing constructed above may be assumed live below this point.
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	// Guarded because of the pump above, not out of caution. Observed: OBS
 	// held OBSInit open in its modal update dialog for ~5 minutes, and by the
@@ -741,7 +741,7 @@ void StreamElementsGlobalStateManager::Shutdown()
 
 	StreamElementsConfig::Destroy();
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	m_initialized = false;
 }
@@ -1312,7 +1312,7 @@ bool StreamElementsGlobalStateManager::DeserializeModalDialog(
 
 			dialog->setFixedSize(width, height);
 
-			QApplication::sendPostedEvents();
+			SEDrainEventQueue();
 
 			dialog->setMinimumSize(width, height);
 			dialog->setMaximumSize(savedMaxSize);
@@ -1535,7 +1535,7 @@ std::shared_ptr<std::promise<CefRefPtr<CefValue>>> StreamElementsGlobalStateMana
 
 			dialog->setFixedSize(width, height);
 
-			QApplication::sendPostedEvents();
+			SEDrainEventQueue();
 
 			dialog->setMinimumSize(width, height);
 			dialog->setMaximumSize(savedMaxSize);

--- a/streamelements/StreamElementsGlobalStateManager.hpp
+++ b/streamelements/StreamElementsGlobalStateManager.hpp
@@ -85,6 +85,12 @@ public:
 public:
 	static std::shared_ptr<StreamElementsGlobalStateManager> GetInstance();
 	static void Destroy();
+
+	// Releases the singleton WITHOUT running any destructor, by parking a
+	// reference that is never freed. Used when OBS asked to close before
+	// initialization completed: the object graph is half-built and running
+	// its destructors corrupts the widget tree (CORE-786).
+	static void Leak();
 	static bool IsInstanceAvailable();
 
 public:

--- a/streamelements/StreamElementsNativeOBSControlsManager.cpp
+++ b/streamelements/StreamElementsNativeOBSControlsManager.cpp
@@ -330,7 +330,7 @@ void StreamElementsNativeOBSControlsManager::HidePreviewTitleBar()
 
 	m_previewTitleContainer->hide();
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	if (m_previewTitleBrowser) {
 		m_previewTitleLayout->removeWidget(m_previewTitleBrowser);

--- a/streamelements/StreamElementsReportIssueDialog.cpp
+++ b/streamelements/StreamElementsReportIssueDialog.cpp
@@ -552,7 +552,7 @@ void StreamElementsReportIssueDialog::accept()
 		if (!dialog.cancelled()) {
 			dialog.setMessage(obs_module_text(
 				"StreamElements.ReportIssue.Progress.Message.CollectingCpuBenchmark"));
-			qApp->sendPostedEvents();
+			SEDrainEventQueue();
 
 			cpu_benchmark = GetCpuCoreBenchmark(
 				CPU_BENCH_TOTAL, cpu_bench_delta);
@@ -561,7 +561,7 @@ void StreamElementsReportIssueDialog::accept()
 		if (!dialog.cancelled()) {
 			dialog.setMessage(obs_module_text(
 				"StreamElements.ReportIssue.Progress.Message.CollectingSysInfo"));
-			qApp->sendPostedEvents();
+			SEDrainEventQueue();
 
 			{
 				CefRefPtr<CefValue> basicInfo =

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -413,12 +413,11 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 
 void SEDrainEventQueue()
 {
-	// Once OBS has been asked to close before we finished initializing,
-	// every further pump dispatches events into a world that is being torn
-	// down -- deferred deletes, queued calls into managers we have already
-	// leaked, and more of Initialize()'s own UI work. Stop pumping
-	// (CORE-786).
-	if (!SEIsUiTeardownSafe())
+	// Not while Initialize() is on the stack -- pumping there delivers the
+	// update thread's queued close() and nests OBS's EXIT dispatch inside
+	// its FINISHED_LOADING dispatch -- and not once a close has been caught,
+	// when every further dispatch feeds a world being torn down (CORE-786).
+	if (!SEIsEventPumpAllowed())
 		return;
 
 	QApplication::sendPostedEvents();

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -411,50 +411,9 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 
 /* ========================================================= */
 
-// See StreamElementsUtils.hpp for why this exists (CORE-786).
-static std::atomic<int> s_eventPumpDepth(0);
-static std::atomic<bool> s_obsInitFinished(false);
-static std::atomic<bool> s_obsInitWatchStarted(false);
-
 void SEDrainEventQueue()
 {
-	++s_eventPumpDepth;
-
 	QApplication::sendPostedEvents();
-
-	--s_eventPumpDepth;
-}
-
-bool IsObsInitFinished()
-{
-	return s_obsInitFinished.load();
-}
-
-static void ObsInitWatchTick(int consecutiveClean)
-{
-	if (s_obsInitFinished.load())
-		return;
-
-	// A timer task can be delivered from a nested loop just as easily as
-	// from the outermost one, so "this ran" proves nothing on its own.
-	// These two conditions are what distinguish OBS's loop from the loops
-	// we know about.
-	const bool clean = s_eventPumpDepth.load() == 0 &&
-			   QApplication::activeModalWidget() == nullptr &&
-			   QApplication::activePopupWidget() == nullptr;
-
-	const int next = clean ? consecutiveClean + 1 : 0;
-
-	if (next >= 2) {
-		s_obsInitFinished.store(true);
-
-		blog(LOG_INFO,
-		     "[obs-streamelements-core]: OBS init finished; dock widget deletion enabled");
-
-		return;
-	}
-
-	QtDelayTask([next]() -> void { ObsInitWatchTick(next); }, 250);
 }
 
 void SEDeleteDockWidgetWhenSafe(QPointer<QDockWidget> dock, const char *id,
@@ -463,9 +422,9 @@ void SEDeleteDockWidgetWhenSafe(QPointer<QDockWidget> dock, const char *id,
 	if (!dock)
 		return;
 
-	if (!IsObsInitFinished()) {
+	if (!SEIsUiTeardownSafe()) {
 		blog(LOG_WARNING,
-		     "[obs-streamelements-core]: leaking dock widget '%s': OBS has not finished initializing, deleting it now would corrupt the widget tree",
+		     "[obs-streamelements-core]: leaking dock widget '%s': OBS was asked to close before initialization completed, deleting it now would corrupt the widget tree",
 		     id ? id : "(unnamed)");
 
 		// Detach from the main window so OBS's own teardown does not
@@ -479,14 +438,6 @@ void SEDeleteDockWidgetWhenSafe(QPointer<QDockWidget> dock, const char *id,
 		dock->deleteLater();
 	else
 		delete dock.data();
-}
-
-void StreamElementsBeginObsInitWatch()
-{
-	if (s_obsInitWatchStarted.exchange(true))
-		return;
-
-	QtDelayTask([]() -> void { ObsInitWatchTick(0); }, 250);
 }
 
 /* ========================================================= */

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -409,6 +409,64 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 	}
 }
 
+/* ========================================================= */
+
+// See StreamElementsUtils.hpp for why this exists (CORE-786).
+static std::atomic<int> s_eventPumpDepth(0);
+static std::atomic<bool> s_obsInitFinished(false);
+static std::atomic<bool> s_obsInitWatchStarted(false);
+
+void SEDrainEventQueue()
+{
+	++s_eventPumpDepth;
+
+	QApplication::sendPostedEvents();
+
+	--s_eventPumpDepth;
+}
+
+bool IsObsInitFinished()
+{
+	return s_obsInitFinished.load();
+}
+
+static void ObsInitWatchTick(int consecutiveClean)
+{
+	if (s_obsInitFinished.load())
+		return;
+
+	// A timer task can be delivered from a nested loop just as easily as
+	// from the outermost one, so "this ran" proves nothing on its own.
+	// These two conditions are what distinguish OBS's loop from the loops
+	// we know about.
+	const bool clean = s_eventPumpDepth.load() == 0 &&
+			   QApplication::activeModalWidget() == nullptr &&
+			   QApplication::activePopupWidget() == nullptr;
+
+	const int next = clean ? consecutiveClean + 1 : 0;
+
+	if (next >= 2) {
+		s_obsInitFinished.store(true);
+
+		blog(LOG_INFO,
+		     "[obs-streamelements-core]: OBS init finished; dock widget deletion enabled");
+
+		return;
+	}
+
+	QtDelayTask([next]() -> void { ObsInitWatchTick(next); }, 250);
+}
+
+void StreamElementsBeginObsInitWatch()
+{
+	if (s_obsInitWatchStarted.exchange(true))
+		return;
+
+	QtDelayTask([]() -> void { ObsInitWatchTick(0); }, 250);
+}
+
+/* ========================================================= */
+
 std::string DockWidgetAreaToString(const Qt::DockWidgetArea area)
 {
 	switch (area) {

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -413,6 +413,14 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 
 void SEDrainEventQueue()
 {
+	// Once OBS has been asked to close before we finished initializing,
+	// every further pump dispatches events into a world that is being torn
+	// down -- deferred deletes, queued calls into managers we have already
+	// leaked, and more of Initialize()'s own UI work. Stop pumping
+	// (CORE-786).
+	if (!SEIsUiTeardownSafe())
+		return;
+
 	QApplication::sendPostedEvents();
 }
 

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -457,6 +457,30 @@ static void ObsInitWatchTick(int consecutiveClean)
 	QtDelayTask([next]() -> void { ObsInitWatchTick(next); }, 250);
 }
 
+void SEDeleteDockWidgetWhenSafe(QPointer<QDockWidget> dock, const char *id,
+				bool useDeleteLater)
+{
+	if (!dock)
+		return;
+
+	if (!IsObsInitFinished()) {
+		blog(LOG_WARNING,
+		     "[obs-streamelements-core]: leaking dock widget '%s': OBS has not finished initializing, deleting it now would corrupt the widget tree",
+		     id ? id : "(unnamed)");
+
+		// Detach from the main window so OBS's own teardown does not
+		// walk into it later.
+		dock->setParent(nullptr);
+
+		return;
+	}
+
+	if (useDeleteLater)
+		dock->deleteLater();
+	else
+		delete dock.data();
+}
+
 void StreamElementsBeginObsInitWatch()
 {
 	if (s_obsInitWatchStarted.exchange(true))

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -228,31 +228,22 @@ std::future<void> __QtDelayTask_Impl(std::function<void()> task, int delayMs, co
 /* ========================================================= */
 
 //
-// OBS init gate (CORE-786).
+// UI teardown gate (CORE-786). Defined in obs-streamelements-core-plugin.cpp,
+// which is where the detection lives; see the long comment there.
 //
-// OBS emits OBS_FRONTEND_EVENT_FINISHED_LOADING from OBSBasic::OnFirstLoad(),
-// which runs INSIDE OBSBasic::OBSInit(). If the user is held on OBS's modal
-// update dialog, OBS can emit FINISHED_LOADING and later EXIT from two
-// separate on_event() calls without ever leaving OBSInit -- so our whole
-// lifecycle can run against a main window that is still being built and is
-// then torn down. Destroying dock widgets in that window is what faulted.
+// False once OBS has been asked to close before our Initialize() completed --
+// the update-thread race. In that state our object graph is half-built and
+// destroying any of it corrupts the widget tree, so every UI teardown site
+// must check this first.
 //
-// IsObsInitFinished() answers "has control returned to OBS's own event loop",
-// conservatively. It only becomes true once a timer task has observed, twice
-// in a row, that no modal or popup is up AND that we are not inside one of our
-// own event pumps. That last condition is what SEDrainEventQueue() maintains:
-// a timer can only fire from an event loop, and the only event loops in play
-// are our pumps (counted), a modal exec() (detected), and OBS's real loop --
-// which is the one we are waiting for.
-//
-// Started from the FINISHED_LOADING handler. Before that, and for a few
-// hundred ms after OBS's loop starts, it reports false.
-//
-void StreamElementsBeginObsInitWatch();
-bool IsObsInitFinished();
+bool SEIsUiTeardownSafe();
 
-// Use instead of QApplication::sendPostedEvents() everywhere. Identical
-// behaviour, plus the depth accounting IsObsInitFinished() relies on.
+// Called at the end of Initialize(). After this, an ordinary close is an
+// ordinary close and teardown proceeds normally.
+void SENoteInitializeCompleted();
+
+// Use instead of QApplication::sendPostedEvents() everywhere: one choke point
+// for every event pump the plug-in runs.
 void SEDrainEventQueue();
 
 // The only sanctioned way to destroy a QDockWidget. Deletes it when the gate

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -223,6 +223,38 @@ std::future<void> __QtDelayTask_Impl(std::function<void()> task, int delayMs, co
 #define QtPostTask QtAsyncCallFunctor(__FILE__, __LINE__, &__QtPostTask_Impl)
 #define QtExecSync QtAsyncCallFunctor(__FILE__, __LINE__, &__QtExecSync_Impl)
 
+/* ========================================================= */
+
+//
+// OBS init gate (CORE-786).
+//
+// OBS emits OBS_FRONTEND_EVENT_FINISHED_LOADING from OBSBasic::OnFirstLoad(),
+// which runs INSIDE OBSBasic::OBSInit(). If the user is held on OBS's modal
+// update dialog, OBS can emit FINISHED_LOADING and later EXIT from two
+// separate on_event() calls without ever leaving OBSInit -- so our whole
+// lifecycle can run against a main window that is still being built and is
+// then torn down. Destroying dock widgets in that window is what faulted.
+//
+// IsObsInitFinished() answers "has control returned to OBS's own event loop",
+// conservatively. It only becomes true once a timer task has observed, twice
+// in a row, that no modal or popup is up AND that we are not inside one of our
+// own event pumps. That last condition is what SEDrainEventQueue() maintains:
+// a timer can only fire from an event loop, and the only event loops in play
+// are our pumps (counted), a modal exec() (detected), and OBS's real loop --
+// which is the one we are waiting for.
+//
+// Started from the FINISHED_LOADING handler. Before that, and for a few
+// hundred ms after OBS's loop starts, it reports false.
+//
+void StreamElementsBeginObsInitWatch();
+bool IsObsInitFinished();
+
+// Use instead of QApplication::sendPostedEvents() everywhere. Identical
+// behaviour, plus the depth accounting IsObsInitFinished() relies on.
+void SEDrainEventQueue();
+
+/* ========================================================= */
+
 std::string DockWidgetAreaToString(const Qt::DockWidgetArea area);
 std::string GetCommandLineOptionValue(const std::string key);
 std::string LoadResourceString(std::string path);

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -242,6 +242,10 @@ bool SEIsUiTeardownSafe();
 // ordinary close and teardown proceeds normally.
 void SENoteInitializeCompleted();
 
+// False while Initialize() is on the stack, and after a close has been caught.
+// Defined in obs-streamelements-core-plugin.cpp.
+bool SEIsEventPumpAllowed();
+
 // Use instead of QApplication::sendPostedEvents() everywhere: one choke point
 // for every event pump the plug-in runs.
 void SEDrainEventQueue();

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -26,6 +26,8 @@
 #include <curl/curl.h>
 
 #include <QMenu>
+#include <QDockWidget>
+#include <QPointer>
 #include <QWidget>
 
 #define SYNC_ACCESS()                                                    \
@@ -252,6 +254,13 @@ bool IsObsInitFinished();
 // Use instead of QApplication::sendPostedEvents() everywhere. Identical
 // behaviour, plus the depth accounting IsObsInitFinished() relies on.
 void SEDrainEventQueue();
+
+// The only sanctioned way to destroy a QDockWidget. Deletes it when the gate
+// above is open; otherwise detaches it from OBS's widget tree and leaks it,
+// loudly. Destroying a dock while OBSInit() is still on the stack corrupts
+// the tree, and by then obs_frontend_get_main_window() may already be null.
+void SEDeleteDockWidgetWhenSafe(QPointer<QDockWidget> dock, const char *id,
+				bool useDeleteLater);
 
 /* ========================================================= */
 

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -13,6 +13,46 @@ StreamElementsWidgetManager::StreamElementsWidgetManager(QMainWindow *parent)
 	assert(parent);
 }
 
+//
+// Destroying a dock widget while OBSInit() is still on the stack corrupts the
+// widget tree: OBS can emit FINISHED_LOADING and EXIT from two separate
+// on_event() calls inside OBSBasic::OnFirstLoad() without ever returning to
+// its own event loop, so our widgets get built into a main window that is
+// already being dismantled and then torn down seconds later. The fault landed
+// in QWidget::~QWidget reading a child's d->parent, which pointed at neither
+// the dock nor anything live (CORE-786).
+//
+// So: only delete when OBS has demonstrably reached its own event loop.
+// Otherwise detach the dock from OBS's tree and leak it. This path is reached
+// during shutdown of a process that is exiting anyway, and a handful of leaked
+// docks is a straight trade against a crash. IsObsInitFinished() is true for
+// the entire normal lifetime of the plugin, so RemoveDockWidget() at runtime
+// still deletes and nothing accumulates.
+//
+static void SafeDeleteDockWidget(QPointer<QDockWidget> dock, const char *id,
+				 bool useDeleteLater)
+{
+	if (!dock)
+		return;
+
+	if (!IsObsInitFinished()) {
+		blog(LOG_WARNING,
+		     "[obs-streamelements-core]: leaking dock widget '%s': OBS has not finished initializing, deleting it now would corrupt the widget tree",
+		     id);
+
+		// Detach from the main window so OBS's own teardown does not
+		// walk into it later.
+		dock->setParent(nullptr);
+
+		return;
+	}
+
+	if (useDeleteLater)
+		dock->deleteLater();
+	else
+		delete dock.data();
+}
+
 StreamElementsWidgetManager::~StreamElementsWidgetManager()
 {
 	while (DestroyCurrentCentralWidget()) {
@@ -61,7 +101,7 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager()
 		if (!dock)
 			continue;
 
-		delete dock.data();
+		SafeDeleteDockWidget(dock, pair.first.c_str(), false);
 	}
 
 	m_dockWidgets.clear();
@@ -95,7 +135,7 @@ void StreamElementsWidgetManager::PushCentralWidget(
 	//obs_frontend_set_preview_program_mode(false);
 
 	// Make sure changes take effect by draining the event queue
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	QSize prevSize = mainWindow()->centralWidget()->size();
 
@@ -106,7 +146,7 @@ void StreamElementsWidgetManager::PushCentralWidget(
 	m_parent->setCentralWidget(widget);
 
 	// Drain event queue
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	widget->setMinimumSize(0, 0);
 
@@ -150,7 +190,7 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 			->RemoveVideoCompositionView();
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 	QSize currSize = mainWindow()->centralWidget()->size();
 
 	m_parent->setCentralWidget(m_nativeCentralWidget);
@@ -160,7 +200,7 @@ bool StreamElementsWidgetManager::DestroyCurrentCentralWidget()
 	mainWindow()->centralWidget()->setMinimumSize(currSize);
 
 	// Drain event queue
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	mainWindow()->centralWidget()->setMinimumSize(0, 0);
 
@@ -264,9 +304,9 @@ bool StreamElementsWidgetManager::AddDockWidget(
 
 	if (area == Qt::NoDockWidgetArea) {
 		dock->setFloating(false);
-		QApplication::sendPostedEvents();
+		SEDrainEventQueue();
 		dock->setFloating(true);
-		QApplication::sendPostedEvents();
+		SEDrainEventQueue();
 	}
 
 	std::string savedId = id;
@@ -462,7 +502,7 @@ bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char *const id,
 		return false;
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	QSize prevMin = dock->window()->minimumSize();
 	QSize prevMax = dock->window()->maximumSize();
@@ -477,7 +517,7 @@ bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char *const id,
 		dock->window()->setMaximumHeight(height);
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	dock->window()->setMinimumSize(prevMin);
 	dock->window()->setMaximumSize(prevMax);
@@ -542,7 +582,7 @@ bool StreamElementsWidgetManager::RemoveDockWidget(const char *const id)
 	if (m_parent)
 		m_parent->removeDockWidget(dock);
 
-	dock->deleteLater();
+	SafeDeleteDockWidget(dock, id, true);
 
 	return true;
 }
@@ -649,7 +689,7 @@ void StreamElementsWidgetManager::SaveDockWidgetsGeometry()
 
 	m_dockWidgetSavedMinSize.clear();
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	for (auto iter : m_dockWidgets) {
 		// Null when Qt destroyed the dock behind our back (CORE-786).
@@ -664,7 +704,7 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 {
 	std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	std::map<std::string, QSize> maxSize;
 
@@ -682,7 +722,7 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 		}
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 
 	for (auto iter : m_dockWidgetSavedMinSize) {
 		QPointer<QDockWidget> dock;
@@ -696,5 +736,5 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 		}
 	}
 
-	QApplication::sendPostedEvents();
+	SEDrainEventQueue();
 }

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -29,30 +29,6 @@ StreamElementsWidgetManager::StreamElementsWidgetManager(QMainWindow *parent)
 // the entire normal lifetime of the plugin, so RemoveDockWidget() at runtime
 // still deletes and nothing accumulates.
 //
-static void SafeDeleteDockWidget(QPointer<QDockWidget> dock, const char *id,
-				 bool useDeleteLater)
-{
-	if (!dock)
-		return;
-
-	if (!IsObsInitFinished()) {
-		blog(LOG_WARNING,
-		     "[obs-streamelements-core]: leaking dock widget '%s': OBS has not finished initializing, deleting it now would corrupt the widget tree",
-		     id);
-
-		// Detach from the main window so OBS's own teardown does not
-		// walk into it later.
-		dock->setParent(nullptr);
-
-		return;
-	}
-
-	if (useDeleteLater)
-		dock->deleteLater();
-	else
-		delete dock.data();
-}
-
 StreamElementsWidgetManager::~StreamElementsWidgetManager()
 {
 	while (DestroyCurrentCentralWidget()) {
@@ -101,7 +77,7 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager()
 		if (!dock)
 			continue;
 
-		SafeDeleteDockWidget(dock, pair.first.c_str(), false);
+		SEDeleteDockWidgetWhenSafe(dock, pair.first.c_str(), false);
 	}
 
 	m_dockWidgets.clear();
@@ -582,7 +558,7 @@ bool StreamElementsWidgetManager::RemoveDockWidget(const char *const id)
 	if (m_parent)
 		m_parent->removeDockWidget(dock);
 
-	SafeDeleteDockWidget(dock, id, true);
+	SEDeleteDockWidgetWhenSafe(dock, id, true);
 
 	return true;
 }

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -24,13 +24,24 @@ StreamElementsWidgetManager::~StreamElementsWidgetManager()
 		     "[obs-streamelements-core]: destroying dock widget '%s'",
 		     pair.first.c_str());
 
-		// QPointer, so a dock widget destroyed behind our back --
-		// by its QMainWindow parent, or by a deleteLater() posted
-		// from elsewhere -- reads back as null instead of dangling.
-		QPointer<QDockWidget> dock(pair.second);
+		// pair.second is already a QPointer (see the header), so a dock
+		// destroyed behind our back -- by its QMainWindow parent during
+		// OBS teardown, or by a deleteLater() posted elsewhere -- reads
+		// back null here rather than dangling.
+		//
+		// Wrapping the raw pointer in a QPointer *here* would not work
+		// and was the gap in the first version of this fix: QPointer
+		// only tracks destructions that happen after it is constructed,
+		// so one built from an already-dangling pointer is born
+		// non-null and the guard passes (CORE-786).
+		QPointer<QDockWidget> dock = pair.second;
 
-		if (!dock)
+		if (!dock) {
+			blog(LOG_INFO,
+			     "[obs-streamelements-core]: dock widget '%s' was already destroyed; skipping",
+			     pair.first.c_str());
 			continue;
+		}
 
 		if (m_parent)
 			m_parent->removeDockWidget(dock);
@@ -335,6 +346,10 @@ bool StreamElementsWidgetManager::ShowWidgetById(const char *const id)
 
 	QDockWidget *dock = m_dockWidgets[id];
 
+	// Null when Qt destroyed the dock behind our back (CORE-786).
+	if (!dock)
+		return false;
+
 	dock->setVisible(true);
 
 	return true;
@@ -353,6 +368,10 @@ bool StreamElementsWidgetManager::SetWidgetTitleById(const char* const id,
 
 	QDockWidget *dock = m_dockWidgets[id];
 
+	// Null when Qt destroyed the dock behind our back (CORE-786).
+	if (!dock)
+		return false;
+
 	dock->setWindowTitle(QString(title));
 
 	return true;
@@ -369,6 +388,10 @@ bool StreamElementsWidgetManager::HideWidgetById(const char *const id)
 	}
 
 	QDockWidget *dock = m_dockWidgets[id];
+
+	// Null when Qt destroyed the dock behind our back (CORE-786).
+	if (!dock)
+		return false;
 
 	dock->setVisible(false);
 
@@ -430,6 +453,10 @@ bool StreamElementsWidgetManager::SetWidgetDimensionsById(const char *const id,
 	}
 
 	QDockWidget *dock = m_dockWidgets[id];
+
+	// Null when Qt destroyed the dock behind our back (CORE-786).
+	if (!dock)
+		return false;
 
 	if (!dock->isFloating() || !dock->window()) {
 		return false;
@@ -502,12 +529,18 @@ bool StreamElementsWidgetManager::RemoveDockWidget(const char *const id)
 		return false;
 	}
 
-	QDockWidget *dock = m_dockWidgets[id];
+	QPointer<QDockWidget> dock = m_dockWidgets[id];
 
 	m_dockWidgets.erase(id);
 	m_dockWidgetAreas.erase(id);
 
-	m_parent->removeDockWidget(dock);
+	// The map entry goes either way; the widget is only touched if Qt has
+	// not already destroyed it (CORE-786).
+	if (!dock)
+		return true;
+
+	if (m_parent)
+		m_parent->removeDockWidget(dock);
 
 	dock->deleteLater();
 
@@ -619,6 +652,10 @@ void StreamElementsWidgetManager::SaveDockWidgetsGeometry()
 	QApplication::sendPostedEvents();
 
 	for (auto iter : m_dockWidgets) {
+		// Null when Qt destroyed the dock behind our back (CORE-786).
+		if (!iter.second)
+			continue;
+
 		m_dockWidgetSavedMinSize[iter.first] = iter.second->size();
 	}
 }
@@ -632,22 +669,30 @@ void StreamElementsWidgetManager::RestoreDockWidgetsGeometry()
 	std::map<std::string, QSize> maxSize;
 
 	for (auto iter : m_dockWidgetSavedMinSize) {
-		if (m_dockWidgets.count(iter.first)) {
-			maxSize[iter.first] =
-				m_dockWidgets[iter.first]->maximumSize();
+		QPointer<QDockWidget> dock;
 
-			m_dockWidgets[iter.first]->setMinimumSize(iter.second);
-			m_dockWidgets[iter.first]->setMaximumSize(iter.second);
+		if (m_dockWidgets.count(iter.first))
+			dock = m_dockWidgets[iter.first];
+
+		if (dock) {
+			maxSize[iter.first] = dock->maximumSize();
+
+			dock->setMinimumSize(iter.second);
+			dock->setMaximumSize(iter.second);
 		}
 	}
 
 	QApplication::sendPostedEvents();
 
 	for (auto iter : m_dockWidgetSavedMinSize) {
-		if (m_dockWidgets.count(iter.first)) {
-			m_dockWidgets[iter.first]->setMinimumSize(QSize(0, 0));
-			m_dockWidgets[iter.first]->setMaximumSize(
-				maxSize[iter.first]);
+		QPointer<QDockWidget> dock;
+
+		if (m_dockWidgets.count(iter.first))
+			dock = m_dockWidgets[iter.first];
+
+		if (dock) {
+			dock->setMinimumSize(QSize(0, 0));
+			dock->setMaximumSize(maxSize[iter.first]);
 		}
 	}
 

--- a/streamelements/StreamElementsWidgetManager.hpp
+++ b/streamelements/StreamElementsWidgetManager.hpp
@@ -103,7 +103,12 @@ private:
 	QPointer<QWidget> m_nativeCentralWidget = nullptr;
 	//QWidget* m_currentCentralWidget = nullptr;
 
-	std::map<std::string, QDockWidget*> m_dockWidgets;
+	// QPointer, not a raw pointer: the docks are children of the OBS main
+	// window (addDockWidget), so Qt owns them and destroys them with that
+	// window. Nothing tells this map when that happens, and on the OBSInit
+	// re-entrancy path it happens before ~StreamElementsWidgetManager runs.
+	// Raw pointers went stale and were deleted a second time (CORE-786).
+	std::map<std::string, QPointer<QDockWidget>> m_dockWidgets;
 	std::map<std::string, Qt::DockWidgetArea> m_dockWidgetAreas;
 
 	std::map<std::string, QSize> m_dockWidgetSavedMinSize;

--- a/streamelements/StreamElementsWorkerManager.cpp
+++ b/streamelements/StreamElementsWorkerManager.cpp
@@ -60,7 +60,7 @@ public:
 		mainWindow->removeDockWidget(m_dockWidget);
 		m_dockWidget->deleteLater();
 
-		QApplication::sendPostedEvents();
+		SEDrainEventQueue();
 	}
 
 	std::string GetUrl() { return m_url; }

--- a/streamelements/StreamElementsWorkerManager.cpp
+++ b/streamelements/StreamElementsWorkerManager.cpp
@@ -54,13 +54,26 @@ public:
 	}
 
 	~StreamElementsWorker() {
+		// Null once OBS has torn down its frontend API, which happens
+		// before our teardown whenever the plugin is destroyed from
+		// inside OBSInit (CORE-786).
 		auto mainWindow = static_cast<QMainWindow *>(
 			obs_frontend_get_main_window());
 
-		mainWindow->removeDockWidget(m_dockWidget);
-		m_dockWidget->deleteLater();
+		QPointer<QDockWidget> dock(m_dockWidget);
 
-		SEDrainEventQueue();
+		m_dockWidget = nullptr;
+
+		if (!dock)
+			return;
+
+		if (mainWindow)
+			mainWindow->removeDockWidget(dock);
+
+		SEDeleteDockWidgetWhenSafe(dock, "streamelements_worker", true);
+
+		// No event pump here: draining mid-teardown is what produced
+		// CORE-777.
 	}
 
 	std::string GetUrl() { return m_url; }

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -342,6 +342,15 @@ static void check_event_pumps_are_counted()
 
 	check(utils.find("void SEDrainEventQueue()") != std::string::npos,
 	      "CORE-786: SEDrainEventQueue() must exist in StreamElementsUtils.cpp");
+
+	// The pump must stop once the close has been caught: every further
+	// dispatch feeds events into a world that is being torn down.
+	auto pump_at = utils.find("void SEDrainEventQueue()");
+	auto pump_end = utils.find("\n}", pump_at);
+	auto pump_body = utils.substr(pump_at, pump_end - pump_at);
+
+	check(pump_body.find("SEIsUiTeardownSafe()") != std::string::npos,
+	      "CORE-786: SEDrainEventQueue() must stop pumping once teardown is unsafe");
 }
 
 // --- CORE-786: dock widgets must not be deleted unguarded.
@@ -411,6 +420,18 @@ static void check_obs_close_is_watched()
 	check(code.find("StreamElementsGlobalStateManager::Leak()") !=
 		      std::string::npos,
 	      "CORE-786: the EXIT path must leak rather than tear down when teardown is unsafe");
+
+	// Removing our callback mutates the vector OBSStudioAPI::on_event() is
+	// iterating. Harmless normally, fatal when EXIT is dispatched from
+	// inside another on_event(), so it must be gated.
+	auto rm = code.find("obs_frontend_remove_event_callback(");
+	check(rm != std::string::npos,
+	      "CORE-786: EXIT-path callback removal not found -- update this invariant");
+	if (rm != std::string::npos) {
+		auto before = code.rfind("SEIsUiTeardownSafe()", rm);
+		check(before != std::string::npos && rm - before < 200,
+		      "CORE-786: obs_frontend_remove_event_callback() must be gated on SEIsUiTeardownSafe()");
+	}
 
 	// The filter must never swallow the event -- OBS has to close exactly
 	// as it would without us.

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -296,6 +296,77 @@ static void check_widget_maps_hold_qpointer()
 	      "CORE-786: m_activeVideoCompositionViewWidget must be a QPointer");
 }
 
+// --- CORE-786: every event pump must go through SEDrainEventQueue().
+//
+// IsObsInitFinished() distinguishes OBS's own event loop from a nested one by
+// counting the pumps we run ourselves. A bare QApplication::sendPostedEvents()
+// anywhere in the plugin is invisible to that counter, so the gate could open
+// while OBSInit() is still on the stack -- which is the exact condition that
+// corrupts the widget tree. The wrapper in StreamElementsUtils.cpp is the only
+// legitimate caller.
+static void check_event_pumps_are_counted()
+{
+	static const char *const kSources[] = {
+		"streamelements/StreamElementsBrowserWidgetManager.cpp",
+		"streamelements/StreamElementsGlobalStateManager.cpp",
+		"streamelements/StreamElementsNativeOBSControlsManager.cpp",
+		"streamelements/StreamElementsWidgetManager.cpp",
+		"streamelements/StreamElementsWorkerManager.cpp",
+		"streamelements/StreamElementsReportIssueDialog.cpp",
+	};
+
+	for (const char *const relpath : kSources) {
+		auto code = strip_line_comments(slurp(relpath));
+
+		if (code.find("sendPostedEvents") != std::string::npos) {
+			std::fprintf(
+				stderr,
+				"FAIL: CORE-786: %s calls sendPostedEvents() directly; use SEDrainEventQueue() so the pump is counted\n",
+				relpath);
+			++failures;
+		}
+	}
+
+	// And the wrapper itself must still contain exactly one real pump.
+	auto utils = strip_line_comments(
+		slurp("streamelements/StreamElementsUtils.cpp"));
+
+	std::regex pump(R"(QApplication::sendPostedEvents\(\);)");
+
+	check(count_matches(utils, pump) == 1,
+	      "CORE-786: StreamElementsUtils.cpp must contain exactly one QApplication::sendPostedEvents(), inside SEDrainEventQueue()");
+
+	check(utils.find("void SEDrainEventQueue()") != std::string::npos,
+	      "CORE-786: SEDrainEventQueue() must exist in StreamElementsUtils.cpp");
+}
+
+// --- CORE-786: dock widgets must not be deleted unguarded.
+static void check_dock_deletion_is_gated()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsWidgetManager.cpp"));
+
+	check(code.find("SafeDeleteDockWidget") != std::string::npos,
+	      "CORE-786: StreamElementsWidgetManager.cpp must delete dock widgets through SafeDeleteDockWidget()");
+
+	check(code.find("IsObsInitFinished") != std::string::npos,
+	      "CORE-786: SafeDeleteDockWidget() must gate on IsObsInitFinished()");
+
+	// The two raw deletion forms are legitimate inside the helper and
+	// nowhere else, so cut the helper out before looking for them.
+	auto helper = code.find("static void SafeDeleteDockWidget(");
+	if (helper != std::string::npos) {
+		auto helper_end = code.find("\n}", helper);
+		if (helper_end != std::string::npos)
+			code.erase(helper, helper_end - helper);
+	}
+
+	check(code.find("delete dock.data();") == std::string::npos,
+	      "CORE-786: bare `delete dock.data();` outside SafeDeleteDockWidget()");
+	check(code.find("dock->deleteLater();") == std::string::npos,
+	      "CORE-786: bare `dock->deleteLater();` outside SafeDeleteDockWidget()");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -306,6 +377,8 @@ int main()
 	check_menu_manager_update_guarded();
 	check_widget_manager_dtor_does_not_drain_events();
 	check_widget_maps_hold_qpointer();
+	check_event_pumps_are_counted();
+	check_dock_deletion_is_gated();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -250,6 +250,52 @@ static void check_widget_manager_dtor_does_not_drain_events()
 	      "CORE-777: ~StreamElementsWidgetManager() must hold each dock widget in a QPointer before deleting it");
 }
 
+// --- CORE-786: the widget maps must hold QPointer, not raw pointers.
+//
+// Docks are children of the OBS main window (addDockWidget), and browser
+// widgets are children of their dock. Qt owns both and destroys them with
+// their parent -- which, on the OBSInit re-entrancy path, happens before
+// ~StreamElementsWidgetManager runs. Raw pointers in these maps went stale
+// and were then deleted a second time.
+//
+// Guarding at the point of use is not enough and was the gap in the first
+// version of this fix: a QPointer constructed from an already-dangling raw
+// pointer is born non-null. The map itself has to hold the QPointer.
+static void check_widget_maps_hold_qpointer()
+{
+	auto wm = strip_line_comments(
+		slurp("streamelements/StreamElementsWidgetManager.hpp"));
+
+	check(wm.find("std::map<std::string, QPointer<QDockWidget>>") !=
+		      std::string::npos,
+	      "CORE-786: m_dockWidgets must be std::map<std::string, QPointer<QDockWidget>>");
+	check(wm.find("std::map<std::string, QDockWidget*>") ==
+		      std::string::npos,
+	      "CORE-786: m_dockWidgets must not hold raw QDockWidget*");
+
+	auto bwm = strip_line_comments(
+		slurp("streamelements/StreamElementsBrowserWidgetManager.hpp"));
+
+	check(bwm.find("QPointer<StreamElementsBrowserWidget>>") !=
+		      std::string::npos,
+	      "CORE-786: m_browserWidgets must hold QPointer<StreamElementsBrowserWidget>");
+	check(bwm.find("std::map<std::string, StreamElementsBrowserWidget*>") ==
+		      std::string::npos,
+	      "CORE-786: m_browserWidgets must not hold raw StreamElementsBrowserWidget*");
+
+	// The composition view widgets are hand-deleted, so they must be
+	// QPointer too or the delete can run twice.
+	auto bw = strip_line_comments(
+		slurp("streamelements/StreamElementsBrowserWidget.hpp"));
+
+	check(bw.find("QPointer<QWidget> m_activeVideoCompositionViewWidgetContainer") !=
+		      std::string::npos,
+	      "CORE-786: m_activeVideoCompositionViewWidgetContainer must be a QPointer");
+	check(bw.find("QPointer<StreamElementsVideoCompositionViewWidget>") !=
+		      std::string::npos,
+	      "CORE-786: m_activeVideoCompositionViewWidget must be a QPointer");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -259,6 +305,7 @@ int main()
 	check_c10_no_duplicate_handler_setcurrentprofile();
 	check_menu_manager_update_guarded();
 	check_widget_manager_dtor_does_not_drain_events();
+	check_widget_maps_hold_qpointer();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -349,8 +349,8 @@ static void check_event_pumps_are_counted()
 	auto pump_end = utils.find("\n}", pump_at);
 	auto pump_body = utils.substr(pump_at, pump_end - pump_at);
 
-	check(pump_body.find("SEIsUiTeardownSafe()") != std::string::npos,
-	      "CORE-786: SEDrainEventQueue() must stop pumping once teardown is unsafe");
+	check(pump_body.find("SEIsEventPumpAllowed()") != std::string::npos,
+	      "CORE-786: SEDrainEventQueue() must gate on SEIsEventPumpAllowed()");
 }
 
 // --- CORE-786: dock widgets must not be deleted unguarded.
@@ -414,6 +414,19 @@ static void check_obs_close_is_watched()
 
 	check(code.find("SENoteInitializeCompleted()") != std::string::npos,
 	      "CORE-786: SENoteInitializeCompleted() must be defined in the plug-in entry point");
+
+	// Pumping the event queue anywhere under Initialize() is what nests
+	// OBS's EXIT dispatch inside its FINISHED_LOADING dispatch, so the
+	// whole call has to run with pumping disabled.
+	check(code.find("bool SEIsEventPumpAllowed()") != std::string::npos,
+	      "CORE-786: SEIsEventPumpAllowed() must be defined in the plug-in entry point");
+
+	check(code.find("s_initializeInProgress") != std::string::npos,
+	      "CORE-786: an in-progress flag must cover the whole of Initialize()");
+
+	check(code.find("StreamElementsInitializeScope initializeScope;") !=
+		      std::string::npos,
+	      "CORE-786: Initialize() must be called inside StreamElementsInitializeScope");
 
 	// The gate has to actually be consulted on the teardown path, and the
 	// unsafe branch must leak rather than destroy.

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -343,28 +343,75 @@ static void check_event_pumps_are_counted()
 // --- CORE-786: dock widgets must not be deleted unguarded.
 static void check_dock_deletion_is_gated()
 {
+	// Every dock teardown site must go through the shared helper.
+	static const char *const kSources[] = {
+		"streamelements/StreamElementsWidgetManager.cpp",
+		"streamelements/StreamElementsWorkerManager.cpp",
+	};
+
+	for (const char *const relpath : kSources) {
+		auto s = strip_line_comments(slurp(relpath));
+
+		if (s.find("SEDeleteDockWidgetWhenSafe") == std::string::npos) {
+			std::fprintf(
+				stderr,
+				"FAIL: CORE-786: %s must destroy dock widgets through SEDeleteDockWidgetWhenSafe()\n",
+				relpath);
+			++failures;
+		}
+	}
+
+	auto utils = strip_line_comments(
+		slurp("streamelements/StreamElementsUtils.cpp"));
+
+	check(utils.find("IsObsInitFinished()") != std::string::npos,
+	      "CORE-786: SEDeleteDockWidgetWhenSafe() must gate on IsObsInitFinished()");
+
 	auto code = strip_line_comments(
 		slurp("streamelements/StreamElementsWidgetManager.cpp"));
 
-	check(code.find("SafeDeleteDockWidget") != std::string::npos,
-	      "CORE-786: StreamElementsWidgetManager.cpp must delete dock widgets through SafeDeleteDockWidget()");
-
-	check(code.find("IsObsInitFinished") != std::string::npos,
-	      "CORE-786: SafeDeleteDockWidget() must gate on IsObsInitFinished()");
-
 	// The two raw deletion forms are legitimate inside the helper and
 	// nowhere else, so cut the helper out before looking for them.
-	auto helper = code.find("static void SafeDeleteDockWidget(");
-	if (helper != std::string::npos) {
-		auto helper_end = code.find("\n}", helper);
-		if (helper_end != std::string::npos)
-			code.erase(helper, helper_end - helper);
-	}
-
 	check(code.find("delete dock.data();") == std::string::npos,
 	      "CORE-786: bare `delete dock.data();` outside SafeDeleteDockWidget()");
 	check(code.find("dock->deleteLater();") == std::string::npos,
 	      "CORE-786: bare `dock->deleteLater();` outside SafeDeleteDockWidget()");
+}
+
+// --- CORE-786: the plug-in must not initialize from inside OBSInit().
+//
+// OBS_FRONTEND_EVENT_FINISHED_LOADING is emitted from OBSBasic::OnFirstLoad(),
+// inside OBSBasic::OBSInit(). Initializing there puts the whole object
+// hierarchy on OBSInit's stack, where OBS can go on to emit EXIT without ever
+// reaching its own event loop. Initialization must be deferred behind
+// IsObsInitFinished().
+static void check_initialize_is_deferred()
+{
+	auto code = strip_line_comments(slurp("obs-streamelements-core-plugin.cpp"));
+
+	auto handler = code.find("case OBS_FRONTEND_EVENT_FINISHED_LOADING:");
+	check(handler != std::string::npos,
+	      "CORE-786: FINISHED_LOADING case not found -- update this invariant");
+	if (handler == std::string::npos)
+		return;
+
+	auto handler_end = code.find("case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:",
+				     handler);
+	if (handler_end == std::string::npos)
+		handler_end = code.size();
+
+	auto branch = code.substr(handler, handler_end - handler);
+
+	// `->Initialize(` is the call on the state manager; the branch may
+	// legitimately mention StreamElementsDeferredInitialize().
+	check(branch.find("->Initialize(") == std::string::npos,
+	      "CORE-786: FINISHED_LOADING must not call Initialize() directly; defer it behind IsObsInitFinished()");
+
+	check(code.find("IsObsInitFinished()") != std::string::npos,
+	      "CORE-786: deferred initialization must gate on IsObsInitFinished()");
+
+	check(code.find("StreamElementsBeginObsInitWatch()") != std::string::npos,
+	      "CORE-786: the OBS init watch must be started from FINISHED_LOADING");
 }
 
 int main()
@@ -379,6 +426,7 @@ int main()
 	check_widget_maps_hold_qpointer();
 	check_event_pumps_are_counted();
 	check_dock_deletion_is_gated();
+	check_initialize_is_deferred();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -298,6 +298,10 @@ static void check_widget_maps_hold_qpointer()
 
 // --- CORE-786: every event pump must go through SEDrainEventQueue().
 //
+// One choke point for every event pump the plug-in runs. A bare
+// QApplication::sendPostedEvents() is how OBS's modal update dialog and its
+// queued close() get dispatched from inside our own Initialize().
+//
 // IsObsInitFinished() distinguishes OBS's own event loop from a nested one by
 // counting the pumps we run ourselves. A bare QApplication::sendPostedEvents()
 // anywhere in the plugin is invisible to that counter, so the gate could open
@@ -364,8 +368,8 @@ static void check_dock_deletion_is_gated()
 	auto utils = strip_line_comments(
 		slurp("streamelements/StreamElementsUtils.cpp"));
 
-	check(utils.find("IsObsInitFinished()") != std::string::npos,
-	      "CORE-786: SEDeleteDockWidgetWhenSafe() must gate on IsObsInitFinished()");
+	check(utils.find("SEIsUiTeardownSafe()") != std::string::npos,
+	      "CORE-786: SEDeleteDockWidgetWhenSafe() must gate on SEIsUiTeardownSafe()");
 
 	auto code = strip_line_comments(
 		slurp("streamelements/StreamElementsWidgetManager.cpp"));
@@ -378,40 +382,48 @@ static void check_dock_deletion_is_gated()
 	      "CORE-786: bare `dock->deleteLater();` outside SafeDeleteDockWidget()");
 }
 
-// --- CORE-786: the plug-in must not initialize from inside OBSInit().
+// --- CORE-786: the plug-in must watch the OBS main window for close.
 //
-// OBS_FRONTEND_EVENT_FINISHED_LOADING is emitted from OBSBasic::OnFirstLoad(),
-// inside OBSBasic::OBSInit(). Initializing there puts the whole object
-// hierarchy on OBSInit's stack, where OBS can go on to emit EXIT without ever
-// reaching its own event loop. Initialization must be deferred behind
-// IsObsInitFinished().
-static void check_initialize_is_deferred()
+// OBSBasic::OBSInit() starts AutoUpdateThread before it emits
+// FINISHED_LOADING, and that thread ends with a queued close() on the main
+// window. If the close lands before Initialize() finishes, our object graph is
+// half-built and must not be torn down. QEvent::Close on the main window is
+// the signal; it is delivered before OBSBasic::closeEvent(), which is what
+// fires EXIT.
+static void check_obs_close_is_watched()
 {
 	auto code = strip_line_comments(slurp("obs-streamelements-core-plugin.cpp"));
 
-	auto handler = code.find("case OBS_FRONTEND_EVENT_FINISHED_LOADING:");
-	check(handler != std::string::npos,
-	      "CORE-786: FINISHED_LOADING case not found -- update this invariant");
-	if (handler == std::string::npos)
-		return;
+	check(code.find("QEvent::Close") != std::string::npos,
+	      "CORE-786: the plug-in must watch for QEvent::Close on the OBS main window");
 
-	auto handler_end = code.find("case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:",
-				     handler);
-	if (handler_end == std::string::npos)
-		handler_end = code.size();
+	check(code.find("installEventFilter") != std::string::npos,
+	      "CORE-786: the close watcher must be installed as an event filter");
 
-	auto branch = code.substr(handler, handler_end - handler);
+	check(code.find("bool SEIsUiTeardownSafe()") != std::string::npos,
+	      "CORE-786: SEIsUiTeardownSafe() must be defined in the plug-in entry point");
 
-	// `->Initialize(` is the call on the state manager; the branch may
-	// legitimately mention StreamElementsDeferredInitialize().
-	check(branch.find("->Initialize(") == std::string::npos,
-	      "CORE-786: FINISHED_LOADING must not call Initialize() directly; defer it behind IsObsInitFinished()");
+	check(code.find("SENoteInitializeCompleted()") != std::string::npos,
+	      "CORE-786: SENoteInitializeCompleted() must be defined in the plug-in entry point");
 
-	check(code.find("IsObsInitFinished()") != std::string::npos,
-	      "CORE-786: deferred initialization must gate on IsObsInitFinished()");
+	// The gate has to actually be consulted on the teardown path, and the
+	// unsafe branch must leak rather than destroy.
+	check(code.find("StreamElementsGlobalStateManager::Leak()") !=
+		      std::string::npos,
+	      "CORE-786: the EXIT path must leak rather than tear down when teardown is unsafe");
 
-	check(code.find("StreamElementsBeginObsInitWatch()") != std::string::npos,
-	      "CORE-786: the OBS init watch must be started from FINISHED_LOADING");
+	// The filter must never swallow the event -- OBS has to close exactly
+	// as it would without us.
+	check(code.find("return QObject::eventFilter(watched, event);") !=
+		      std::string::npos,
+	      "CORE-786: the close watcher must not consume events");
+
+	// And Initialize() must record completion, or the gate never opens.
+	auto gsm = strip_line_comments(
+		slurp("streamelements/StreamElementsGlobalStateManager.cpp"));
+
+	check(gsm.find("SENoteInitializeCompleted();") != std::string::npos,
+	      "CORE-786: Initialize() must call SENoteInitializeCompleted() on completion");
 }
 
 int main()
@@ -426,7 +438,7 @@ int main()
 	check_widget_maps_hold_qpointer();
 	check_event_pumps_are_counted();
 	check_dock_deletion_is_gated();
-	check_initialize_is_deferred();
+	check_obs_close_is_watched();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Fixes CORE-786

Accepting OBS's startup update prompt crashed OBS. Four wrong root causes were chased before this one; each was disproved by its own instrumentation, which is why the diagnostics are kept in the tree.

## Root cause

`OBSBasic::OBSInit()` starts the update checker **before** it tells plug-ins the UI is ready, and the two are unordered:

```
OBSBasic.cpp:1307   TimedCheckForUpdates()  -> new AutoUpdateThread; start()
OBSBasic.cpp:1371   OnFirstLoad()           -> OBS_FRONTEND_EVENT_FINISHED_LOADING
```

`AutoUpdateThread` then reaches back onto the main thread twice:

1. `queryUpdate()` calls `invokeMethod(this, "queryUpdateSlot", Qt::BlockingQueuedConnection)`. `this` is the `QThread` **object**, which lives in the main thread — so the update dialog's `exec()`, a nested modal event loop, runs on the main thread dispatched by whichever event pump runs next. That pump was ours, inside `Initialize()`.
2. After launching the updater, `run()` ends with `invokeMethod(App()->GetMainWindow(), "close")`, queued. Our *next* pump delivered it, so `OBSBasic::close()` → `closeEvent()` → `OBS_FRONTEND_EVENT_EXIT` ran **nested inside our own `Initialize()`**.

Two failures follow. We are asked to tear down an object graph still under construction — every crash chased here was a destructor touching something `Initialize()` had just built, with docks created at 02:48:17 and destroyed at 02:48:20 and `init done` never reached. And `OBSStudioAPI::on_event()` iterates `callbacks` with the size captured once while `obs_frontend_remove_event_callback()` erases from it, so the outer `FINISHED_LOADING` loop resumes over a shrunken vector and calls through garbage — an AV at `on_event+0x4c` with no plug-in frames on the stack.

## Fix

**1. Never pump the event queue while `Initialize()` is on the stack.** An RAII scope sets an in-progress flag around the call; `SEDrainEventQueue()` — the single choke point all 24 pump sites now route through — returns immediately while it is set. Without our pump, the queued `close()` waits for OBS's own event loop, which only runs after `OBSInit` returns, so `on_event()` is never re-entered. In practice `Initialize()` now completes in ~2 s, *before* the dialog appears, so the race does not occur.

**2. Safety net for a machine where the dialog still wins.** An event filter on the OBS main window watches `QEvent::Close`, which is delivered before `OBSBasic::closeEvent()` and therefore before EXIT. A close arriving before `Initialize()` completed marks UI teardown unsafe, and the EXIT path leaks plug-in state via `Leak()` — parking a reference that is never freed, so no destructor runs, now or at static destruction — rather than tearing down a half-built graph. A close *after* `init done` is an ordinary shutdown and behaves exactly as before.

`QEvent::Close` is the correct signal: the queued call arrives as a private `QMetaCallEvent` with no readable method name, indistinguishable from any other `invokeMethod` on the window. EXIT before `init done` is a second, independent trigger for quit paths that never send a close.

Also included: `QPointer` in the dock/browser-widget maps and in the composition-view members (hygiene — it is what disproved the third hypothesis), a null main-window guard in `~StreamElementsWorker`, and `SEDeleteDockWidgetWhenSafe()` as the one sanctioned way to destroy a dock.

## Verification

Three scenarios against OBS 32.2.0 with a 32.2.2 update pending. **Zero minidumps, zero crash logs** across all of them.

| scenario | result |
| -- | -- |
| Update accepted, init wins | ordinary shutdown — 9/9 docks, `shutdown complete`, `reference count balance = 0` |
| Plain start and quit | identical; `Number of memory leaks: 9`, matching the pre-existing baseline |
| Update accepted, dialog wins (simulated) | close caught 1 ms before the shutdown banner, `Leak()` taken, teardown skipped, clean exit |

The third was forced with a temporary env-gated hook holding the completion flag false for five minutes. Uncommitted and reverted after the run — without it that path had never executed.

Four source invariants added, each negative-tested (reverting the fix produces a named failure): pumps must route through `SEDrainEventQueue()`; that must gate on `SEIsEventPumpAllowed()`; dock deletion must go through `SEDeleteDockWidgetWhenSafe()`; the close watcher must exist and must not consume events. `ctest` 2/2. Built and run against a real obs-studio tree, not just CI.

## Known costs

- **Dock sizing at startup.** The central-widget sizing hack and the dock geometry save/restore rely on draining to settle, which no longer happens during initialization. Cosmetic, but it deserves a deliberate look before release — nothing looked wrong in testing, but nobody checked on purpose.
- **The leak path skips CEF teardown and config persist.** Only reached when the process is exiting and about to be replaced by the updater.
- **This does not fix the underlying lifecycle.** `Initialize()` still runs inside `OBSInit`; it just no longer participates in OBS's re-entrancy. CORE-757 remains the structural cure.

## Upstream

The stale-`size()` loop in `OBSStudioAPI::on_event()` is an OBS bug. This removes our ability to trigger it; another plug-in deregistering during a nested dispatch still can. Worth reporting separately — OBS's contribution guidelines require submitted content to be human-written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
