### PR TITLE
docs(release): refresh the untagged-channel-version comments (CORE-859)

### DIFF
--- a/.github/actions/se-release/lib.sh
+++ b/.github/actions/se-release/lib.sh
@@ -191,9 +191,12 @@ resolve_previous_full_tag() {
 		fi
 	fi
 
-	# The changelog needs the tag object, not merely a release. Not every version that
-	# has reached a channel was tagged: windows/stable currently references
-	# 20241127000268, and tag 24.11.27.268 does not exist in this repo.
+	# The changelog needs the tag object, not merely a release, and a version that
+	# reached a channel is not guaranteed to have been tagged. windows/stable served
+	# 20241127000268 for a long time with no 24.11.27.268 tag; the tag and a back-filled
+	# release were created by hand on 2026-08-25, so that particular gap is closed, but
+	# the guard stays -- nothing in the pipeline enforces that a channel version was
+	# ever tagged.
 	if [ -n "$_prev" ] && ! git rev-parse -q --verify "refs/tags/$_prev^{commit}" > /dev/null 2>&1; then
 		warn "previous tag '$_prev' is not present in this clone; the changelog will be omitted"
 		_prev=""

--- a/.github/actions/se-release/publish.sh
+++ b/.github/actions/se-release/publish.sh
@@ -48,9 +48,10 @@ if [ "$MODE" = "rollback" ]; then
 	fi
 
 	# Re-assert the incoming (older) version as the full, Latest release. It may predate
-	# this automation or never have been tagged at all -- windows/stable currently points
-	# at 20241127000268, whose tag 24.11.27.268 does not exist -- so warn, never fail:
-	# the revert above is the part that matters.
+	# this automation, or have reached a channel without ever being tagged -- that was
+	# true of windows/stable's 20241127000268 until its tag and release were back-filled
+	# by hand on 2026-08-25. Nothing prevents it recurring, so warn, never fail: the
+	# revert above is the part that matters.
 	if gh release view "$TAG" --json id > /dev/null 2>&1; then
 		note "Re-asserting $TAG as the full, Latest release"
 		gh_write release edit "$TAG" --prerelease=false --title "$TAG" --latest

--- a/.github/actions/se-release/resolve.sh
+++ b/.github/actions/se-release/resolve.sh
@@ -117,9 +117,10 @@ qa | beta | latest)
 	fi
 
 	# The scan is `git log <base>..<tag>`, so the lower bound has to exist as a tag in
-	# this clone. Not every version that reached a channel was tagged -- windows/stable
-	# references 20241127000268 and tag 24.11.27.268 was never pushed -- so this is a live
-	# condition rather than a hypothetical.
+	# this clone, and a version that reached a channel is not guaranteed to have one.
+	# windows/stable served 20241127000268 with no 24.11.27.268 tag until both it and a
+	# back-filled release were created by hand on 2026-08-25. The guard stays: the
+	# pipeline never enforced the invariant, so it can recur.
 	if [ -n "$BASE" ] && ! git rev-parse -q --verify "refs/tags/$BASE^{commit}" > /dev/null 2>&1; then
 		warn "linear: tag '$BASE' is not present in this clone; the CLI will choose its own scan base"
 		BASE=""


### PR DESCRIPTION
`lib.sh`, `publish.sh` and `resolve.sh` each cited **24.11.27.268** as the live example of a channel version that was never tagged. That is no longer true — the tag and a back-dated release now exist, so a reader checking the example would find it contradicted and could reasonably conclude the guard is dead code.

The comments are rewritten to record what actually happened and why each guard stays: nothing in the pipeline enforces that a channel version was ever tagged, so the condition can recur.

**Guards themselves are unchanged.** This is comments only — `sh -n` clean on all three files, and `git diff` touches no executable line.

Context on the releases that made the example stale is on CORE-859.

Fixes CORE-859