### PR TITLE
fix(crash): bound the consent prompt so a blocked one cannot hang the process (CORE-862)

### DIFF
--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -808,6 +808,79 @@ ArmSentryScope(const StreamElementsCrashContext::Result &context,
 /* ================================================================= */
 
 //
+//
+// Deadline on the consent prompt (CORE-862).
+//
+// The prompt is a native Win32 modal dialog, and every Win32 modal loop
+// dispatches the private message Qt's event dispatcher uses to drain its
+// posted-event queue. So a queued call can run inside the prompt, and if it
+// opens a QDialog::exec() its nested loop sits on top of ours and
+// DialogBoxIndirectParamW cannot return until that unrelated dialog is
+// answered. Observed with a cdb attach: the prompt had already been answered
+// and hidden while USER32!DialogBox2 was still on the stack.
+//
+// The choke point in __QtPostTask_Impl stops OUR queued work from doing that.
+// It cannot stop OBS's own posted calls or another plug-in's, and nothing can:
+// a nested modal loop is above us on the stack, and no other thread can unwind
+// it. EndDialog only marks the dialog for termination; it does not return.
+//
+// So the only bounded outcome available from outside is to stop waiting. The
+// process has already crashed; leaving a zombie OBS holding the user's machine
+// is worse than losing one report.
+//
+// Scoped to the prompt alone, and disarmed the moment it returns. Everything
+// after it is already bounded -- the daemon wait by shutdown_timeout, the
+// progress window by its own 2s join, and the host filter exits. Arming a
+// single watchdog over the whole path would have to outlast a 60s upload, which
+// makes it useless as a backstop.
+//
+// Generous on purpose: this must never fire for someone typing a description.
+// Five minutes is far longer than that and far shorter than forever.
+//
+static const DWORD CRASH_PROMPT_DEADLINE_MS = 5 * 60 * 1000;
+
+static HANDLE s_promptWatchdogThread = NULL;
+static HANDLE s_promptWatchdogAnswered = NULL;
+
+static DWORD WINAPI PromptWatchdogThreadProc(LPVOID)
+{
+	if (::WaitForSingleObject(s_promptWatchdogAnswered,
+				  CRASH_PROMPT_DEADLINE_MS) == WAIT_OBJECT_0)
+		return 0; // answered in time; nothing to do
+
+	blog(LOG_ERROR,
+	     "obs-streamelements-core: StreamElements: Crash Handler: the crash consent prompt has not returned after %lu seconds -- most likely blocked behind another modal dialog. Terminating rather than leaving the process hung; this report is lost. See CORE-862.",
+	     (unsigned long)(CRASH_PROMPT_DEADLINE_MS / 1000));
+
+	// Not exit() and not abort(): both run code on the way out, and abort()
+	// would re-enter our own SIGABRT handler.
+	::TerminateProcess(::GetCurrentProcess(), 3);
+
+	return 0;
+}
+
+static void ArmPromptWatchdog()
+{
+	s_promptWatchdogAnswered = ::CreateEventW(NULL, TRUE, FALSE, NULL);
+
+	if (!s_promptWatchdogAnswered)
+		return; // no watchdog is better than a watchdog that fires early
+
+	s_promptWatchdogThread = ::CreateThread(
+		NULL, 0, PromptWatchdogThreadProc, NULL, 0, NULL);
+}
+
+static void DisarmPromptWatchdog()
+{
+	if (s_promptWatchdogAnswered)
+		::SetEvent(s_promptWatchdogAnswered);
+
+	// Deliberately not waiting on the thread and not closing the handles:
+	// the wait above releases it, and a crash path must not block on its own
+	// bookkeeping. The process is about to end regardless.
+	s_promptWatchdogThread = NULL;
+}
+
 // The whole crash path, shared by the two ways a fatal condition reaches us:
 // the top-level SEH filter and the SIGABRT handler below.
 //
@@ -912,9 +985,15 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 			// crash data from users who never agreed to it -- and
 			// would lose the descriptions, which are frequently the
 			// only account of what the user was actually doing.
+			// Bounded, because the prompt can be blocked behind a
+			// modal dialog we do not own. See ArmPromptWatchdog.
+			ArmPromptWatchdog();
+
 			const auto consent =
 				StreamElementsCrashConsentDialog::Prompt(
 					s_userName, s_userEmail, s_userDiscord);
+
+			DisarmPromptWatchdog();
 
 			if (consent.consented) {
 				PersistContactDetails(consent.name,

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -761,6 +761,57 @@ static void check_guard_buffer_released_first()
 	}
 }
 
+// --- CORE-862: the consent prompt must be bounded.
+//
+// The choke point in __QtPostTask_Impl stops OUR queued work from opening a
+// modal dialog inside the prompt. It cannot stop OBS's own posted calls or
+// another plug-in's, and nothing can -- a nested modal loop is above us on the
+// stack and no other thread can unwind it. So the prompt needs a deadline, or a
+// crashed process can sit there indefinitely holding the user's machine.
+static void check_consent_prompt_is_bounded()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp"));
+
+	check(code.find("CRASH_PROMPT_DEADLINE_MS") != std::string::npos,
+	      "CORE-862: the consent prompt must have a deadline");
+
+	// Armed immediately before the prompt and released immediately after --
+	// scoped to the prompt alone, because everything after it is already
+	// bounded and a watchdog spanning the upload would have to outlast it.
+	auto arm = code.find("ArmPromptWatchdog();");
+	auto prompt = code.find("StreamElementsCrashConsentDialog::Prompt(");
+	auto disarm = code.find("DisarmPromptWatchdog();");
+
+	check(arm != std::string::npos && prompt != std::string::npos &&
+		      disarm != std::string::npos,
+	      "CORE-862: prompt watchdog wiring not found -- update this invariant");
+
+	if (arm != std::string::npos && prompt != std::string::npos &&
+	    disarm != std::string::npos) {
+		check(arm < prompt,
+		      "CORE-862: the watchdog must be armed BEFORE the prompt, or it cannot bound it");
+		check(disarm > prompt,
+		      "CORE-862: the watchdog must be released AFTER the prompt returns");
+	}
+
+	// TerminateProcess, not exit() and not abort(): both run code on the way
+	// out, and abort() would re-enter our own SIGABRT handler.
+	auto watchdog = code.find("PromptWatchdogThreadProc");
+	check(watchdog != std::string::npos,
+	      "CORE-862: watchdog thread proc not found -- update this invariant");
+
+	if (watchdog != std::string::npos) {
+		auto body = code.substr(watchdog, 900);
+
+		check(body.find("TerminateProcess") != std::string::npos,
+		      "CORE-862: the watchdog must terminate the process when the deadline passes");
+		check(body.find("abort()") == std::string::npos &&
+			      body.find("exit(") == std::string::npos,
+		      "CORE-862: the watchdog must not use abort() or exit() -- abort() re-enters our own SIGABRT handler");
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -780,6 +831,7 @@ int main()
 	check_queued_tasks_suppressed_during_crash();
 	check_oom_handler_observes_and_chains();
 	check_guard_buffer_released_first();
+	check_consent_prompt_is_bounded();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Completes CORE-862. #146 took the choke point; this closes the scope limit that PR explicitly left open.

## Why a deadline, and why nothing cleverer

`__QtPostTask_Impl`'s gate stops **our** queued work from opening a modal dialog inside the consent prompt. It cannot stop OBS's own posted calls or another plug-in's — and nothing can. A nested modal loop sits *above us on the stack*, and no other thread can unwind it. `EndDialog` only marks the dialog for termination; `DialogBoxIndirectParamW` still cannot return.

So the only bounded outcome available from outside is to stop waiting. The process has already crashed; a zombie OBS holding the user's machine is worse than one lost report.

## Scoped to the prompt alone

Armed immediately before the prompt, released the moment it returns. Everything after it is already bounded — the daemon wait by `shutdown_timeout`, the progress window by its own 2s join, the host filter exits. A single watchdog spanning the whole path would have to outlast a 60s upload, which makes it useless as a backstop.

**Five minutes** — far longer than anyone spends typing a description, far shorter than forever. `TerminateProcess`, not `exit()` or `abort()`: both run code on the way out, and `abort()` would re-enter our own SIGABRT handler.

**Trade-off, stated plainly:** when the deadline fires we lose both the report *and* OBS's own crash log, because the host filter never runs. That is the cost of not hanging.

## Verified both directions

Against a real `_purecall` crash, with the deadline temporarily shortened to 20s:

| test | prompt | watchdog | outcome |
| -- | -- | -- | -- |
| **A** | left unanswered | **fired at 20s**, logged the reason | process terminated — `HasExited=True`, 0 handles |
| **B** | answered in time | **0 firings** — disarmed | crash path completed, OBS crash log written |

```
Crash Handler: the crash consent prompt has not returned after 20 seconds --
most likely blocked behind another modal dialog. Terminating rather than
leaving the process hung; this report is lost. See CORE-862.
```

Both temporaries — the shortened deadline and the crash trigger — reverted before commit.

## Tests

Four invariants, each negative-tested: the deadline exists, the watchdog is armed **before** the prompt, released **after** it, and terminates rather than calling `abort()` or `exit()`.

Local gates: builds clean under `/WX`, `ctest` 5/5, clang-format clean.

Fixes CORE-862