### PR TITLE
fix(crash): take sentry's SIGABRT door so abort() is gated and consented (CORE-860)

### DIFF
--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -214,7 +214,43 @@ public:
 			      httpResponseReceivedCallback, nullptr);
 	}
 
+public:
+	//
+	// Discards the frames at the top of the walk that belong to us, before
+	// anything is recorded or tested.
+	//
+	// Only for a walk whose CONTEXT we captured ourselves, inside our own
+	// crash handler -- the abort()/SIGABRT path. There the innermost frame
+	// is the handler, so this module is on the stack unconditionally and the
+	// verdict below would be true for every abort in the process, including
+	// OBS's and other plugins'. That is not a gate, it is a rubber stamp.
+	//
+	// An SEH crash gets its CONTEXT from the OS at the fault point and our
+	// filter is not in it, so that path must NOT set this.
+	//
+	// Skipping stops at the first frame that is not ours -- normally the
+	// handler frame alone, then `raise`. A fault genuinely inside our code
+	// reappears further down the stack, below the CRT's abort machinery, and
+	// still passes the gate.
+	//
+	// Call immediately before each walk: this arms a one-shot that the walk
+	// itself clears.
+	void SetSkipLeadingOwnFrames(bool skip) { m_skippingOwnFrames = skip; }
+
 protected:
+	bool IsModuleOfInterest(const char *moduleName) const
+	{
+		if (!moduleName)
+			return false;
+
+		for (auto &filter : modulesOfInterest) {
+			if (strcasecmp(filter.c_str(), moduleName) == 0)
+				return true;
+		}
+
+		return false;
+	}
+
 	virtual void OnCallstackEntry(CallstackEntryType eType,
 				      CallstackEntry &entry) override
 	{
@@ -222,6 +258,13 @@ protected:
 
 		if (!entry.offset)
 			return;
+
+		if (m_skippingOwnFrames) {
+			if (IsModuleOfInterest(entry.moduleName))
+				return;
+
+			m_skippingOwnFrames = false;
+		}
 
 #define LOCAL_SPACE "\t"
 		output += entry.loadedImageName;
@@ -236,22 +279,18 @@ protected:
 		output += "\n";
 #undef LOCAL_SPACE
 
-		if (!hasMatchModuleOfInterest) {
-			for (auto filter : modulesOfInterest) {
-				if (strcasecmp(filter.c_str(),
-					       entry.moduleName) == 0) {
-					hasMatchModuleOfInterest = true;
-
-					break;
-				}
-			}
-		}
+		if (!hasMatchModuleOfInterest)
+			hasMatchModuleOfInterest =
+				IsModuleOfInterest(entry.moduleName);
 	}
 
 public:
 	bool hasMatchModuleOfInterest = false;
 	std::vector<std::string> modulesOfInterest;
 	std::string output;
+
+private:
+	bool m_skippingOwnFrames = false;
 };
 
 #else
@@ -275,6 +314,9 @@ public:
 		modulesOfInterest.push_back("obs-streamelements");
 	}
 
+	// See the Windows walker: arms a one-shot that the walk clears.
+	void SetSkipLeadingOwnFrames(bool skip) { m_skippingOwnFrames = skip; }
+
 	void Walk()
 	{
 		void *frames[128];
@@ -291,33 +333,51 @@ public:
 			if (dladdr(frames[i], &info) && info.dli_fname)
 				image = info.dli_fname;
 
+			const bool isOwnModule = IsModuleOfInterest(image);
+
+			if (m_skippingOwnFrames) {
+				if (isOwnModule)
+					continue;
+
+				m_skippingOwnFrames = false;
+			}
+
 			output += image;
 			output += "\t";
 			output += (symbols && symbols[i]) ? symbols[i] : "";
 			output += "\n";
 
-			if (hasMatchModuleOfInterest || !*image)
-				continue;
-
-			const std::string path = image;
-
-			for (auto &filter : modulesOfInterest) {
-				if (path.find(filter) != std::string::npos) {
-					hasMatchModuleOfInterest = true;
-
-					break;
-				}
-			}
+			if (!hasMatchModuleOfInterest)
+				hasMatchModuleOfInterest = isOwnModule;
 		}
 
 		if (symbols)
 			free(symbols);
 	}
 
+protected:
+	bool IsModuleOfInterest(const char *image) const
+	{
+		if (!image || !*image)
+			return false;
+
+		const std::string path = image;
+
+		for (auto &filter : modulesOfInterest) {
+			if (path.find(filter) != std::string::npos)
+				return true;
+		}
+
+		return false;
+	}
+
 public:
 	bool hasMatchModuleOfInterest = false;
 	std::vector<std::string> modulesOfInterest;
 	std::string output;
+
+private:
+	bool m_skippingOwnFrames = false;
 };
 
 #endif
@@ -409,10 +469,13 @@ StreamElementsCrashContext::~StreamElementsCrashContext()
 	m_impl = nullptr;
 }
 
-void StreamElementsCrashContext::WalkStack(void *contextRecord)
+void StreamElementsCrashContext::WalkStack(void *contextRecord,
+					   bool skipOwnLeadingFrames)
 {
 	if (!m_impl || !m_impl->stackWalker)
 		return;
+
+	m_impl->stackWalker->SetSkipLeadingOwnFrames(skipOwnLeadingFrames);
 
 #ifdef WIN32
 	m_impl->stackWalker->ShowCallstack(::GetCurrentThread(),
@@ -851,11 +914,8 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 		// which is outside this tree entirely, so that entry is only
 		// insurance against the layout changing.
 		L"plugins/obs-streamelements-core.plugin/contents/macos/",
-		L"plugins/obs-streamelements-core/bin/",
-		L"updates/",
-		L"profiler_data/",
-		L"obslive_restored_files/",
-		L"crashes/"};
+		L"plugins/obs-streamelements-core/bin/", L"updates/",
+		L"profiler_data/", L"obslive_restored_files/", L"crashes/"};
 
 	// Collect all files
 	for (auto &i : std::filesystem::recursive_directory_iterator(
@@ -936,9 +996,8 @@ StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()
 	uintmax_t totalBytes = 0;
 
 	for (auto &candidate : candidates) {
-		const uintmax_t fileLimit = candidate.isPlugin
-						    ? maxPluginFileBytes
-						    : maxFileBytes;
+		const uintmax_t fileLimit =
+			candidate.isPlugin ? maxPluginFileBytes : maxFileBytes;
 
 		const bool tooBig = candidate.size > fileLimit;
 		const bool overBudget = totalBytes + candidate.size >

--- a/streamelements/StreamElementsCrashContext.hpp
+++ b/streamelements/StreamElementsCrashContext.hpp
@@ -70,7 +70,15 @@ public:
 	//
 	// `contextRecord` is a PCONTEXT. Typed as void* so the header does not
 	// drag <windows.h> into every translation unit that includes it.
-	void WalkStack(void *contextRecord);
+	//
+	// `skipOwnLeadingFrames` discards the frames at the top of the walk that
+	// belong to this plug-in, before they are recorded or tested. Set it
+	// only when the CONTEXT was captured inside our own crash handler --
+	// the abort()/SIGABRT path -- where our module is on the stack
+	// unconditionally and would otherwise make ShouldReport() true for every
+	// abort in the process. An SEH crash takes its CONTEXT from the OS at
+	// the fault point and must leave this false.
+	void WalkStack(void *contextRecord, bool skipOwnLeadingFrames = false);
 
 	// The module-of-interest verdict: false means the crashing stack never
 	// passed through our code and the report must be suppressed entirely.

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -17,6 +17,13 @@
 #include <stdio.h>
 #include <wchar.h>
 
+// signal() for the SIGABRT door, _set_purecall_handler() for pure virtual
+// calls. Both are process-wide CRT state shared with OBS, which is the point:
+// see the CORE-860 block further down.
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <windows.h>
 #include <dwmapi.h>
 
@@ -500,6 +507,35 @@ static bool IsTagWorthyAttribute(const std::string &name)
 }
 
 //
+// The handful of tags that identify the build, armed at startup rather than on
+// the crash path.
+//
+// Everything else is collected when the process is dying and set in
+// ArmSentryScope(). That is fine while the crash path is the only way an event
+// is produced -- but CORE-860 was exactly the case where it was not, and those
+// events arrived with no product, no version and no platform, which made them
+// nearly impossible to place. These three cost nothing at startup and mean any
+// future bypass still yields an attributable event.
+//
+// Kept to three: with SENTRY_INTEGRATION_WER, tags map onto
+// WerRegisterCustomMetadata, capped at 8. These plus the two set on the crash
+// path plus crash.kind leaves headroom.
+//
+static void ArmStableSentryTags()
+{
+	sentry_set_tag("product", "SE.Live");
+	sentry_set_tag("obs_version", obs_get_version_string());
+
+#if defined(_M_AMD64)
+	sentry_set_tag("arch", "x86_64");
+#elif defined(_M_ARM64)
+	sentry_set_tag("arch", "arm64");
+#else
+	sentry_set_tag("arch", "x86");
+#endif
+}
+
+//
 // Identifies the reporter on every event.
 //
 // The machine id is always present; name and email only once the user has
@@ -640,7 +676,17 @@ ArmSentryScope(const StreamElementsCrashContext::Result &context,
 
 /* ================================================================= */
 
-static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
+//
+// The whole crash path, shared by the two ways a fatal condition reaches us:
+// the top-level SEH filter and the SIGABRT handler below.
+//
+// `skipOwnLeadingFrames` is false for SEH, where the CONTEXT comes from the OS
+// at the fault point, and true for SIGABRT, where we captured it ourselves and
+// our own handler is therefore the innermost frame. See
+// StreamElementsCrashContext::WalkStack.
+//
+static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
+				 bool skipOwnLeadingFrames)
 {
 	if (pExceptionInfo->ExceptionRecord->ExceptionCode ==
 	    EXCEPTION_STACK_OVERFLOW) {
@@ -653,7 +699,8 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 	}
 
 	if (s_crashContext)
-		s_crashContext->WalkStack(pExceptionInfo->ContextRecord);
+		s_crashContext->WalkStack(pExceptionInfo->ContextRecord,
+					  skipOwnLeadingFrames);
 
 	// Stops host API calls from running once we are on the crash path. The
 	// consent prompt below is modal, and a modal message loop keeps
@@ -730,6 +777,107 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 	InterlockedDecrement(&s_insideExceptionFilter);
 
 	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
+{
+	return HandleFatalException(pExceptionInfo, false);
+}
+
+/* ================================================================= */
+
+//
+// The second door (CORE-860).
+//
+// sentry_init() installs TWO crash entry points on Windows, not one --
+// sentry-native/src/backends/native/sentry_crash_handler.c:
+//
+//   g_previous_filter = SetUnhandledExceptionFilter(crash_exception_filter);
+//   sentry__win32_install_sigabrt_handler(crash_sigabrt_handler);
+//
+// The second is a plain signal(SIGABRT, ...). Displacing only the first left
+// every abort() going straight to sentry: uploaded with no consent prompt, no
+// module-of-interest gate and none of the payload, because all of that lives in
+// the filter above. That is not a corner case -- abort() is how EVERY _purecall
+// arrives, which is the entire double-destruction family behind CORE-777 and
+// CORE-786. The one crash class we most need data on was the one class that
+// arrived empty. Observed as SELIVE-E and SELIVE-K.
+//
+// So we take that door too, and route it into the same path.
+//
+// macOS never had this problem: the .mm handler installs its own handlers for
+// all six signals, SIGABRT included, BEFORE sentry_init.
+//
+
+// Sentry's handle_sigabrt, displaced by ours. Only ever used if the shared path
+// above returns, which it should not -- a bug there degrades to sentry's old
+// behaviour rather than to silence.
+static void(__cdecl *s_sentryAbortHandler)(int) = nullptr;
+
+// Set by the purecall handler so the event says what kind of abort this was.
+// A bare "abort" and a pure virtual call want very different investigations.
+static volatile LONG s_abortIsPurecall = 0L;
+
+static void __cdecl SentryAbortHandler(int signum)
+{
+	// abort() carries no exception context, so build the same synthetic
+	// record sentry's own handler builds. RtlCaptureContext captures the
+	// CALLER's context, so the innermost frame is this function -- hence
+	// skipOwnLeadingFrames below.
+	CONTEXT context;
+	RtlCaptureContext(&context);
+
+	EXCEPTION_RECORD record;
+	memset(&record, 0, sizeof(record));
+	record.ExceptionCode = STATUS_FATAL_APP_EXIT;
+	record.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
+#if defined(_M_AMD64)
+	record.ExceptionAddress = (PVOID)context.Rip;
+#elif defined(_M_IX86)
+	record.ExceptionAddress = (PVOID)context.Eip;
+#elif defined(_M_ARM64)
+	record.ExceptionAddress = (PVOID)context.Pc;
+#endif
+
+	EXCEPTION_POINTERS pointers;
+	pointers.ContextRecord = &context;
+	pointers.ExceptionRecord = &record;
+
+	if (s_initialized) {
+		// Cheap, and it survives the gate rejecting the crash, which
+		// costs nothing. Set here rather than in ArmSentryScope because
+		// it describes how we were entered, not what was collected.
+		sentry_set_tag("crash.kind",
+			       s_abortIsPurecall ? "purecall" : "abort");
+	}
+
+	HandleFatalException(&pointers, true);
+
+	// Only reachable on re-entry -- HandleFatalException terminates the
+	// process on the first pass through. Hand back to sentry so a crash is
+	// still reported, then make sure abort() cannot return to its caller.
+	if (s_sentryAbortHandler)
+		s_sentryAbortHandler(signum);
+
+	TerminateProcess(GetCurrentProcess(), 3);
+}
+
+//
+// Without this a pure virtual call arrives as an anonymous abort: the CRT's
+// default _purecall handler just calls abort(), and the resulting event is
+// titled after whatever the innermost resolvable symbol happens to be. Sentry
+// grouped two unrelated ones together as "handle_sigabrt".
+//
+// Deliberately routed through abort() rather than duplicating the handler, so
+// there is exactly one abort path to reason about. The _purecall/abort/raise
+// frames stay in the walked stack, which is useful: they are what identifies
+// the fault.
+//
+static void __cdecl SentryPurecallHandler(void)
+{
+	InterlockedExchange(&s_abortIsPurecall, 1L);
+
+	abort();
 }
 
 /* ================================================================= */
@@ -862,11 +1010,31 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 
 	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
 
+	ArmStableSentryTags();
+
 	// Whatever sentry_init() installed. Ours goes on top, so ours runs
 	// first and this one is invoked by us, deliberately, only when the
 	// module-of-interest gate passes.
 	s_sentryExceptionFilter =
 		SetUnhandledExceptionFilter(SentryExceptionFilter);
+
+	// The other door sentry_init() installed. Same reasoning, same order:
+	// ours on top, sentry's kept as the fallback. Without this, abort() --
+	// and therefore every _purecall -- goes straight to sentry, ungated and
+	// unconsented. See the CORE-860 block above.
+	s_sentryAbortHandler = signal(SIGABRT, SentryAbortHandler);
+
+	if (s_sentryAbortHandler == SIG_ERR) {
+		s_sentryAbortHandler = nullptr;
+
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not install the SIGABRT handler; abort() crashes will bypass the consent prompt and the module-of-interest gate");
+	}
+
+	// Process-wide, and the displaced handler is deliberately dropped: the
+	// CRT's default is "call abort()", which is where ours ends up anyway,
+	// so there is nothing to chain to.
+	_set_purecall_handler(SentryPurecallHandler);
 
 	s_crashContext = new StreamElementsCrashContext();
 

--- a/streamelements/StreamElementsSentryCrashHandler.hpp
+++ b/streamelements/StreamElementsSentryCrashHandler.hpp
@@ -39,6 +39,17 @@
 // sentry_handle_exception" -- a crash whose stack never passed through our code
 // goes straight from step 2 to step 4 and Sentry never hears about it.
 //
+// 3. sentry_init() installs TWO crash entry points on Windows, not one: the
+//    top-level filter above, and a plain signal(SIGABRT, ...). Owning only the
+//    first left abort() -- and therefore every _purecall, which is the whole
+//    double-destruction family behind CORE-777 and CORE-786 -- going straight
+//    to sentry with no gate, no consent prompt and no payload. So this handler
+//    owns both doors, and both funnel into the same path. The only difference
+//    is that the SIGABRT path captures its own CONTEXT, which puts our handler
+//    on the stack and means the leading frames must be dropped before the gate
+//    is applied, or the gate would pass for every abort in the process.
+//    See CORE-860.
+//
 // See CORE-554 for the full design, including why the `native` backend rather
 // than crashpad.
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,11 @@ endfunction()
 se_add_test(test_video_encoder_template_demo
   test_video_encoder_template_demo.cpp)
 
+# --- Behavioural test: CORE-860 (the module-of-interest gate must not be
+#     rubber-stamped by the crash handler's own frames on the abort path) ---
+se_add_test(test_crash_gate_leading_frames
+  test_crash_gate_leading_frames.cpp)
+
 # --- Source-invariant test: catches re-introduction of any of the
 #     bug patterns this PR fixes. ---
 se_add_test(test_source_invariants

--- a/tests/test_crash_gate_leading_frames.cpp
+++ b/tests/test_crash_gate_leading_frames.cpp
@@ -1,0 +1,263 @@
+// CORE-860: the module-of-interest gate on the abort()/SIGABRT path.
+//
+// Background. sentry_init() installs two crash entry points on Windows: the
+// top-level SEH filter, and a plain signal(SIGABRT, ...). We used to own only
+// the first, so every abort() -- and therefore every _purecall, which is the
+// whole double-destruction family -- went straight to Sentry with no consent
+// prompt, no gate and no payload.
+//
+// Taking the second door introduces a hazard that does not exist on the first.
+// An SEH crash gets its CONTEXT from the OS at the fault point, so our handler
+// is not in it. A SIGABRT has no context, so we capture one ourselves with
+// RtlCaptureContext -- from inside our own handler. That puts this plug-in on
+// the stack of EVERY abort in the process, including OBS's and other plugins'.
+// Fed to the gate unchanged, `hasMatchModuleOfInterest` would be true every
+// time: not a gate, a rubber stamp, and every abort in OBS would raise a
+// consent prompt in our name and upload someone else's crash.
+//
+// The fix is to drop the leading frames that belong to us before anything is
+// recorded or tested, and to stop dropping at the first frame that is not ours.
+//
+// This mirrors MyStackWalker's frame filter from StreamElementsCrashContext.cpp
+// -- the real one derives from StackWalker and is entangled with CEF, HTTP and
+// dbghelp, none of which belong in a unit test. The logic under test is the
+// twenty lines of frame filtering, reproduced exactly.
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+// Mirror of MyStackWalker (Windows branch) in StreamElementsCrashContext.cpp.
+struct Walker {
+	std::vector<std::string> modulesOfInterest = {"obs-streamelements-core",
+						      "obs-streamelements"};
+
+	bool hasMatchModuleOfInterest = false;
+
+	// The recorded stack -- what ends up in stack.txt.
+	std::vector<std::string> recorded;
+
+	void SetSkipLeadingOwnFrames(bool skip) { m_skippingOwnFrames = skip; }
+
+	bool IsModuleOfInterest(const char *moduleName) const
+	{
+		if (!moduleName)
+			return false;
+
+		for (auto &filter : modulesOfInterest) {
+#ifdef _WIN32
+			if (_stricmp(filter.c_str(), moduleName) == 0)
+#else
+			if (strcasecmp(filter.c_str(), moduleName) == 0)
+#endif
+				return true;
+		}
+
+		return false;
+	}
+
+	void OnCallstackEntry(const char *moduleName)
+	{
+		if (m_skippingOwnFrames) {
+			if (IsModuleOfInterest(moduleName))
+				return;
+
+			m_skippingOwnFrames = false;
+		}
+
+		recorded.push_back(moduleName ? moduleName : "");
+
+		if (!hasMatchModuleOfInterest)
+			hasMatchModuleOfInterest =
+				IsModuleOfInterest(moduleName);
+	}
+
+	void Walk(const std::vector<const char *> &frames, bool skipOwnLeading)
+	{
+		SetSkipLeadingOwnFrames(skipOwnLeading);
+
+		for (auto *frame : frames)
+			OnCallstackEntry(frame);
+	}
+
+private:
+	bool m_skippingOwnFrames = false;
+};
+
+// The stack an abort() produces once we hold the SIGABRT door. Frame 0 is our
+// own handler, because that is where RtlCaptureContext was called.
+static const std::vector<const char *> kForeignAbort = {
+	"obs-streamelements-core", // SentryAbortHandler  <- ours, and only ours
+	"ucrtbase",                // raise
+	"ucrtbase",                // abort
+	"vcruntime140",            // _purecall
+	"Qt6Widgets",              // the actual fault
+	"obs64",
+};
+
+// Same shape, but the object that was double-destructed is ours.
+static const std::vector<const char *> kOwnAbort = {
+	"obs-streamelements-core", // SentryAbortHandler
+	"ucrtbase",                // raise
+	"ucrtbase",                // abort
+	"vcruntime140",            // _purecall
+	"obs-streamelements-core", // the actual fault -- genuinely ours
+	"Qt6Widgets",
+	"obs64",
+};
+
+// --- The gate must reject a foreign abort ---------------------------------
+static void check_foreign_abort_is_rejected()
+{
+	Walker w;
+	w.Walk(kForeignAbort, true);
+
+	check(!w.hasMatchModuleOfInterest,
+	      "CORE-860: an abort with no plug-in frame below the handler must NOT be reported");
+
+	check(w.recorded.size() == kForeignAbort.size() - 1,
+	      "CORE-860: exactly the one handler frame should be dropped");
+
+	check(!w.recorded.empty() && w.recorded.front() == "ucrtbase",
+	      "CORE-860: skipping must stop at the first frame that is not ours");
+}
+
+// --- ...and this is what makes the difference ------------------------------
+//
+// The negative control. Without the skip, the very same stack passes, which is
+// precisely the rubber stamp this change exists to prevent. If this ever starts
+// failing, the skip has stopped being load-bearing and the test above is
+// passing for the wrong reason.
+static void check_negative_control_without_skip()
+{
+	Walker w;
+	w.Walk(kForeignAbort, false);
+
+	check(w.hasMatchModuleOfInterest,
+	      "CORE-860: negative control -- without the skip this foreign abort would be reported");
+}
+
+// --- A genuine fault of ours must still pass -------------------------------
+static void check_own_abort_is_reported()
+{
+	Walker w;
+	w.Walk(kOwnAbort, true);
+
+	check(w.hasMatchModuleOfInterest,
+	      "CORE-860: an abort whose fault really is ours must still be reported");
+
+	// The skip is one-shot: the second own-module frame is the real fault
+	// and must survive both the record and the verdict.
+	check(w.recorded.size() == kOwnAbort.size() - 1,
+	      "CORE-860: only the leading handler frame may be dropped, not later own frames");
+
+	bool ownFrameRecorded = false;
+	for (auto &m : w.recorded) {
+		if (m == "obs-streamelements-core")
+			ownFrameRecorded = true;
+	}
+
+	check(ownFrameRecorded,
+	      "CORE-860: the real faulting frame must remain in the recorded stack");
+}
+
+// --- The SEH path must be untouched ----------------------------------------
+static void check_seh_path_unchanged()
+{
+	const std::vector<const char *> foreign = {"Qt6Widgets", "obs64",
+						   "ntdll"};
+	const std::vector<const char *> ours = {"obs-streamelements-core",
+						"Qt6Widgets", "obs64"};
+
+	Walker a;
+	a.Walk(foreign, false);
+	check(!a.hasMatchModuleOfInterest,
+	      "CORE-860: SEH gate must still reject a foreign crash");
+	check(a.recorded.size() == foreign.size(),
+	      "CORE-860: the SEH path must drop no frames at all");
+
+	Walker b;
+	b.Walk(ours, false);
+	check(b.hasMatchModuleOfInterest,
+	      "CORE-860: SEH gate must still accept our own crash");
+	check(b.recorded.size() == ours.size(),
+	      "CORE-860: the SEH path must drop no frames at all");
+}
+
+// --- Consecutive leading own frames all go ---------------------------------
+//
+// The handler is one frame today, but inlining, a helper, or a future change
+// could make it several. Skipping is defined by "still ours", not by a count.
+static void check_multiple_leading_own_frames()
+{
+	const std::vector<const char *> frames = {
+		"obs-streamelements-core",
+		"obs-streamelements",
+		"obs-streamelements-core",
+		"ucrtbase",
+		"Qt6Widgets",
+	};
+
+	Walker w;
+	w.Walk(frames, true);
+
+	check(!w.hasMatchModuleOfInterest,
+	      "CORE-860: a run of leading own frames must all be skipped");
+	check(w.recorded.size() == 2,
+	      "CORE-860: only the leading run of own frames may be dropped");
+}
+
+// --- Module matching stays case-insensitive --------------------------------
+static void check_case_insensitive()
+{
+	const std::vector<const char *> frames = {"OBS-StreamElements-Core",
+						  "ucrtbase", "Qt6Widgets"};
+
+	Walker w;
+	w.Walk(frames, true);
+
+	check(!w.hasMatchModuleOfInterest,
+	      "CORE-860: module matching must stay case-insensitive when skipping");
+}
+
+// --- A null module name must not crash the walk ----------------------------
+static void check_null_module_name()
+{
+	Walker w;
+	w.SetSkipLeadingOwnFrames(true);
+	w.OnCallstackEntry(nullptr);
+
+	check(!w.hasMatchModuleOfInterest,
+	      "CORE-860: a null module name must not pass the gate");
+}
+
+int main()
+{
+	check_foreign_abort_is_rejected();
+	check_negative_control_without_skip();
+	check_own_abort_is_reported();
+	check_seh_path_unchanged();
+	check_multiple_leading_own_frames();
+	check_case_insensitive();
+	check_null_module_name();
+
+	if (failures) {
+		std::fprintf(stderr, "%d crash-gate check(s) failed\n",
+			     failures);
+		return 1;
+	}
+
+	std::puts("test_crash_gate_leading_frames: all checks passed");
+	return 0;
+}

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -76,7 +76,8 @@ static void check_c4_no_self_assign_cefclientid()
 {
 	auto src = slurp("streamelements/StreamElementsApiMessageHandler.cpp");
 
-	std::regex bad(R"(context\s*->\s*cefClientId\s*=\s*context\s*->\s*cefClientId)");
+	std::regex bad(
+		R"(context\s*->\s*cefClientId\s*=\s*context\s*->\s*cefClientId)");
 	check(count_matches(src, bad) == 0,
 	      "C4: StreamElementsApiMessageHandler.cpp must not contain "
 	      "`context->cefClientId = context->cefClientId` (self-assign)");
@@ -132,9 +133,10 @@ static void check_c10_no_duplicate_handler_setcurrentprofile()
 	std::regex reg(R"(API_HANDLER_BEGIN\(\"setCurrentProfile\"\))");
 	std::size_t count = count_matches(src, reg);
 	if (count != 1) {
-		std::fprintf(stderr,
-			     "FAIL: C10: setCurrentProfile is registered %zu time(s); expected exactly 1\n",
-			     count);
+		std::fprintf(
+			stderr,
+			"FAIL: C10: setCurrentProfile is registered %zu time(s); expected exactly 1\n",
+			count);
 		++failures;
 	}
 }
@@ -155,8 +157,7 @@ static void check_c10_no_duplicate_handler_setcurrentprofile()
 //   UpdateInternal+0x54  mov rcx,[rsi+18h]  rsi=0  ->  read of 0x18
 static void check_menu_manager_update_guarded()
 {
-	auto src = slurp(
-		"streamelements/StreamElementsGlobalStateManager.cpp");
+	auto src = slurp("streamelements/StreamElementsGlobalStateManager.cpp");
 
 	// Every occurrence must be the guarded one. Counting both forms and
 	// comparing is what distinguishes them: the call sits on its own line
@@ -401,7 +402,8 @@ static void check_dock_deletion_is_gated()
 // fires EXIT.
 static void check_obs_close_is_watched()
 {
-	auto code = strip_line_comments(slurp("obs-streamelements-core-plugin.cpp"));
+	auto code = strip_line_comments(
+		slurp("obs-streamelements-core-plugin.cpp"));
 
 	check(code.find("QEvent::Close") != std::string::npos,
 	      "CORE-786: the plug-in must watch for QEvent::Close on the OBS main window");
@@ -460,6 +462,85 @@ static void check_obs_close_is_watched()
 	      "CORE-786: Initialize() must call SENoteInitializeCompleted() on completion");
 }
 
+// --- CORE-860: both of sentry's crash entry points must be ours.
+//
+// sentry_init() installs a top-level SEH filter AND a signal(SIGABRT, ...)
+// handler. Owning only the first sent every abort() -- every _purecall, so the
+// whole double-destruction family -- straight to Sentry with no consent prompt,
+// no module-of-interest gate and no payload.
+static void check_both_sentry_doors_are_owned()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp"));
+
+	check(code.find("SetUnhandledExceptionFilter(SentryExceptionFilter)") !=
+		      std::string::npos,
+	      "CORE-860: the SEH filter must still be installed");
+
+	check(code.find("signal(SIGABRT,") != std::string::npos,
+	      "CORE-860: the SIGABRT door must be taken too, or abort() bypasses the gate and the consent prompt");
+
+	check(code.find("_set_purecall_handler(") != std::string::npos,
+	      "CORE-860: a pure virtual call must be identified as such, not arrive as an anonymous abort");
+
+	// Both doors must funnel into the same path, or the gate and the
+	// consent prompt exist on only one of them.
+	check(count_matches(code, std::regex("HandleFatalException\\(")) >= 3,
+	      "CORE-860: both entry points must call the shared HandleFatalException()");
+
+	// The SEH path takes its CONTEXT from the OS at the fault point; the
+	// abort path captures its own, from inside our handler. Only the latter
+	// may drop leading frames -- see check_abort_path_drops_own_frames.
+	check(code.find("HandleFatalException(pExceptionInfo, false)") !=
+		      std::string::npos,
+	      "CORE-860: the SEH path must NOT skip leading frames");
+
+	check(code.find("HandleFatalException(&pointers, true)") !=
+		      std::string::npos,
+	      "CORE-860: the abort path MUST skip its own leading frames");
+
+	// Identity has to survive a future bypass of the crash path.
+	check(code.find("ArmStableSentryTags();") != std::string::npos,
+	      "CORE-860: the stable identity tags must be armed at init, not only on the crash path");
+}
+
+// --- CORE-860: the abort path must not rubber-stamp the gate.
+//
+// The SIGABRT handler captures its own CONTEXT, so this plug-in is on the stack
+// of every abort in the process. Without dropping those leading frames, the
+// module-of-interest verdict is true for everyone's crashes.
+static void check_abort_path_drops_own_frames()
+{
+	auto hpp = strip_line_comments(
+		slurp("streamelements/StreamElementsCrashContext.hpp"));
+
+	check(hpp.find("bool skipOwnLeadingFrames") != std::string::npos,
+	      "CORE-860: WalkStack() must offer the leading-frame skip");
+
+	auto cpp = strip_line_comments(
+		slurp("streamelements/StreamElementsCrashContext.cpp"));
+
+	check(cpp.find("SetSkipLeadingOwnFrames(skipOwnLeadingFrames)") !=
+		      std::string::npos,
+	      "CORE-860: WalkStack() must pass the skip flag through to the walker");
+
+	// The skip must run before the frame is recorded and before the verdict
+	// is taken, and must stop at the first frame that is not ours.
+	auto skip = cpp.find("if (m_skippingOwnFrames) {");
+	check(skip != std::string::npos,
+	      "CORE-860: the walker must implement the leading-frame skip");
+
+	if (skip != std::string::npos) {
+		auto verdict = cpp.find("hasMatchModuleOfInterest =", skip);
+		check(verdict != std::string::npos && verdict > skip,
+		      "CORE-860: the skip must be applied before the module-of-interest verdict");
+
+		auto stops = cpp.find("m_skippingOwnFrames = false;", skip);
+		check(stops != std::string::npos && stops - skip < 200,
+		      "CORE-860: skipping must stop at the first frame that is not ours");
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -473,6 +554,8 @@ int main()
 	check_event_pumps_are_counted();
 	check_dock_deletion_is_gated();
 	check_obs_close_is_watched();
+	check_both_sentry_doors_are_owned();
+	check_abort_path_drops_own_frames();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
`sentry_init()` installs **two** crash entry points on Windows, not one — `sentry-native/src/backends/native/sentry_crash_handler.c:1094`:

```c
g_previous_filter = SetUnhandledExceptionFilter(crash_exception_filter);
sentry__win32_install_sigabrt_handler(crash_sigabrt_handler);
```

We only ever displaced the first. So every `abort()` — and therefore every `_purecall`, which is the whole double-destruction family behind CORE-777 and CORE-786 — went straight to Sentry with **no consent prompt, no module-of-interest gate and no payload**, because all of that lives in the filter we owned.

Found while analysing **SELIVE-K**. Measured: 2 users, 2 events, both uploaded without being asked and without a single attachment or tag. Every other event in the project came through the filter correctly, which is a clean confirmation of the mechanism — aborts bypassed, nothing else did.

## The gate hazard this introduces

An SEH crash gets its `CONTEXT` from the OS at the fault point, so our filter is not in it. A SIGABRT has no context, so we capture one ourselves — from inside our own handler, which puts this plug-in on the stack of **every** abort in the process. Fed to the gate unchanged, `hasMatchModuleOfInterest` would be true every time: not a gate, a rubber stamp, and every abort in OBS would raise a consent prompt in our name and upload someone else's crash.

So `WalkStack()` grows an opt-in that drops the leading frames belonging to us, stopping at the first frame that is not ours. A fault genuinely inside our code reappears below the CRT's abort machinery and still passes. The SEH path must never set it, and an invariant asserts that.

## Also

- **`_set_purecall_handler()`** — a pure virtual call is now identified as such rather than arriving as an anonymous abort. Sentry had grouped two unrelated ones under `handle_sigabrt`.
- **Stable tags armed at init** (`product`, `obs_version`, `arch`) rather than only on the crash path, so any future bypass still yields an attributable event.

## macOS is unaffected

`StreamElementsSentryCrashHandler.mm:53` already installs handlers for all six signals, `SIGABRT` included, **before** `sentry_init`.

## Verification

End to end against a real OBS 32.2.2, firing a genuine pure virtual call through a temporary trigger (reverted before commit). The captured stack shows the full new chain:

```
trigger -> VCRUNTIME140!_purecall -> SentryPurecallHandler -> abort -> raise
        -> SentryAbortHandler -> HandleFatalException -> consent dialog
```

| | before (SELIVE-K) | after (SELIVE-M) |
| -- | -- | -- |
| consent prompt | never shown | shown |
| title | `handle_sigabrt` (sentry's) | `SentryAbortHandler` (ours) |
| `product` / `obs_version` / `arch` | empty | `SE.Live` / `32.2.2` / `x86_64` |
| `crash.kind` | empty | `purecall` |
| contexts | none | `selive`, `async_call_context`, `user_report` |
| attachments | **0** | **4** — config zip, async-context, api-context, stack.txt |

## Tests

- `test_crash_gate_leading_frames` — behavioural, mirrors the walker's frame filter: foreign abort rejected, own abort still reported, SEH path unchanged, runs of leading frames, case-insensitivity, null module name. Includes a **negative control** that fails if the skip ever stops being load-bearing.
- Two new source invariants covering both doors, the skip flag, and init-time tags.

All eight negative-tested — each new check was individually made to fail by reverting the thing it guards, then restored.

Local gates: plugin builds clean under `/WX`, `ctest` 3/3, clang-format clean.

Fixes CORE-860