### PR TITLE
chore(installer): delete the dead 32-bit installer path (CORE-416)

### DIFF
--- a/.github/workflows/build-obs-streamelements-installer.yml
+++ b/.github/workflows/build-obs-streamelements-installer.yml
@@ -174,17 +174,14 @@ jobs:
 
             if not exist ${{ env.ROOT }}\..\obs-studio\build64_qt6\rundir\${{ env.BUILD_CONFIG }} md ${{ env.ROOT }}\..\obs-studio\build64_qt6\rundir\${{ env.BUILD_CONFIG }}
 
-            if not exist ${{ env.ROOT }}\..\obs-studio\build32_qt6\rundir\${{ env.BUILD_CONFIG }} md ${{ env.ROOT }}\..\obs-studio\build32_qt6\rundir\${{ env.BUILD_CONFIG }}
 
             if not exist ${{ env.ROOT }}\..\download md ${{ env.ROOT }}\..\download
 
             if not exist ${{ env.ROOT }}\..\download\obs-streamelements-core md ${{ env.ROOT }}\..\download\obs-streamelements-core
 
-            if not exist ${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6 md ${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6
 
             if not exist ${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6 md ${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6
 
-            if not exist ${{ env.ROOT }}\..\download\obs-streamelements\build32_qt6 md ${{ env.ROOT }}\..\download\obs-streamelements\build32_qt6
 
             if not exist ${{ env.ROOT }}\..\download\obs-streamelements\build64_qt6 md ${{ env.ROOT }}\..\download\obs-streamelements\build64_qt6
 
@@ -193,7 +190,6 @@ jobs:
 
 
 
-            curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-core/latest/windows/build32_qt6.zip --output ${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6.zip
 
             curl -f https://storage.googleapis.com/se-obs-builds/obs-streamelements-core/latest/windows/build64_qt6.zip --output ${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6.zip
 
@@ -207,25 +203,21 @@ jobs:
 
 
 
-            7z x -y ${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6.zip -o${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6
 
             7z x -y ${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6.zip -o${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6
 
 
 
 
-            xcopy ${{ env.ROOT }}\..\download\obs-streamelements-core\build32_qt6\*.* ${{ env.ROOT }}\..\obs-studio\build32_qt6\rundir\${{ env.BUILD_CONFIG }} /S /E /I /Y
 
             xcopy ${{ env.ROOT }}\..\download\obs-streamelements-core\build64_qt6\*.* ${{ env.ROOT }}\..\obs-studio\build64_qt6\rundir\${{ env.BUILD_CONFIG }} /S /E /I /Y
 
-            xcopy ${{ env.ROOT }}\..\download\obs-streamelements\build32_qt6\*.* ${{ env.ROOT }}\..\obs-studio\build32_qt6\rundir\${{ env.BUILD_CONFIG }} /S /E /I /Y
 
             xcopy ${{ env.ROOT }}\..\download\obs-streamelements\build64_qt6\*.* ${{ env.ROOT }}\..\obs-studio\build64_qt6\rundir\${{ env.BUILD_CONFIG }} /S /E /I /Y
 
 
 
 
-            curl -f https://storage.googleapis.com/cdn.streamelements.com/obs/dist/obs-streamelements-set-machine-config/windows/qa/obs-streamelements-set-machine-config-32.exe --output ${{ env.ROOT }}\..\obs-studio\build32_qt6\rundir\${{ env.BUILD_CONFIG }}\obs-plugins\32bit\obs-streamelements-set-machine-config.exe
 
             curl -f https://storage.googleapis.com/cdn.streamelements.com/obs/dist/obs-streamelements-set-machine-config/windows/qa/obs-streamelements-set-machine-config-64.exe --output ${{ env.ROOT }}\..\obs-studio\build64_qt6\rundir\${{ env.BUILD_CONFIG }}\obs-plugins\64bit\obs-streamelements-set-machine-config.exe
 
@@ -291,8 +283,6 @@ jobs:
 
             $StreamElementsExe64bit = 'obs-streamelements-setup-x64.exe'
 
-            $StreamElementsExe32bit = 'obs-streamelements-setup-x86.exe'
-
 
             # One encoding object for everything: UTF-8, and $false = no BOM, ever.
             $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
@@ -341,15 +331,25 @@ jobs:
 
             cd "${{ env.ROOT }}"
 
-            makensis /V4 /DSKIP_64BIT_CONTENT main.nsi
-
-            ren obs-streamelements-setup.exe $StreamElementsExe32bit
-
-            makensis /V4 /DSKIP_32BIT_CONTENT main.nsi
-
-            ren obs-streamelements-setup.exe $StreamElementsExe64bit
-
+            # One installer, built once (CORE-416).
+            #
+            # This used to run makensis three times: /DSKIP_64BIT_CONTENT for an x86
+            # installer, /DSKIP_32BIT_CONTENT for the x64 one, and once more bare. The
+            # x86 build was assembled from a build32_qt6.zip that nothing has produced
+            # for a long time, and deploy published the x64 exe under the 32-bit
+            # filename anyway -- so the x86 installer was already fiction.
+            #
+            # With the 32-bit content gone from main.nsi there is nothing left for
+            # /DSKIP_32BIT_CONTENT to skip, so one bare build covers both outputs.
+            # Confirmed by compiling old-with-define against new-without and diffing:
+            # the NSIS payload is identical.
+            #
+            # The -x64 copy stays because the signing, verify and upload steps below
+            # glob obs-streamelements-setup*.exe, and because build.yml republishes the
+            # x64 exe under the 32-bit filename for any legacy client still asking.
             makensis /V4 main.nsi
+
+            copy obs-streamelements-setup.exe $StreamElementsExe64bit
 
       - name: Sign Windows binaries
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2

--- a/CI/obs-streamelements-installer/main.nsi
+++ b/CI/obs-streamelements-installer/main.nsi
@@ -566,22 +566,13 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
     # Data
     #########################################################################
 
-    !ifndef SKIP_64BIT_CONTENT
-        SetOutPath $INSTDIR\data\obs-plugins\obs-streamelements-core
+    SetOutPath $INSTDIR\data\obs-plugins\obs-streamelements-core
 
-        File /r ..\download\obs-streamelements-core\build64_qt6\data\obs-plugins\obs-streamelements-core\*.*
-    !else
-        !ifndef SKIP_32BIT_CONTENT
-            SetOutPath $INSTDIR\data\obs-plugins\obs-streamelements-core
-
-            File /r ..\download\obs-streamelements-core\build32_qt6\data\obs-plugins\obs-streamelements-core\*.*
-        !endif
-    !endif
+    File /r ..\download\obs-streamelements-core\build64_qt6\data\obs-plugins\obs-streamelements-core\*.*
 
     #########################################################################
     # 64 bit
     #########################################################################
-!ifndef SKIP_64BIT_CONTENT
     SetOutPath $INSTDIR\bin\64bit
 
     # Clear BOTH crash backends before laying down whichever this build carries.
@@ -636,7 +627,6 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
     Delete "$OUTDIR\obs-streamelements.qt5.pdb"
     Delete "$OUTDIR\obs-streamelements-core.qt5.dymod"
     Delete "$OUTDIR\obs-streamelements-core.qt5.pdb"
-!endif
 
     #########################################################################
     # 32 bit
@@ -652,38 +642,34 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
 
     setup_obs_32:
 
-!ifndef SKIP_32BIT_CONTENT
-    SetOutPath $INSTDIR\bin\32bit
-
-    # Same clean-then-restore as the 64-bit section above. No 32-bit Sentry
-    # build exists today, so only the daemon line is speculative -- but it
-    # removes what a previous install left, which is the whole point.
-    Delete "$INSTDIR\obs-plugins\32bit\sentry-crash.exe"
-
-    File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BsSndRpt.exe
-    File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BugSplat.dll
-    File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BugSplatHD.exe
-    File ..\download\obs-streamelements-core\build32_qt6\bin\32bit\BugSplatRc.dll
-
-    SetOutPath $INSTDIR\obs-plugins\32bit\locales
-
-    File /nonfatal ..\download\obs-streamelements-core\build32_qt6\obs-plugins\32bit\locales\*.*
-
-    SetOutPath $INSTDIR\obs-plugins\32bit
-
-    File /oname=obs-streamelements-core.dll ..\download\obs-streamelements-core\build32_qt6\obs-plugins\32bit\obs-streamelements-core.dll
-    File /oname=obs-streamelements-core.pdb ..\download\obs-streamelements-core\build32_qt6\obs-plugins\32bit\obs-streamelements-core.pdb
-    
-    File /nonfatal ..\download\obs-streamelements-core\build32_qt6\obs-plugins\32bit\obs-streamelements-set-machine-config.*
-
-    Delete /REBOOTOK "$OUTDIR\obs-streamelements.dll"
-    Delete /REBOOTOK "$OUTDIR\obs-streamelements.pdb"
-
-    Delete "$OUTDIR\obs-streamelements.qt5.dymod"
-    Delete "$OUTDIR\obs-streamelements.qt5.pdb"
-    Delete "$OUTDIR\obs-streamelements-core.qt5.dymod"
-    Delete "$OUTDIR\obs-streamelements-core.qt5.pdb"
-!endif
+    #
+    # Nothing happens here any more (CORE-416).
+    #
+    # We stopped shipping 32-bit. The "32-bit installer" was built from a
+    # build32_qt6.zip that nothing has produced for a long time -- a legacy
+    # object still sitting in the bucket -- and the deploy step papered over
+    # that by publishing the x64 exe under the 32-bit filename, so what users
+    # actually received was already x64.
+    #
+    # Everything that used to stand here sat inside !ifndef SKIP_32BIT_CONTENT,
+    # and CI always passed that define for the installer it shipped. So it was
+    # already dead code in the only build anyone ever ran. Verified rather than
+    # assumed: compiling HEAD with /DSKIP_32BIT_CONTENT and this revision with
+    # no defines, against the same input tree, produces an identical NSIS
+    # payload -- all 3,132,685 bytes of header, install code, string table and
+    # data block. The only differing bytes are five in an alignment gap in
+    # .rsrc that NSIS never zeroes, plus the CRC32 that covers them.
+    #
+    # Note what is deliberately NOT here: cleanup of stale 32-bit files. Those
+    # Delete lines were inside the same guard, so the x64 installer never ran
+    # them either. Keeping them would be a behaviour change dressed up as a
+    # deletion. The uninstaller still clears them.
+    #
+    # The RunningX64 check and the two labels stay. They cost two instructions,
+    # they are what keeps this compile identical to the previous one, and the
+    # 32-bit OBS *host* detection further down is a separate concern from
+    # whether we ship a 32-bit plug-in.
+    #
 
 skip_obs_32:
 
@@ -937,11 +923,7 @@ Function DownloadAndInstallOBS
     ${If} ${RunningX64}
         ; Check if we can skip 32-bit installation on 64-bit system
 
-!ifndef SKIP_64BIT_CONTENT
         IfFileExists "$INSTDIR\bin\32bit\obs32.exe" get_obs_32 skip_obs_32
-!else
-        goto get_obs_32
-!endif
     ${Else}
         goto get_obs_32
     ${EndIf}


### PR DESCRIPTION
Fixes CORE-416

## What was actually there

The "32-bit installer" had not been real for a long time:

- its `makensis /DSKIP_64BIT_CONTENT` run packed `build32_qt6.zip`, which **nothing produces any more** — the object in the bucket is a leftover from years ago;
- `build.yml` then republished the x64 exe under the 32-bit filename anyway, with the comment *"This is not a mistake, we no longer support 32bit builds"*.

So users asking for x86 were already receiving x64. This deletes the machinery rather than the capability.

## Changes

**`build-obs-streamelements-installer.yml`**
- dropped the `build32_qt6` mkdir / curl / 7z / xcopy plumbing and the 32-bit `set-machine-config` download
- dropped `$StreamElementsExe32bit` and the `/DSKIP_64BIT_CONTENT` makensis run
- with the 32-bit content gone there is nothing left for `/DSKIP_32BIT_CONTENT` to skip either, so the remaining two invocations collapse to **one build plus a copy**

**`main.nsi`**
- removed both `SKIP_*_CONTENT` guards and the 32-bit `File` directives
- the `RunningX64` check and the `setup_obs_32` / `skip_obs_32` labels stay — they steer 32-bit OBS **host** detection, which is a separate concern from whether we ship a 32-bit plug-in

**`build.yml` needs no change.** It already publishes the x64 exe under the 32-bit filename, and its x86 download was already commented out.

## Deliberately not included

Cleanup of stale 32-bit files left behind by old installs. Those `Delete` lines sat inside the same `!ifndef SKIP_32BIT_CONTENT`, so the shipped x64 installer **never ran them**. Keeping them would have been a behaviour change dressed up as a deletion — worth doing, but as its own issue. The uninstaller still clears them.

I had them in an earlier revision of this branch and backed it out once the baseline compile showed the 23-byte difference.

## Verification

Not "it should be equivalent" — measured. Compiled `HEAD` with `/DSKIP_32BIT_CONTENT` (exactly what CI ran for the shipping installer) and this revision with no defines, against the same input tree:

| region | result |
|---|---|
| installer stub `.text`/`.rdata`/`.data` | identical (33,280 bytes) |
| **NSIS payload** — header, install code, string table, data block | **identical (3,132,685 bytes)** |
| `.rsrc` | 5–6 bytes differ |
| trailing CRC32 | differs |

The `.rsrc` bytes sit in the alignment gap between the icon-group resource and `VS_VERSIONINFO`, which NSIS never zeroes; they vary between consecutive runs of the *same* script, so they are stale buffer content, not output. `VS_VERSIONINFO` itself is untouched.

Compile statistics match exactly:

```
BASELINE : 2449 instructions (68572 bytes), 557 strings (14298 bytes), 2 sections (4144 bytes), 6 pages
CANDIDATE: 2449 instructions (68572 bytes), 557 strings (14298 bytes), 2 sections (4144 bytes), 6 pages
```

`makensis` exits 0 with the same 8 warnings as the baseline (all `7010 no files found` from `/nonfatal` inputs I chose not to stub). CI's `build-installer / windows` job is the second gate.

## Note for the reviewer

`CI/obs-streamelements-installer/.github/workflows/build.yml` still mentions `build32` 8 times. It is a **vendored copy of the installer repo's own CI**, pulled in wholesale by #80, and is inert — GitHub only reads `.github/workflows` from the repo root, and nothing references it. Left alone here because deleting another repo's vendored CI is a separate call; flagging it so the acceptance grep doesn't surprise anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)