### PR TITLE
fix(crash): take the allocation door, and release the guard buffer first (CORE-863)

### DIFF
--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -18,10 +18,13 @@
 #include <stdio.h>
 #include <wchar.h>
 
-// signal() for the SIGABRT door, _set_purecall_handler() for pure virtual
-// calls. Both are process-wide CRT state shared with OBS, which is the point:
-// see the CORE-860 block further down.
+// The CRT doors into a dying process: signal() for SIGABRT,
+// _set_purecall_handler() for pure virtual calls, _set_new_handler() and
+// _set_new_mode() for allocation failure. All of it is process-wide state
+// shared with OBS, which is the point -- see the CORE-860 and CORE-863 blocks
+// further down.
 #include <signal.h>
+#include <new.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -53,6 +56,14 @@ static LPTOP_LEVEL_EXCEPTION_FILTER s_sentryExceptionFilter = nullptr;
 static LPTOP_LEVEL_EXCEPTION_FILTER s_hostExceptionFilter = nullptr;
 
 static LONG s_insideExceptionFilter = 0L;
+
+// What killed us, read by HandleFatalException() to set crash.kind and written
+// by the CRT handlers far below. Declared here only because the reader comes
+// first in the file; the reasoning for each lives with the handler that sets it.
+//
+// Both are one-way: nothing clears them.
+static volatile LONG s_abortIsPurecall = 0L; // the purecall door (CORE-860)
+static volatile LONG s_sawOutOfMemory = 0L;  // the allocation door (CORE-863)
 
 // Contact details from the last report the user filled in. Read once at
 // startup, so the crash path never has to touch the config to prefill the
@@ -800,14 +811,72 @@ ArmSentryScope(const StreamElementsCrashContext::Result &context,
 // The whole crash path, shared by the two ways a fatal condition reaches us:
 // the top-level SEH filter and the SIGABRT handler below.
 //
-// `skipOwnLeadingFrames` is false for SEH, where the CONTEXT comes from the OS
-// at the fault point, and true for SIGABRT, where we captured it ourselves and
-// our own handler is therefore the innermost frame. See
-// StreamElementsCrashContext::WalkStack.
+// `fromAbortDoor` says which. One flag rather than two, because the two things
+// it decides follow from the same fact and must never disagree:
+//
+//   - the stack walk drops our own leading frames, because the abort door is
+//     the one where we captured the CONTEXT ourselves and our handler is
+//     therefore the innermost frame. SEH takes its CONTEXT from the OS at the
+//     fault point, where we are not on the stack at all. See
+//     StreamElementsCrashContext::WalkStack.
+//
+//   - crash.kind falls back to "abort" rather than "exception".
 //
 static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
-				 bool skipOwnLeadingFrames)
+				 bool fromAbortDoor)
 {
+	//
+	// First statement in the whole crash path, and it has to be (CORE-863).
+	//
+	// StreamElementsCrashContext reserves 1MB at construction so that
+	// collection has headroom on a process that died of exhaustion. That
+	// reserve used to be handed back on the first line of Collect() -- which
+	// runs after the stack walk and after the consent prompt, both of which
+	// allocate. On the one crash class the reserve exists for, it was not
+	// available to the two things most likely to fail first.
+	//
+	// Safe to call more than once; the second call does nothing. The new
+	// handler calls it too, earlier still.
+	//
+	StreamElementsCrashContext::ReleaseGuardBuffer();
+
+	//
+	// What killed us, on whichever door we came through.
+	//
+	// This lives here rather than in the SIGABRT handler, and that placement
+	// was bought with a wasted test run: an uncaught std::bad_alloc does NOT
+	// reach abort() on MSVC. `throw` becomes a real SEH exception
+	// (0xE06D7363, RaiseException), so an unhandled one lands in the filter
+	// above, not in the abort door. Tagging only in the abort handler meant
+	// the OOM this was written for arrived untagged. Both doors funnel
+	// through here, so this is the only correct place for it.
+	//
+	// Precedence, and it matters which way round:
+	//
+	//   purecall  proximate and certain -- the CRT told us moments ago that
+	//             the call which failed was a pure virtual one.
+	//
+	//   oom       inferred and STICKY. It says an allocation failed at some
+	//             point, not that it is why we are dying; a failure that was
+	//             caught and handled leaves it set for the life of the
+	//             process. So it must not outrank purecall, or it would
+	//             relabel a later, unrelated crash. It does outrank the two
+	//             below, which carry no cause at all.
+	//
+	//   abort     came through the SIGABRT door with no better explanation.
+	//
+	//   exception came through the SEH filter -- an access violation, or a
+	//             C++ exception nobody caught.
+	//
+	if (s_initialized) {
+		const char *kind = s_abortIsPurecall  ? "purecall"
+				   : s_sawOutOfMemory ? "oom"
+				   : fromAbortDoor    ? "abort"
+						      : "exception";
+
+		sentry_set_tag("crash.kind", kind);
+	}
+
 	if (pExceptionInfo->ExceptionRecord->ExceptionCode ==
 	    EXCEPTION_STACK_OVERFLOW) {
 		static ULONG stack_size = 0L;
@@ -819,8 +888,9 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 	}
 
 	if (s_crashContext)
-		s_crashContext->WalkStack(pExceptionInfo->ContextRecord,
-					  skipOwnLeadingFrames);
+		s_crashContext->WalkStack(
+			pExceptionInfo->ContextRecord,
+			/*skipOwnLeadingFrames=*/fromAbortDoor);
 
 	// Stops host API calls from running once we are on the crash path. The
 	// consent prompt below is modal, and a modal message loop keeps
@@ -934,9 +1004,52 @@ static LONG CALLBACK SentryExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 // behaviour rather than to silence.
 static void(__cdecl *s_sentryAbortHandler)(int) = nullptr;
 
-// Set by the purecall handler so the event says what kind of abort this was.
-// A bare "abort" and a pure virtual call want very different investigations.
-static volatile LONG s_abortIsPurecall = 0L;
+//
+// Out of memory (CORE-863).
+//
+// The BugSplat integration installed five process-global CRT hooks -- purecall,
+// SIGABRT, terminate, invalid-parameter and this one -- all routed to a
+// deliberate null write so the exception filter would see them. The Sentry
+// migration dropped all five; CORE-860 recovered the first two. This is the
+// allocation one.
+//
+// Deliberately NOT what BugSplat did. Its memory_depleted() force-crashes the
+// process on any allocation failure, and _set_new_mode(1) extends that to plain
+// malloc -- which would preempt libobs's own bmalloc -> bcrash handling. A
+// plug-in overriding the host's allocation-failure policy is not a call we get
+// to make.
+//
+// So this observes and chains. Standard semantics are preserved exactly:
+// returning 0 means operator new throws std::bad_alloc and malloc returns NULL,
+// as they do today. If that goes unhandled it reaches abort() and the SIGABRT
+// handler above, which can now say the crash was an OOM rather than a generic
+// abort. If it IS handled, nothing is broken and nothing is reported -- a
+// handled allocation failure is not a crash.
+//
+static _PNH s_previousNewHandler = nullptr;
+static int s_previousNewMode = 0;
+
+static int __cdecl SentryNewHandler(size_t size)
+{
+	InterlockedExchange(&s_sawOutOfMemory, 1L);
+
+	// Now, not later. This is the moment the process has no memory, and the
+	// crash path is about to want some -- the stack walk and the consent
+	// prompt both allocate before Collect() runs. Safe to call more than
+	// once; the second call does nothing.
+	StreamElementsCrashContext::ReleaseGuardBuffer();
+
+	// Nothing is logged here on purpose: blog() formats, and formatting
+	// allocates, on the one code path where allocation is what failed.
+
+	// Chain. If whoever held this handler before us can free something and
+	// ask for a retry, that is a better outcome than a crash and it is
+	// theirs to decide, not ours.
+	if (s_previousNewHandler)
+		return s_previousNewHandler(size);
+
+	return 0;
+}
 
 static void __cdecl SentryAbortHandler(int signum)
 {
@@ -962,14 +1075,6 @@ static void __cdecl SentryAbortHandler(int signum)
 	EXCEPTION_POINTERS pointers;
 	pointers.ContextRecord = &context;
 	pointers.ExceptionRecord = &record;
-
-	if (s_initialized) {
-		// Cheap, and it survives the gate rejecting the crash, which
-		// costs nothing. Set here rather than in ArmSentryScope because
-		// it describes how we were entered, not what was collected.
-		sentry_set_tag("crash.kind",
-			       s_abortIsPurecall ? "purecall" : "abort");
-	}
 
 	HandleFatalException(&pointers, true);
 
@@ -1191,6 +1296,21 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	// CRT's default is "call abort()", which is where ours ends up anyway,
 	// so there is nothing to chain to.
 	_set_purecall_handler(SentryPurecallHandler);
+
+	// The allocation door (CORE-863). Unlike purecall, this one CAN be
+	// chained -- _set_new_handler hands back whoever held it -- and is,
+	// because an upstream handler that can free memory and ask for a retry
+	// should still win.
+	s_previousNewHandler = _set_new_handler(SentryNewHandler);
+
+	// Routes plain malloc failures through the handler above as well, not
+	// just operator new. libobs allocates through bmalloc -> malloc, so
+	// without this the largest allocator in the process is invisible to it.
+	//
+	// Not a behaviour change on its own: the handler returns 0 unless
+	// something upstream asked for a retry, and malloc then returns NULL
+	// exactly as it does today.
+	s_previousNewMode = _set_new_mode(1);
 
 	s_crashContext = new StreamElementsCrashContext();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,11 @@ se_add_test(test_crash_gate_leading_frames
 se_add_test(test_crash_suppresses_queued_tasks
   test_crash_suppresses_queued_tasks.cpp)
 
+# --- Behavioural test: CORE-863 (the OOM handler must observe and chain,
+#     not seize the host's allocation-failure policy) ---
+se_add_test(test_crash_oom_handler
+  test_crash_oom_handler.cpp)
+
 # --- Source-invariant test: catches re-introduction of any of the
 #     bug patterns this PR fixes. ---
 se_add_test(test_source_invariants

--- a/tests/test_crash_oom_handler.cpp
+++ b/tests/test_crash_oom_handler.cpp
@@ -1,0 +1,282 @@
+// CORE-863: the out-of-memory handler must observe and chain, not seize.
+//
+// Background. BugSplat installed five process-global CRT hooks; the Sentry
+// migration dropped all five, and CORE-860 recovered two. This is the
+// allocation one -- _set_new_handler plus _set_new_mode.
+//
+// The design decision under test is that our handler is NOT what BugSplat's
+// was. BugSplat's memory_depleted() force-crashes the process on any allocation
+// failure, and _set_new_mode(1) extends that to plain malloc -- which would
+// preempt libobs's own bmalloc -> bcrash handling. A plug-in does not get to
+// override the host's allocation-failure policy.
+//
+// So ours must:
+//   - record that an OOM happened,
+//   - hand back the 1MB guard buffer at the moment memory ran out, not later,
+//   - chain to whoever held the handler before us and honour a retry request,
+//   - and otherwise return 0, preserving standard semantics exactly:
+//     operator new throws std::bad_alloc, malloc returns NULL.
+//
+// Mirrors SentryNewHandler and the crash.kind precedence from
+// StreamElementsSentryCrashHandler.cpp. The real ones need the CRT and sentry;
+// the logic under test is the twenty lines reproduced here.
+
+#include <cstdio>
+#include <cstddef>
+#include <string>
+
+static int failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+/* ================================================================= */
+
+#ifndef _WIN32
+#define __cdecl
+#endif
+
+typedef int(__cdecl *NewHandler)(size_t);
+
+static long g_sawOutOfMemory = 0;
+static long g_abortIsPurecall = 0;
+static int g_guardReleaseCount = 0;
+static bool g_guardBufferHeld = true;
+
+static NewHandler g_previousNewHandler = nullptr;
+
+// Mirror of StreamElementsCrashContext::ReleaseGuardBuffer -- idempotent.
+static void ReleaseGuardBuffer()
+{
+	++g_guardReleaseCount;
+
+	if (!g_guardBufferHeld)
+		return;
+
+	g_guardBufferHeld = false;
+}
+
+// Mirror of SentryNewHandler.
+static int SentryNewHandler(size_t size)
+{
+	g_sawOutOfMemory = 1;
+
+	ReleaseGuardBuffer();
+
+	if (g_previousNewHandler)
+		return g_previousNewHandler(size);
+
+	return 0;
+}
+
+// Mirror of the crash.kind selection in HandleFatalException.
+//
+// `fromAbortDoor` distinguishes the two entry points. It matters more than it
+// looks: an uncaught std::bad_alloc does NOT reach abort() on MSVC -- `throw`
+// raises a real SEH exception, so the OOM case arrives with fromAbortDoor
+// false, through the filter.
+static const char *CrashKind(bool fromAbortDoor)
+{
+	return g_abortIsPurecall  ? "purecall"
+	       : g_sawOutOfMemory ? "oom"
+	       : fromAbortDoor    ? "abort"
+				  : "exception";
+}
+
+static void Reset()
+{
+	g_sawOutOfMemory = 0;
+	g_abortIsPurecall = 0;
+	g_guardReleaseCount = 0;
+	g_guardBufferHeld = true;
+	g_previousNewHandler = nullptr;
+}
+
+/* ================================================================= */
+
+// --- Standard semantics are preserved --------------------------------------
+//
+// Returning 0 is what makes operator new throw std::bad_alloc and malloc return
+// NULL. Returning non-zero tells the CRT to retry the allocation, so a handler
+// that returned non-zero unconditionally would spin forever.
+static void check_returns_zero_without_a_chain()
+{
+	Reset();
+
+	check(SentryNewHandler(4096) == 0,
+	      "CORE-863: with no previous handler the new handler must return 0, or operator new never throws and malloc never returns NULL");
+}
+
+// --- It records the OOM ----------------------------------------------------
+static void check_records_the_oom()
+{
+	Reset();
+
+	check(CrashKind(true) == std::string("abort"),
+	      "CORE-863: before any allocation failure the abort door must report a plain abort");
+	check(CrashKind(false) == std::string("exception"),
+	      "CORE-863: before any allocation failure the SEH door must report an exception, not an abort");
+
+	SentryNewHandler(4096);
+
+	check(g_sawOutOfMemory == 1,
+	      "CORE-863: the handler must record that an allocation failed");
+	check(CrashKind(true) == std::string("oom"),
+	      "CORE-863: an abort after an allocation failure must be reported as an OOM");
+}
+
+// --- The guard buffer is released here, not in Collect() -------------------
+//
+// This is the whole reason the reserve exists: the moment memory ran out is the
+// moment the crash path needs headroom.
+static void check_releases_the_guard_buffer()
+{
+	Reset();
+
+	check(g_guardBufferHeld,
+	      "CORE-863: the guard buffer should be held before any failure");
+
+	SentryNewHandler(4096);
+
+	check(!g_guardBufferHeld,
+	      "CORE-863: the new handler must hand the guard buffer back immediately");
+}
+
+// --- Releasing twice is harmless -------------------------------------------
+//
+// HandleFatalException also releases it, and both may run.
+static void check_guard_release_is_idempotent()
+{
+	Reset();
+
+	SentryNewHandler(4096);
+	SentryNewHandler(8192);
+	ReleaseGuardBuffer(); // as HandleFatalException does
+
+	check(g_guardReleaseCount == 3,
+	      "CORE-863: every release attempt should be counted by this mirror");
+	check(!g_guardBufferHeld,
+	      "CORE-863: repeated release must stay released and must not fault");
+}
+
+/* ================================================================= */
+
+static int g_previousCalledWith = 0;
+static int g_previousReturns = 0;
+
+static int PreviousHandler(size_t size)
+{
+	g_previousCalledWith = (int)size;
+
+	return g_previousReturns;
+}
+
+// --- Chaining: an upstream retry wins --------------------------------------
+//
+// If whoever held the handler before us can free something and asks for a
+// retry, that is a better outcome than a crash, and it is theirs to decide.
+static void check_chains_and_honours_retry()
+{
+	Reset();
+	g_previousNewHandler = &PreviousHandler;
+	g_previousCalledWith = 0;
+	g_previousReturns = 1; // "I freed something, try again"
+
+	const int result = SentryNewHandler(12345);
+
+	check(g_previousCalledWith == 12345,
+	      "CORE-863: the previous handler must be called, with the original size");
+	check(result == 1,
+	      "CORE-863: an upstream retry request must be passed through, not swallowed");
+}
+
+// --- Chaining: an upstream refusal is passed through too -------------------
+static void check_chains_refusal()
+{
+	Reset();
+	g_previousNewHandler = &PreviousHandler;
+	g_previousReturns = 0; // "I cannot help either"
+
+	check(SentryNewHandler(4096) == 0,
+	      "CORE-863: an upstream refusal must still end in 0 so the standard path runs");
+}
+
+// --- Even a chained retry still records the OOM ----------------------------
+//
+// The allocation may yet succeed, but it failed once, and that is worth knowing
+// if the process dies later.
+static void check_records_even_when_retried()
+{
+	Reset();
+	g_previousNewHandler = &PreviousHandler;
+	g_previousReturns = 1;
+
+	SentryNewHandler(4096);
+
+	check(g_sawOutOfMemory == 1,
+	      "CORE-863: a recovered allocation failure must still be recorded");
+	check(!g_guardBufferHeld,
+	      "CORE-863: the guard buffer is released on any failure, recovered or not");
+}
+
+/* ================================================================= */
+
+// --- Precedence: purecall outranks a sticky OOM flag -----------------------
+//
+// The OOM flag is inferred and never cleared. A failure that was caught and
+// handled leaves it set forever, so it must not relabel a later, unrelated
+// pure-virtual crash.
+static void check_purecall_outranks_stale_oom()
+{
+	Reset();
+
+	SentryNewHandler(4096); // handled fine, long ago
+	g_abortIsPurecall = 1;  // and now something else kills us
+
+	check(CrashKind(true) == std::string("purecall"),
+	      "CORE-863: a definite, proximate purecall must outrank a sticky OOM flag");
+}
+
+// --- ...but OOM outranks a bare abort, on either door ---
+//
+// This is the std::bad_alloc -> terminate -> abort path the handler exists for.
+static void check_oom_outranks_bare_abort()
+{
+	Reset();
+
+	SentryNewHandler(4096);
+
+	// Through the SEH door, because that is how an uncaught bad_alloc
+	// actually arrives -- verified by a real OOM, not assumed.
+	check(CrashKind(false) == std::string("oom"),
+	      "CORE-863: an uncaught bad_alloc arrives through the SEH filter and must still be reported as an OOM");
+	check(CrashKind(true) == std::string("oom"),
+	      "CORE-863: and so must one that arrives through the abort door");
+}
+
+int main()
+{
+	check_returns_zero_without_a_chain();
+	check_records_the_oom();
+	check_releases_the_guard_buffer();
+	check_guard_release_is_idempotent();
+	check_chains_and_honours_retry();
+	check_chains_refusal();
+	check_records_even_when_retried();
+	check_purecall_outranks_stale_oom();
+	check_oom_outranks_bare_abort();
+
+	if (failures) {
+		std::fprintf(stderr, "%d OOM-handler check(s) failed\n",
+			     failures);
+		return 1;
+	}
+
+	std::puts("test_crash_oom_handler: all checks passed");
+	return 0;
+}

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -644,6 +644,123 @@ static void check_queued_tasks_suppressed_during_crash()
 	      "CORE-862: the crash gate must precede item->running, or dropped tasks appear as running in async-context.json");
 }
 
+// --- CORE-863: the allocation door must be owned, chained, and not seized.
+//
+// BugSplat installed five process-global CRT hooks; the Sentry migration
+// dropped all five and CORE-860 recovered two. This is the allocation one.
+//
+// The design constraint is as important as the hook itself: BugSplat's
+// memory_depleted() force-crashes on any allocation failure, which would
+// preempt libobs's own bmalloc -> bcrash handling. Ours observes and chains.
+static void check_oom_handler_observes_and_chains()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp"));
+
+	check(code.find("_set_new_handler(SentryNewHandler)") !=
+		      std::string::npos,
+	      "CORE-863: the allocation door must be taken, or an OOM is reported as a generic abort at best");
+
+	// malloc failures must route through it too -- libobs allocates through
+	// bmalloc -> malloc, which is the largest allocator in the process.
+	check(code.find("_set_new_mode(1)") != std::string::npos,
+	      "CORE-863: _set_new_mode(1) must route malloc failures through the handler as well");
+
+	// The displaced handler must be kept and called: an upstream handler
+	// that can free memory and ask for a retry has to still win.
+	check(code.find("s_previousNewHandler = _set_new_handler(") !=
+		      std::string::npos,
+	      "CORE-863: the displaced new handler must be captured for chaining");
+
+	std::regex chains(
+		R"(if \(s_previousNewHandler\)\s*return s_previousNewHandler\(size\);)");
+	check(count_matches(code, chains) == 1,
+	      "CORE-863: the handler must chain and pass the upstream answer through, not swallow a retry request");
+
+	// And it must otherwise return 0 -- that is what preserves standard
+	// semantics (bad_alloc thrown, malloc returns NULL) rather than seizing
+	// the host's policy the way BugSplat's terminator() did.
+	auto handler = code.find("int __cdecl SentryNewHandler(size_t size)");
+	check(handler != std::string::npos,
+	      "CORE-863: SentryNewHandler not found -- update this invariant");
+
+	if (handler != std::string::npos) {
+		auto body = code.substr(handler, 700);
+
+		check(body.find("return 0;") != std::string::npos,
+		      "CORE-863: the handler must return 0 when nothing upstream can help, so operator new still throws and malloc still returns NULL");
+
+		check(body.find("terminator") == std::string::npos &&
+			      body.find("TerminateProcess") ==
+				      std::string::npos,
+		      "CORE-863: the handler must NOT force-crash the process -- that would preempt libobs's own bmalloc failure handling");
+
+		// The guard buffer exists for exactly this moment.
+		check(body.find("ReleaseGuardBuffer();") != std::string::npos,
+		      "CORE-863: the new handler must hand the guard buffer back at the moment memory ran out");
+	}
+
+	// crash.kind precedence: a sticky, inferred OOM flag must not relabel a
+	// definite, proximate purecall.
+	std::regex kindPrecedence(
+		R"(s_abortIsPurecall\s*\?\s*"purecall"\s*:\s*s_sawOutOfMemory\s*\?\s*"oom"\s*:\s*fromAbortDoor\s*\?\s*"abort"\s*:\s*"exception")");
+	check(count_matches(code, kindPrecedence) == 1,
+	      "CORE-863: crash.kind must rank purecall above the sticky OOM flag, OOM above a bare abort, and distinguish the two doors");
+
+	// And it must be set on the SHARED path, not in the abort handler.
+	// An uncaught std::bad_alloc never reaches abort() on MSVC -- `throw`
+	// raises a real SEH exception (0xE06D7363), so it lands in the filter.
+	// Tagging only in the abort handler left the OOM this exists for
+	// untagged, which a test run caught.
+	auto shared = code.find(
+		"static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,");
+	auto tag = code.find("sentry_set_tag(\"crash.kind\", kind);");
+	auto abortDoor = code.find("static void __cdecl SentryAbortHandler(");
+
+	check(shared != std::string::npos && tag != std::string::npos &&
+		      abortDoor != std::string::npos,
+	      "CORE-863: crash.kind wiring not found -- update this invariant");
+
+	if (shared != std::string::npos && tag != std::string::npos &&
+	    abortDoor != std::string::npos) {
+		check(tag > shared && tag < abortDoor,
+		      "CORE-863: crash.kind must be set on the shared crash path, not only in the abort handler -- an uncaught bad_alloc arrives through the SEH filter");
+	}
+}
+
+// --- CORE-863: the guard buffer must be released before anything allocates.
+//
+// It is reserved so that collection has headroom on an exhausted process. It
+// used to be handed back on the first line of Collect(), which runs after the
+// stack walk and after the consent prompt -- both of which allocate.
+static void check_guard_buffer_released_first()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp"));
+
+	auto entry = code.find(
+		"static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,");
+	check(entry != std::string::npos,
+	      "CORE-863: HandleFatalException not found -- update this invariant");
+
+	if (entry == std::string::npos)
+		return;
+
+	auto release = code.find(
+		"StreamElementsCrashContext::ReleaseGuardBuffer();", entry);
+	auto walk = code.find("WalkStack(", entry);
+
+	check(release != std::string::npos,
+	      "CORE-863: the crash path must release the guard buffer");
+	check(walk != std::string::npos,
+	      "CORE-863: WalkStack call not found -- update this invariant");
+
+	if (release != std::string::npos && walk != std::string::npos) {
+		check(release < walk,
+		      "CORE-863: the guard buffer must be released BEFORE the stack walk, which allocates");
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -661,6 +778,8 @@ int main()
 	check_abort_path_drops_own_frames();
 	check_sentry_init_is_diagnosable();
 	check_queued_tasks_suppressed_during_crash();
+	check_oom_handler_observes_and_chains();
+	check_guard_buffer_released_first();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
BugSplat installed five process-global CRT hooks via `SetGlobalCRTExceptionBehavior()`, all routed to a deliberate null write so the exception filter would see them. The Sentry migration dropped all five; CORE-860 recovered two without knowing that was what it was doing. This takes the allocation one, and audits what is left.

## Deliberately not what BugSplat did

`memory_depleted()` calls `terminator()` and **force-crashes the process on any allocation failure**, with `_set_new_mode(1)` extending that to plain `malloc` — which would preempt libobs's own `bmalloc` → `bcrash` handling. A plug-in does not get to override the host's allocation-failure policy.

Ours observes and chains. `_set_new_handler` hands back whoever held it, and we call them: an upstream handler that can free memory and ask for a retry still wins. Otherwise we return 0, preserving standard semantics exactly — `operator new` throws `std::bad_alloc`, `malloc` returns `NULL`. Nothing changes except that we now know.

`_set_new_mode(1)` is set so malloc failures route through it too; libobs allocates through `bmalloc` → `malloc`, the largest allocator in the process.

## Guard buffer released at the right moment

`StreamElementsCrashContext` reserves 1 MB at construction so collection has headroom on an exhausted process — but it was handed back on the **first line of `Collect()`**, which runs after the stack walk and after the consent prompt, both of which allocate. On the one crash class the reserve exists for, it was not available to the two things most likely to fail first. Now released at the top of `HandleFatalException`, and in the new handler earlier still.

## A claim I got wrong, caught by the test

The issue said an unhandled allocation failure "reaches `abort()` and our SIGABRT handler". **It does not.** An uncaught `std::bad_alloc` on MSVC raises a real SEH exception (`0xE06D7363`), so it lands in the top-level filter, not the abort door.

The first verification run proved it: the event arrived as `RaiseException` with `crash.kind` **empty**, because the tagging had been written into `SentryAbortHandler`, which never ran. Moved to `HandleFatalException`, which both doors funnel through.

`HandleFatalException`'s two booleans also became one — which door we came through decides both whether to drop our own leading frames and what `crash.kind` falls back to, and the two must never disagree.

## crash.kind is now four-way

`purecall` > `oom` > `abort` > `exception`. The sticky, inferred OOM flag deliberately does **not** outrank a definite, proximate `purecall`: a handled allocation failure leaves it set for the life of the process and must not relabel a later, unrelated crash. Ordinary SEH crashes now carry `exception` where they carried nothing. Still within the 8-tag WER cap.

## Verified with a real OOM

A single 128 TB request — fails locally, without exhausting the machine.

```
SE_SIMULATE_OOM -- requesting 140737488355328 bytes via malloc
SE_SIMULATE_OOM -- malloc returned NULL (expected)
SE_SIMULATE_OOM -- now via operator new, uncaught
```

`malloc` still returns `NULL` exactly as before — the handler ran, recorded the failure, released the guard, and returned 0 rather than seizing policy.

| | before the tag fix | after |
| -- | -- | -- |
| issue | SELIVE-P | **SELIVE-Q** |
| `crash.kind` | *(empty)* | **`oom`** |
| product / obs_version / arch | ✅ | ✅ |

Temporary trigger reverted before commit — `grep` for `SE_SIMULATE_OOM` finds nothing.

## Tests

Nine behavioural checks over the handler and the precedence — upstream retry honoured and passed through, recovered failures still recorded, OOM label correct through **both** doors. Two source invariants covering installation, chaining, the no-force-crash constraint, guard ordering, and that the tag lives on the shared path.

**Eleven negative tests, all flip.** The last two were added after the tag bug: reverting the tag into the abort handler, and mislabelling the SEH door as `abort`.

## Audit result

Of the eight doors into a dying process, seven are now accounted for. The eighth — the WER runtime exception module, covering heap corruption and every `__fastfail` — is **verified missing**: the build produces `sentry-wer.dll`, `main.nsi` never ships it, and the runtime says `Native WER module not found`. Filed as **CORE-864** rather than fixed here, because enabling it means deciding the consent model for crashes reported after we are already dead.

Fixes CORE-863