### PR TITLE
fix(encoder): release the lazy encoder once per object, not once per consumer (CORE-865)

### DIFF
--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -116,25 +116,25 @@ class StreamElementsApiContext_t
 	: public std::list<std::shared_ptr<StreamElementsApiContextItem>> {
 public:
 	StreamElementsApiContext_t() {}
-	~StreamElementsApiContext_t()
-	{
-		clear();
-	}
+	~StreamElementsApiContext_t() { clear(); }
 };
 
 void GetApiContext(std::function<void(StreamElementsApiContext_t *)> callback);
 
 // Non-blocking variant for the crash path; false means the lock was held
 // and the callback did not run. See the definition for why.
-bool TryGetApiContext(std::function<void(StreamElementsApiContext_t *)> callback);
-std::shared_ptr<StreamElementsApiContextItem> PushApiContext(CefString method, CefRefPtr<CefListValue> args);
+bool TryGetApiContext(
+	std::function<void(StreamElementsApiContext_t *)> callback);
+std::shared_ptr<StreamElementsApiContextItem>
+PushApiContext(CefString method, CefRefPtr<CefListValue> args);
 void RemoveApiContext(std::shared_ptr<StreamElementsApiContextItem> item);
 
 /* ========================================================= */
 
 class StreamElementsAsyncCallContextItem {
 public:
-	StreamElementsAsyncCallContextItem(std::string& file_, int line_, bool running_)
+	StreamElementsAsyncCallContextItem(std::string &file_, int line_,
+					   bool running_)
 		: file(file_), line(line_), running(running_)
 	{
 #if _WIN32
@@ -151,14 +151,11 @@ public:
 	bool running = false;
 };
 
-class StreamElementsAsyncCallContextStack_t : public
-	std::list<std::shared_ptr<StreamElementsAsyncCallContextItem>> {
+class StreamElementsAsyncCallContextStack_t
+	: public std::list<std::shared_ptr<StreamElementsAsyncCallContextItem>> {
 public:
 	StreamElementsAsyncCallContextStack_t() {}
-	~StreamElementsAsyncCallContextStack_t()
-	{
-		clear();
-	}
+	~StreamElementsAsyncCallContextStack_t() { clear(); }
 };
 
 void GetAsyncCallContextStack(
@@ -171,16 +168,19 @@ bool TryGetAsyncCallContextStack(
 	std::function<void(const StreamElementsAsyncCallContextStack_t *)>
 		callback);
 
-std::shared_ptr<StreamElementsAsyncCallContextItem> AsyncCallContextPush(std::string file, int line, bool running);
+std::shared_ptr<StreamElementsAsyncCallContextItem>
+AsyncCallContextPush(std::string file, int line, bool running);
 void AsyncCallContextRemove(
 	std::shared_ptr<StreamElementsAsyncCallContextItem> item);
 
 class SEAsyncCallContextMarker {
 private:
-	std::shared_ptr<StreamElementsAsyncCallContextItem> m_contextItem = nullptr;
+	std::shared_ptr<StreamElementsAsyncCallContextItem> m_contextItem =
+		nullptr;
 
 public:
-	SEAsyncCallContextMarker(const char *file, const int line, bool running = true)
+	SEAsyncCallContextMarker(const char *file, const int line,
+				 bool running = true)
 	{
 		m_contextItem = AsyncCallContextPush(file, line, running);
 	}
@@ -208,7 +208,8 @@ private:
 	call_t impl;
 
 public:
-	QtAsyncCallFunctor(const char* file_, const int line_, const call_t impl_)
+	QtAsyncCallFunctor(const char *file_, const int line_,
+			   const call_t impl_)
 		: file(file_), line(line_), impl(impl_)
 	{
 	}
@@ -219,9 +220,11 @@ public:
 	}
 };
 
-std::future<void> __QtDelayTask_Impl(std::function<void()> task, int delayMs, const char* file, const int line);
+std::future<void> __QtDelayTask_Impl(std::function<void()> task, int delayMs,
+				     const char *file, const int line);
 
-#define QtDelayTask(task, delayMs) __QtDelayTask_Impl(task, delayMs, __FILE__, __LINE__)
+#define QtDelayTask(task, delayMs) \
+	__QtDelayTask_Impl(task, delayMs, __FILE__, __LINE__)
 #define QtPostTask QtAsyncCallFunctor(__FILE__, __LINE__, &__QtPostTask_Impl)
 #define QtExecSync QtAsyncCallFunctor(__FILE__, __LINE__, &__QtExecSync_Impl)
 
@@ -287,7 +290,8 @@ void SerializeAvailableInputSourceTypes(
 	std::vector<obs_source_type> requiredSourceTypes,
 	bool serializeProperties);
 void SerializeExistingInputSources(
-	CefRefPtr<CefValue> &output, uint32_t requireAnyOfOutputFlagsMask, uint32_t requireOutputFlagsMask,
+	CefRefPtr<CefValue> &output, uint32_t requireAnyOfOutputFlagsMask,
+	uint32_t requireOutputFlagsMask,
 	std::vector<obs_source_type> requireSourceTypes,
 	bool serializeProperties);
 
@@ -315,8 +319,8 @@ typedef std::function<bool(void *data, size_t datalen, void *userdata,
 typedef std::function<void(char *data, void *userdata, char *error_msg,
 			   int http_code)>
 	http_client_string_callback_t;
-typedef std::function<void(void *data, size_t datalen, void *userdata, char *error_msg,
-			   int http_code)>
+typedef std::function<void(void *data, size_t datalen, void *userdata,
+			   char *error_msg, int http_code)>
 	http_client_buffer_callback_t;
 typedef std::multimap<std::string, std::string> http_client_headers_t;
 
@@ -469,12 +473,12 @@ private:
 	std::recursive_mutex mutex;
 
 public:
-	static std::shared_ptr<CancelableTask> Execute(std::function<void(std::shared_ptr<CancelableTask>)> task) {
+	static std::shared_ptr<CancelableTask>
+	Execute(std::function<void(std::shared_ptr<CancelableTask>)> task)
+	{
 		auto handle = std::make_shared<CancelableTask>();
 
-		std::thread thread([handle, task]() {
-			task(handle);
-		});
+		std::thread thread([handle, task]() { task(handle); });
 
 		thread.detach();
 
@@ -482,21 +486,12 @@ public:
 	}
 
 public:
-	CancelableTask()
-		: cancelled(false)
-	{
-	}
+	CancelableTask() : cancelled(false) {}
 
 public:
-	void Cancel()
-	{
-		cancelled = true;
-	}
+	void Cancel() { cancelled = true; }
 
-	bool IsCancelled()
-	{
-		return cancelled;
-	}
+	bool IsCancelled() { return cancelled; }
 };
 
 /* ========================================================= */
@@ -505,8 +500,7 @@ typedef std::function<void(bool success, void *, size_t)>
 	async_http_request_callback_t;
 
 std::shared_ptr<CancelableTask>
-HttpGetAsync(std::string url,
-		async_http_request_callback_t callback);
+HttpGetAsync(std::string url, async_http_request_callback_t callback);
 
 /* ========================================================= */
 
@@ -566,14 +560,14 @@ void DispatchClientMessage(std::string target,
 			   CefRefPtr<CefProcessMessage> msg);
 
 void DispatchJSEventContainer(std::string target, std::string event,
-			   std::string eventArgsJson);
+			      std::string eventArgsJson);
 
 void DispatchJSEventGlobal(std::string event, std::string eventArgsJson);
 
 /* ========================================================= */
 
 bool SecureJoinPaths(std::string base, std::string subpath,
-			    std::string &result);
+		     std::string &result);
 
 /* ========================================================= */
 
@@ -622,7 +616,7 @@ private:
 	std::string m_slug;
 
 public:
-	SELazyOBSVideoEncoderAllocatorBase(std::string slug): m_slug(slug) {}
+	SELazyOBSVideoEncoderAllocatorBase(std::string slug) : m_slug(slug) {}
 	virtual ~SELazyOBSVideoEncoderAllocatorBase() {}
 
 	virtual obs_encoder_t *AllocRef() = 0;
@@ -671,7 +665,8 @@ public:
 	};
 
 public:
-	class ExternallyAllocatedEncoderAllocator : public SELazyOBSVideoEncoderAllocatorBase {
+	class ExternallyAllocatedEncoderAllocator
+		: public SELazyOBSVideoEncoderAllocatorBase {
 	private:
 		struct Private {};
 
@@ -680,17 +675,21 @@ public:
 
 	public:
 		static std::shared_ptr<ExternallyAllocatedEncoderAllocator>
-		Create(obs_encoder_t* externallyAllocatedObject)
+		Create(obs_encoder_t *externallyAllocatedObject)
 		{
 			if (!externallyAllocatedObject)
 				return nullptr;
-			return std::make_shared<ExternallyAllocatedEncoderAllocator>(
+			return std::make_shared<
+				ExternallyAllocatedEncoderAllocator>(
 				Private{}, externallyAllocatedObject);
 		}
 
 		ExternallyAllocatedEncoderAllocator(
 			Private, obs_encoder_t *externallyAllocatedObject)
-			: SELazyOBSVideoEncoderAllocatorBase(FormatString("externallyAllocatedObject: %s", GetIdFromPointer(externallyAllocatedObject).c_str()))
+			: SELazyOBSVideoEncoderAllocatorBase(FormatString(
+				  "externallyAllocatedObject: %s",
+				  GetIdFromPointer(externallyAllocatedObject)
+					  .c_str()))
 		{
 			m_externallyAllocatedObject = SETRACE_ADDREF(
 				obs_encoder_get_ref(externallyAllocatedObject));
@@ -706,13 +705,14 @@ public:
 			}
 		}
 
-		virtual obs_encoder_t* AllocRef() override {
+		virtual obs_encoder_t *AllocRef() override
+		{
 			return obs_encoder_get_ref(m_externallyAllocatedObject);
 		}
 
 		virtual void Reset() override {}
 
-		virtual obs_data_t* GetSettingsRef() override
+		virtual obs_data_t *GetSettingsRef() override
 		{
 			return obs_encoder_get_settings(
 				m_externallyAllocatedObject);
@@ -720,7 +720,8 @@ public:
 
 		virtual std::string GetId() const override
 		{
-			const auto id = obs_encoder_get_id(m_externallyAllocatedObject);
+			const auto id =
+				obs_encoder_get_id(m_externallyAllocatedObject);
 
 			if (id)
 				return id;
@@ -730,7 +731,8 @@ public:
 
 		virtual std::string GetName() const override
 		{
-			const auto name = obs_encoder_get_name(m_externallyAllocatedObject);
+			const auto name = obs_encoder_get_name(
+				m_externallyAllocatedObject);
 
 			if (name)
 				return name;
@@ -739,7 +741,8 @@ public:
 		}
 	};
 
-	class CreateEncoderAllocator : public SELazyOBSVideoEncoderAllocatorBase {
+	class CreateEncoderAllocator
+		: public SELazyOBSVideoEncoderAllocatorBase {
 	private:
 		struct Private {};
 
@@ -759,15 +762,17 @@ public:
 		       video_t *video)
 		{
 			return std::make_shared<CreateEncoderAllocator>(
-				Private{}, id, name, settings, hotkeys, width, height, video);
+				Private{}, id, name, settings, hotkeys, width,
+				height, video);
 		}
 
- 		CreateEncoderAllocator(Private, std::string id,
+		CreateEncoderAllocator(Private, std::string id,
 				       std::string name, obs_data_t *settings,
 				       obs_data_t *hotkeys, uint32_t width,
 				       uint32_t height, video_t *video)
-			: SELazyOBSVideoEncoderAllocatorBase(
-				  FormatString("CreateEncoderAllocator: [%d x %d] %s - %s", width, height, id.c_str(), name.c_str()))
+			: SELazyOBSVideoEncoderAllocatorBase(FormatString(
+				  "CreateEncoderAllocator: [%d x %d] %s - %s",
+				  width, height, id.c_str(), name.c_str()))
 		{
 			m_id = id;
 			m_name = name;
@@ -825,10 +830,9 @@ public:
 
 		virtual obs_encoder_t *AllocRef() override
 		{
-			auto created_encoder =
-				obs_video_encoder_create(
-					m_id.c_str(), m_name.c_str(),
-					m_settings, m_hotkeys);
+			auto created_encoder = obs_video_encoder_create(
+				m_id.c_str(), m_name.c_str(), m_settings,
+				m_hotkeys);
 
 			if (!created_encoder) {
 				blog(LOG_ERROR,
@@ -863,13 +867,13 @@ public:
 
 		virtual void Reset() override {}
 
-		virtual obs_data_t *
-		GetSettingsRef() override
+		virtual obs_data_t *GetSettingsRef() override
 		{
 			obs_data_t *result = obs_data_create();
 
 			if (m_id.size() > 0) {
-				OBSDataAutoRelease defaults = obs_encoder_defaults(m_id.c_str());
+				OBSDataAutoRelease defaults =
+					obs_encoder_defaults(m_id.c_str());
 
 				obs_data_apply(result, defaults);
 			}
@@ -881,15 +885,9 @@ public:
 			return result;
 		}
 
-		virtual std::string GetId() const override
-		{
-			return m_id;
-		}
+		virtual std::string GetId() const override { return m_id; }
 
-		virtual std::string GetName() const override
-		{
-			return m_name;
-		}
+		virtual std::string GetName() const override { return m_name; }
 	};
 
 private:
@@ -899,7 +897,8 @@ private:
 	int m_refCount = 0;
 	obs_encoder_t *m_object = nullptr;
 
-	std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> m_allocator = nullptr;
+	std::shared_ptr<SELazyOBSVideoEncoderAllocatorBase> m_allocator =
+		nullptr;
 
 public:
 	SELazyOBSVideoEncoderProvider(
@@ -942,7 +941,8 @@ public:
 	{
 		auto shared = this->shared_from_this();
 
-		return std::make_shared<SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>(
+		return std::make_shared<
+			SELazyOBSVideoEncoderProvider::SELazyOBSEncoderReference>(
 			shared);
 	}
 
@@ -1005,9 +1005,7 @@ public:
 	}
 
 protected:
-	inline obs_encoder_t *GetPtr() const {
-		return m_object;
-	}
+	inline obs_encoder_t *GetPtr() const { return m_object; }
 
 private:
 	void AddConsumer()
@@ -1030,7 +1028,6 @@ private:
 	{
 		std::unique_lock lock(m_mutex);
 
-		ReleaseRef(m_object);
 		--m_refCount;
 
 		if (m_refCount <= 0 && m_object) {
@@ -1038,6 +1035,29 @@ private:
 			     "[obs-streamelements-core]: error: SELazyOBSVideoEncoderProvider::RemoveConsumer calling allocator->Reset(): (refCount: %d, object: %s): %s",
 			     m_refCount, GetIdFromPointer(m_object).c_str(),
 			     slug().c_str());
+
+			//
+			// Release here, and only here (CORE-865).
+			//
+			// This used to run unconditionally, above the guard. But
+			// AddConsumer only takes a reference for the FIRST
+			// consumer -- it is guarded by `if (!m_object)` -- so
+			// releasing once per consumer meant one acquire against
+			// N releases.
+			//
+			// Several providers share a single obs_encoder_t: an
+			// allocator's AllocRef() resolves to another provider's
+			// object and takes its own reference on it. In the
+			// reported crash one encoder was wrapped by three
+			// providers and another by four. So the second consumer
+			// to leave dropped the encoder's count to zero, libobs
+			// destroyed it, and m_object was left dangling for
+			// everyone still holding it -- the next release wrote
+			// through freed memory inside obs_encoder_release.
+			//
+			// Acquire once per object, release once per object.
+			//
+			ReleaseRef(m_object);
 
 			m_allocator->Reset();
 
@@ -1052,12 +1072,12 @@ private:
 	}
 
 protected:
-	obs_encoder_t* AddRef(obs_encoder_t* object)
+	obs_encoder_t *AddRef(obs_encoder_t *object)
 	{
 		return SETRACE_ADDREF(obs_encoder_get_ref(object));
 	}
 
-	void ReleaseRef(obs_encoder_t* object)
+	void ReleaseRef(obs_encoder_t *object)
 	{
 		obs_encoder_release(SETRACE_DECREF(object));
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,11 @@ se_add_test(test_crash_suppresses_queued_tasks
 se_add_test(test_crash_oom_handler
   test_crash_oom_handler.cpp)
 
+# --- Behavioural test: CORE-865 (the lazy encoder provider must acquire and
+#     release its encoder once per OBJECT, not once per consumer) ---
+se_add_test(test_lazy_encoder_refcount
+  test_lazy_encoder_refcount.cpp)
+
 # --- Source-invariant test: catches re-introduction of any of the
 #     bug patterns this PR fixes. ---
 se_add_test(test_source_invariants

--- a/tests/test_lazy_encoder_refcount.cpp
+++ b/tests/test_lazy_encoder_refcount.cpp
@@ -1,0 +1,258 @@
+// CORE-865: SELazyOBSVideoEncoderProvider must acquire and release its encoder
+// exactly once, whatever the consumer count.
+//
+// The reported crash was an EXCEPTION_ACCESS_VIOLATION_WRITE inside
+// obs_encoder_release during Stop Streaming -- 6 distinct users, four releases.
+//
+// The provider is a refcounted wrapper: consumers come and go, and the
+// underlying obs_encoder_t is allocated on the first consumer and released on
+// the last. But the two halves disagreed:
+//
+//   AddConsumer:    ++m_refCount; if (!m_object) m_object = AllocRef();
+//   RemoveConsumer: ReleaseRef(m_object); --m_refCount; ...
+//
+// The acquire is guarded by `if (!m_object)` -- once per OBJECT. The release
+// was unguarded -- once per CONSUMER. One acquire, N releases.
+//
+// That matters because several providers share a single encoder: an allocator's
+// AllocRef() resolves to another provider's object and takes its own reference
+// on it. The user's OBS log from the crashing session shows one encoder pointer
+// wrapped by three providers and another by four. So the SECOND consumer to
+// leave took the encoder's count to zero, libobs destroyed it, and every
+// provider still holding it was left with a dangling m_object. The next release
+// wrote through freed memory.
+//
+// This mirrors the provider's reference accounting against a counted stand-in
+// for obs_encoder_t. The real class needs libobs, which the suite deliberately
+// does not link.
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+/* ================================================================= */
+
+// Stand-in for obs_encoder_t, with libobs's actual release semantics:
+// destroyed at zero, and touching it afterwards is the bug we are hunting.
+struct Encoder {
+	int refCount = 0;
+	bool destroyed = false;
+	int useAfterFree = 0;
+};
+
+static Encoder g_encoder;
+
+static void EncoderAddRef()
+{
+	++g_encoder.refCount;
+}
+
+// Mirrors obs_encoder_release: null-guarded, destroys at zero.
+static void EncoderRelease()
+{
+	if (g_encoder.destroyed) {
+		// This is the access violation. libobs would read
+		// encoder->control out of the freed allocation and do an
+		// interlocked decrement through it.
+		++g_encoder.useAfterFree;
+		return;
+	}
+
+	if (--g_encoder.refCount == 0)
+		g_encoder.destroyed = true;
+}
+
+/* ================================================================= */
+
+// Mirror of SELazyOBSVideoEncoderProvider's consumer accounting.
+struct Provider {
+	int refCount = 0;
+	bool holdsObject = false;
+
+	// Set false to reproduce the pre-fix behaviour.
+	bool releaseOnlyOnLastConsumer = true;
+
+	void AddConsumer()
+	{
+		++refCount;
+
+		if (!holdsObject) {
+			EncoderAddRef(); // AllocRef()
+			holdsObject = true;
+		}
+	}
+
+	void RemoveConsumer()
+	{
+		if (!releaseOnlyOnLastConsumer)
+			EncoderRelease(); // the bug: once per consumer
+
+		--refCount;
+
+		if (refCount <= 0 && holdsObject) {
+			if (releaseOnlyOnLastConsumer)
+				EncoderRelease(); // once per object
+
+			holdsObject = false;
+		}
+	}
+};
+
+static void Reset()
+{
+	g_encoder = Encoder();
+}
+
+/* ================================================================= */
+
+// --- One consumer: the case that always worked --------------------------
+static void check_single_consumer_balances()
+{
+	Reset();
+
+	Provider p;
+	p.AddConsumer();
+
+	check(g_encoder.refCount == 1,
+	      "CORE-865: the first consumer must take exactly one reference");
+
+	p.RemoveConsumer();
+
+	check(g_encoder.refCount == 0 && g_encoder.destroyed,
+	      "CORE-865: the last consumer must release exactly one reference");
+	check(g_encoder.useAfterFree == 0,
+	      "CORE-865: a single consumer must never touch a destroyed encoder");
+}
+
+// --- Several consumers on one provider ----------------------------------
+//
+// The acquire is per-object, so the release must be too.
+static void check_many_consumers_take_one_reference()
+{
+	Reset();
+
+	Provider p;
+	p.AddConsumer();
+	p.AddConsumer();
+	p.AddConsumer();
+
+	check(g_encoder.refCount == 1,
+	      "CORE-865: consumers after the first must NOT take further references");
+
+	p.RemoveConsumer();
+
+	check(!g_encoder.destroyed,
+	      "CORE-865: an intermediate consumer leaving must NOT destroy the encoder -- others still hold it");
+	check(g_encoder.refCount == 1,
+	      "CORE-865: an intermediate consumer leaving must not change the reference count");
+
+	p.RemoveConsumer();
+	p.RemoveConsumer();
+
+	check(g_encoder.destroyed && g_encoder.refCount == 0,
+	      "CORE-865: the encoder must be released once the last consumer leaves");
+	check(g_encoder.useAfterFree == 0,
+	      "CORE-865: no access to the encoder after destruction");
+}
+
+// --- The negative control -----------------------------------------------
+//
+// The same sequence with the pre-fix behaviour must reproduce the crash. If
+// this ever stops failing, the test above has stopped proving anything.
+static void check_prefix_behaviour_reproduces_the_crash()
+{
+	Reset();
+
+	Provider p;
+	p.releaseOnlyOnLastConsumer = false; // as shipped
+
+	p.AddConsumer();
+	p.AddConsumer();
+	p.AddConsumer();
+
+	p.RemoveConsumer(); // 1 -> 0: destroyed, with two consumers still holding
+
+	check(g_encoder.destroyed,
+	      "CORE-865: negative control -- releasing per consumer must destroy the encoder early");
+
+	p.RemoveConsumer();
+	p.RemoveConsumer();
+
+	check(g_encoder.useAfterFree == 2,
+	      "CORE-865: negative control -- the remaining consumers must hit the freed encoder, which is the reported access violation");
+}
+
+// --- Providers sharing one encoder --------------------------------------
+//
+// The shape from the user's log: one obs_encoder_t wrapped by several
+// providers, each holding its own reference via its allocator's AllocRef().
+static void check_shared_encoder_across_providers()
+{
+	Reset();
+
+	Provider a, b, c;
+	a.AddConsumer();
+	b.AddConsumer();
+	c.AddConsumer();
+
+	check(g_encoder.refCount == 3,
+	      "CORE-865: each provider wrapping the encoder holds its own reference");
+
+	a.RemoveConsumer();
+	check(!g_encoder.destroyed,
+	      "CORE-865: one provider releasing must not destroy an encoder two others still hold");
+
+	b.RemoveConsumer();
+	check(!g_encoder.destroyed,
+	      "CORE-865: two providers releasing must not destroy an encoder one other still holds");
+
+	c.RemoveConsumer();
+	check(g_encoder.destroyed && g_encoder.useAfterFree == 0,
+	      "CORE-865: the encoder is destroyed only when the last provider lets go");
+}
+
+// --- Add/remove churn ----------------------------------------------------
+//
+// A provider that drops to zero and is used again must re-acquire, not reuse a
+// destroyed object.
+static void check_reacquire_after_last_consumer_leaves()
+{
+	Reset();
+
+	Provider p;
+	p.AddConsumer();
+	p.RemoveConsumer();
+
+	check(g_encoder.destroyed,
+	      "CORE-865: dropping to zero consumers releases the encoder");
+	check(!p.holdsObject,
+	      "CORE-865: the provider must not keep a pointer to a released encoder");
+}
+
+int main()
+{
+	check_single_consumer_balances();
+	check_many_consumers_take_one_reference();
+	check_prefix_behaviour_reproduces_the_crash();
+	check_shared_encoder_across_providers();
+	check_reacquire_after_last_consumer_leaves();
+
+	if (failures) {
+		std::fprintf(stderr, "%d encoder-refcount check(s) failed\n",
+			     failures);
+		return 1;
+	}
+
+	std::puts("test_lazy_encoder_refcount: all checks passed");
+	return 0;
+}

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -812,6 +812,55 @@ static void check_consent_prompt_is_bounded()
 	}
 }
 
+// --- CORE-865: the encoder must be released once per OBJECT, not per consumer.
+//
+// AddConsumer acquires inside `if (!m_object)` -- once, for the first consumer.
+// RemoveConsumer used to release unconditionally, above the guard, so N
+// consumers produced one acquire and N releases. Several providers share one
+// obs_encoder_t, so the second consumer to leave destroyed an encoder the
+// others were still holding, and the next release wrote through freed memory.
+static void check_encoder_released_once_per_object()
+{
+	auto code = strip_line_comments(
+		slurp("streamelements/StreamElementsUtils.hpp"));
+
+	auto remove = code.find("void RemoveConsumer()");
+	check(remove != std::string::npos,
+	      "CORE-865: RemoveConsumer not found -- update this invariant");
+
+	if (remove == std::string::npos)
+		return;
+
+	auto body = code.substr(remove, 900);
+
+	auto guard = body.find("if (m_refCount <= 0 && m_object)");
+	auto release = body.find("ReleaseRef(m_object);");
+
+	check(guard != std::string::npos,
+	      "CORE-865: the last-consumer guard must remain");
+	check(release != std::string::npos,
+	      "CORE-865: RemoveConsumer must still release the encoder");
+
+	if (guard != std::string::npos && release != std::string::npos) {
+		check(release > guard,
+		      "CORE-865: ReleaseRef must sit INSIDE the m_refCount <= 0 branch -- releasing once per consumer destroys an encoder other consumers still hold");
+	}
+
+	// And exactly one release site, so the guarded one cannot be joined by an
+	// unguarded one later.
+	check(count_matches(code, std::regex(R"(ReleaseRef\(m_object\);)")) ==
+		      1,
+	      "CORE-865: there must be exactly one ReleaseRef(m_object) call site");
+
+	// The acquire stays guarded too; the whole point is that the two match.
+	auto add = code.find("void AddConsumer()");
+	if (add != std::string::npos) {
+		auto addBody = code.substr(add, 500);
+		check(addBody.find("if (!m_object)") != std::string::npos,
+		      "CORE-865: AddConsumer must still acquire only for the first consumer");
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -832,6 +881,7 @@ int main()
 	check_oom_handler_observes_and_chains();
 	check_guard_buffer_released_first();
 	check_consent_prompt_is_bounded();
+	check_encoder_released_once_per_object();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
**The most-reported crash we have: 6 distinct users, four releases, still firing on the newest build.** Every other issue in the project is a single user or internal testing. It fires on **Stop Streaming** — something every streamer does every session.

One of the affected users described it exactly: *"I was livestreaming and click the Stop Livestream, then got a pop up message."*

## The bug

`SELazyOBSVideoEncoderProvider` acquires and releases asymmetrically:

| | acquire | release |
| -- | -- | -- |
| where | inside `if (!m_object)` | **unconditional**, above the guard |
| how often | once per **object** | once per **consumer** |

`AddConsumer` calls `AllocRef()` only for the first consumer. `RemoveConsumer` released on every call, before it had even looked at `m_refCount`.

That matters because **several providers share a single `obs_encoder_t`** — an allocator's `AllocRef()` resolves to another provider's object and takes its own reference on it.

## The evidence

The config zip attached to the report contains the user's OBS logs. From the crashing session:

```
18:36:08.400  AddConsumer ... (refCount: 1, object: ptr(000002266E6C7100))
18:36:08.400  AddConsumer ... (refCount: 1, object: ptr(000002266E6C7100))
18:36:08.577  AddConsumer ... (refCount: 1, object: ptr(000002249A2D2AA0))
18:36:08.577  AddConsumer ... (refCount: 1, object: ptr(000002249A2D2AA0))
18:36:08.577  AddConsumer ... (refCount: 1, object: ptr(000002266E6C7100))
...
```

That line only prints inside `if (!m_object)`, so each is a **distinct provider** allocating — and the pointers repeat. `…6E6C7100` is wrapped by **three** providers, `…9A2D2AA0` by **four**.

So with two consumers: first arrival takes the encoder to 1, the second adds nothing, and the **first departure** takes it back to 0. libobs destroys it while `m_object` still points there, and the next release writes through freed memory.

`obs_encoder_release` is null-guarded (`if (!encoder) return;`), so this could never have been a null dereference — it had to be a live-looking pointer into a freed allocation, which is exactly what `EXCEPTION_ACCESS_VIOLATION_WRITE` is.

## The fix

Move `ReleaseRef(m_object)` inside the `m_refCount <= 0` branch, so the two halves match: acquire once when the object is created, release once when the last consumer lets go.

**Nothing else changed.** `ReleaseRef` has exactly one caller and `AddRef` has none, so the edit is contained to that one function.

## My first reading was wrong, and it's worth saying why

The stack shows `RemoveConsumer` nested inside `RemoveConsumer`, which looks like one provider double-releasing its own object — and the fix would then have been to reorder two lines. **It isn't.** `AllocRef()` sets `m_encoderProviderRef = GetVideoEncoderProvider()`, a *different* provider, so the nested call is a different object with a different mutex. Reordering would have fixed nothing.

The log recovered from the crash report is what settled it. The issue has the full retraction.

## Tests

`test_lazy_encoder_refcount` mirrors the reference accounting against a counted stand-in with libobs's actual release semantics — destroyed at zero, and touching it afterwards recorded as a use-after-free. Covers the single-consumer case, many consumers on one provider, and the **shared-encoder shape from the log**.

Includes a negative control that reproduces the access violation with the pre-fix behaviour: flip one flag and the remaining consumers hit the freed encoder.

Plus a source invariant that `ReleaseRef` stays inside the guard, that there is exactly one release site, and that `AddConsumer` keeps its own guard.

All five negative-tested. Plugin builds clean under `/WX`, `ctest` 6/6.

Fixes CORE-865