### PR TITLE
feat(crash): capture fast-fail and heap corruption behind a gated WER module (CORE-864)

### DIFF
--- a/CI/obs-streamelements-installer/main.nsi
+++ b/CI/obs-streamelements-installer/main.nsi
@@ -602,6 +602,8 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
     Delete "$INSTDIR\bin\64bit\BugSplatHD64.exe"
     Delete "$INSTDIR\bin\64bit\BugSplatRc64.dll"
     Delete "$INSTDIR\obs-plugins\64bit\sentry-crash.exe"
+    Delete "$INSTDIR\obs-plugins\64bit\se-crash-wer.dll"
+    Delete "$INSTDIR\obs-plugins\64bit\sentry-wer.dll"
 
     # /nonfatal on the crash-reporting runtime: which of these exists depends on
     # STREAMELEMENTS_CRASH_HANDLER at build time, and the installer has no way to
@@ -628,6 +630,29 @@ Section "${PRODUCT_SHORT_NAME} Add-On" section_install_streamelements
     # to land here, next to obs-streamelements-core.dll, not in bin\64bit.
     # /nonfatal because a BugSplat build does not produce it.
     File /nonfatal ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\sentry-crash.exe
+
+    # The two WER runtime exception modules (CORE-864). Heap corruption and
+    # every __fastfail bypass SEH, so nothing in the crashing process ever sees
+    # them; these are what capture that class, out of process, from inside
+    # WerFault.exe.
+    #
+    # se-crash-wer.dll is ours. It applies the module-of-interest gate and the
+    # standing-consent check, then forwards to sentry's module. The handler
+    # registers it by absolute path, resolved beside its own module, which is
+    # why it can live here.
+    #
+    # sentry-wer.dll must land HERE and nowhere else, and specifically NOT in
+    # bin\64bit next to obs64.exe. sentry-native's wer_default_path() joins
+    # "sentry-wer.dll" onto the host executable's directory and registers
+    # whatever it finds there; a copy in bin\64bit would therefore get
+    # registered by sentry itself, and sentry's module claims every fast-fail
+    # in the process -- OBS's own and every other plug-in's -- with no gate at
+    # all. Keeping it here is what keeps ours the only registered module.
+    #
+    # /nonfatal for the same reason as the daemon above: a BugSplat build
+    # produces neither.
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\se-crash-wer.dll
+    File /nonfatal ..\download\obs-streamelements-core\build64_qt6\obs-plugins\64bit\sentry-wer.dll
 
     Delete /REBOOTOK "$OUTDIR\obs-streamelements.dll"
     Delete /REBOOTOK "$OUTDIR\obs-streamelements.pdb"

--- a/CI/obs-streamelements-uninstaller/main.nsi
+++ b/CI/obs-streamelements-uninstaller/main.nsi
@@ -188,6 +188,18 @@ Section "section_main" section_main
     Delete "$INSTDIR\bin\64bit\BugSplatRc64.dll"
     Delete "$INSTDIR\obs-plugins\64bit\sentry-crash.exe"
 
+    # The WER runtime exception modules (CORE-864).
+    Delete "$INSTDIR\obs-plugins\64bit\se-crash-wer.dll"
+    Delete "$INSTDIR\obs-plugins\64bit\sentry-wer.dll"
+
+    # And the per-user allow-list entry that let WerFault load ours. The plug-in
+    # writes this on every start, keyed by the DLL's full path, and deliberately
+    # does not remove it at shutdown -- a crash during OBS's own teardown should
+    # still be caught. So this is the only place it is ever cleaned up. Harmless
+    # if left (WER only consults it for a process that registered the module),
+    # but it would otherwise name a DLL that no longer exists, forever.
+    DeleteRegValue HKCU "Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules" "$INSTDIR\obs-plugins\64bit\se-crash-wer.dll"
+
     Delete "$INSTDIR\obs-plugins\32bit\obs-streamelements.qt5.dymod"
     Delete "$INSTDIR\obs-plugins\32bit\obs-streamelements.qt5.pdb"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,54 @@ if (ENABLE_SENTRY)
 			endif()
 		endif()
 	endforeach()
+
+	# The gating WER runtime exception module (CORE-864).
+	#
+	# Heap corruption and every __fastfail bypass SEH, so neither our filter
+	# nor OBS's ever sees them; a WER runtime exception module, running out of
+	# process inside WerFault.exe, is the only thing that can capture them.
+	#
+	# sentry builds one -- sentry-wer.dll, from the target above -- but it
+	# claims every such crash in the host process, including OBS's own and
+	# every other plugin's. Registering it directly would undo the
+	# module-of-interest gate for one crash class. So we build our own, which
+	# applies the gate and the standing-consent check and then forwards to
+	# sentry's, and we register ours instead.
+	#
+	# Its own target because it is loaded into WerFault.exe, not into OBS: it
+	# must link neither libobs nor Qt nor sentry. Both DLLs are copied beside
+	# the plugin below, and sentry's is deliberately NOT placed next to
+	# obs64.exe, which is the only place sentry's own registration looks --
+	# that is what keeps ours the only module registered.
+	if (WIN32)
+		add_library(se-crash-wer SHARED
+			streamelements/StreamElementsWerModule.cpp
+			streamelements/StreamElementsWerModule.def
+		)
+
+		# No "lib" prefix and no debug postfix: WerFault loads it by the
+		# exact path we register, and the .def names the DLL.
+		set_property(TARGET se-crash-wer PROPERTY PREFIX "")
+		set_property(TARGET se-crash-wer PROPERTY DEBUG_POSTFIX "")
+
+		# Qt's autogen is on for everything in this directory. This target
+		# has no Qt in it and must not acquire any -- it is loaded into
+		# WerFault.exe, not into OBS -- so the moc/uic/rcc passes are turned
+		# off rather than left to produce an empty translation unit.
+		set_property(TARGET se-crash-wer PROPERTY AUTOMOC OFF)
+		set_property(TARGET se-crash-wer PROPERTY AUTOUIC OFF)
+		set_property(TARGET se-crash-wer PROPERTY AUTORCC OFF)
+
+		# /MD, matching libobs and the plugin. See the note on
+		# MSVC_RUNTIME_LIBRARY at the top of this file.
+		set_property(TARGET se-crash-wer PROPERTY MSVC_RUNTIME_LIBRARY
+			"MultiThreadedDLL")
+
+		target_include_directories(se-crash-wer PRIVATE
+			"${CMAKE_CURRENT_SOURCE_DIR}/streamelements")
+
+		target_link_libraries(se-crash-wer PRIVATE dbghelp psapi)
+	endif()
 endif()
 
 # WIN32 is part of the condition now that ENABLE_BUGSPLAT tracks the selected
@@ -632,6 +680,7 @@ set(obs-streamelements-core_HEADERS
 	streamelements/StreamElementsCrashConsentDialog.hpp
 	streamelements/StreamElementsBugSplatCrashHandler.hpp
 	streamelements/StreamElementsSentryCrashHandler.hpp
+	streamelements/StreamElementsWerRegistration.h
 	streamelements/StreamElementsMessageBus.hpp
 	streamelements/StreamElementsControllerServer.hpp
 	streamelements/StreamElementsObsSceneManager.hpp
@@ -1019,6 +1068,36 @@ if (WIN32)
 			"$<TARGET_FILE:sentry-crash>"
 			"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit/"
 		)
+
+		# The two WER module DLLs travel together and land in exactly the
+		# same place, for two different reasons (CORE-864).
+		#
+		# se-crash-wer.dll is ours: the handler registers it by absolute
+		# path, resolved relative to its own module, so it can live here
+		# rather than beside obs64.exe.
+		#
+		# sentry-wer.dll is sentry's, and it is here *because* sentry will
+		# not look here. wer_default_path() in sentry_backend_native.c
+		# joins "sentry-wer.dll" onto the directory of the host executable
+		# and registers whatever it finds. Putting it beside obs64.exe
+		# would make sentry register it, and sentry's module claims every
+		# fast-fail in the process -- OBS's own and every other plugin's --
+		# with no gate. Keeping it here means sentry logs "Native WER
+		# module not found", registers nothing, and ours stays the only
+		# registered module; ours then loads this copy explicitly by the
+		# path it was given.
+		add_dependencies(obs-streamelements-core se-crash-wer sentry-wer)
+
+		foreach(se_wer_target se-crash-wer sentry-wer)
+			add_custom_command(TARGET obs-streamelements-core POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"$<TARGET_FILE:${se_wer_target}>"
+				"$<TARGET_FILE_DIR:obs-streamelements-core>"
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"$<TARGET_FILE:${se_wer_target}>"
+				"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit/"
+			)
+		endforeach()
 	endif()
 endif()
 

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -1,7 +1,11 @@
 #include "StreamElementsApiMessageHandler.hpp"
 
-// __fastfail, for the crashProgramFastFail test hook below.
+// __fastfail, for the crashProgramFastFail test hook below. Windows only: this
+// file is in the unconditional source list, and neither the intrinsic nor the
+// header exists on macOS.
+#ifdef WIN32
 #include <intrin.h>
+#endif
 
 #include "cef-headers.hpp"
 
@@ -3345,6 +3349,10 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 	}
 	API_HANDLER_END();
 
+#ifdef WIN32
+	// Windows only, and not for want of a macOS equivalent: the door this
+	// exists to test is a WER runtime exception module, which is a Windows
+	// mechanism. There is nothing on macOS for the call to prove.
 	API_HANDLER_BEGIN("crashProgramFastFail");
 	{
 		// The counterpart to crashProgram above, and the only way to
@@ -3369,6 +3377,7 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		__fastfail(FAST_FAIL_FATAL_APP_EXIT);
 	}
 	API_HANDLER_END();
+#endif
 
 	API_HANDLER_BEGIN("deadlockProgram");
 	{

--- a/streamelements/StreamElementsApiMessageHandler.cpp
+++ b/streamelements/StreamElementsApiMessageHandler.cpp
@@ -1,5 +1,8 @@
 #include "StreamElementsApiMessageHandler.hpp"
 
+// __fastfail, for the crashProgramFastFail test hook below.
+#include <intrin.h>
+
 #include "cef-headers.hpp"
 
 #include "Version.hpp"
@@ -3339,6 +3342,31 @@ void StreamElementsApiMessageHandler::RegisterIncomingApiCallHandlers()
 		// *((int *)nullptr) = 12345; // exception
         
 		UNUSED_PARAMETER(result);
+	}
+	API_HANDLER_END();
+
+	API_HANDLER_BEGIN("crashProgramFastFail");
+	{
+		// The counterpart to crashProgram above, and the only way to
+		// exercise the fast-fail door (CORE-864).
+		//
+		// __fastfail raises STATUS_STACK_BUFFER_OVERRUN, which bypasses
+		// SEH entirely: our top-level filter never runs, the SIGABRT
+		// door never runs, and OBS's own handler never runs. The one
+		// thing that can capture it is the WER runtime exception module,
+		// out of process, after we are already dead -- so without a
+		// trigger there is no way to confirm that path works until a
+		// real user hits it.
+		//
+		// It matters that the call sits HERE, in the plug-in's own
+		// module. The gate that module applies asks whether the crashed
+		// thread's stack passes through our code, so a trigger placed
+		// anywhere else would be declined by design -- and would prove
+		// the opposite of what it set out to.
+		//
+		// Nothing runs after this line: not the UNUSED_PARAMETER, not
+		// the handler's epilogue. The process is gone.
+		__fastfail(FAST_FAIL_FATAL_APP_EXIT);
 	}
 	API_HANDLER_END();
 

--- a/streamelements/StreamElementsConfig.hpp
+++ b/streamelements/StreamElementsConfig.hpp
@@ -274,6 +274,37 @@ public:
 		SaveConfig();
 	}
 
+	//
+	// Standing consent for crashes that cannot ask (CORE-864).
+	//
+	// Heap corruption and every __fastfail kill the process before any
+	// handler of ours runs, so they are captured out of process by a WER
+	// runtime exception module, after we are already dead. There is no
+	// opportunity to show a prompt. The module reads this answer instead --
+	// it is carried into the crash in the registration block, see
+	// StreamElementsWerRegistration.h -- and reports nothing without it.
+	//
+	// Set from the ordinary crash-time prompt: "Send report" grants it,
+	// "Don't send" withdraws it. That is what the prompt now says it does.
+	// Defaults to false, so a user who has never answered a prompt has
+	// nothing sent on their behalf.
+	//
+	bool GetCrashReportStandingConsent()
+	{
+		return config_get_bool(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "StandingConsent");
+	}
+
+	void SetCrashReportStandingConsent(bool value)
+	{
+		config_set_bool(
+			StreamElementsConfig::GetInstance()->GetConfig(),
+			"CrashReporting", "StandingConsent", value);
+
+		SaveConfig();
+	}
+
 	std::string GetSceneItemsAuxActionsConfig()
 	{
 		const char *value = config_get_string(

--- a/streamelements/StreamElementsConfig.hpp
+++ b/streamelements/StreamElementsConfig.hpp
@@ -274,37 +274,6 @@ public:
 		SaveConfig();
 	}
 
-	//
-	// Standing consent for crashes that cannot ask (CORE-864).
-	//
-	// Heap corruption and every __fastfail kill the process before any
-	// handler of ours runs, so they are captured out of process by a WER
-	// runtime exception module, after we are already dead. There is no
-	// opportunity to show a prompt. The module reads this answer instead --
-	// it is carried into the crash in the registration block, see
-	// StreamElementsWerRegistration.h -- and reports nothing without it.
-	//
-	// Set from the ordinary crash-time prompt: "Send report" grants it,
-	// "Don't send" withdraws it. That is what the prompt now says it does.
-	// Defaults to false, so a user who has never answered a prompt has
-	// nothing sent on their behalf.
-	//
-	bool GetCrashReportStandingConsent()
-	{
-		return config_get_bool(
-			StreamElementsConfig::GetInstance()->GetConfig(),
-			"CrashReporting", "StandingConsent");
-	}
-
-	void SetCrashReportStandingConsent(bool value)
-	{
-		config_set_bool(
-			StreamElementsConfig::GetInstance()->GetConfig(),
-			"CrashReporting", "StandingConsent", value);
-
-		SaveConfig();
-	}
-
 	std::string GetSceneItemsAuxActionsConfig()
 	{
 		const char *value = config_get_string(

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -52,22 +52,24 @@ static const wchar_t *const PRIVACY_TEXT =
 	L"These may contain personal information, and are used only to diagnose this crash. Stream keys are removed.";
 
 //
-// What answering here also decides (CORE-864).
+// The crashes this dialog can never appear for (CORE-864).
 //
-// Heap corruption and fast-fail crashes kill the process before any handler of
-// ours runs. They are captured out of process, by a WER module, after we are
-// already dead -- so there is no possible moment at which this dialog could
-// appear for them. They are reported on the strength of the last answer given
-// here, or not at all.
+// Heap corruption and fast-fail kill the process before any handler of ours
+// runs. They are captured out of process, by a WER module, after we are already
+// dead -- so there is no moment at which this dialog could be shown for them,
+// and no earlier answer is required for them to be sent.
 //
-// Saying so is not optional. Consent obtained for "this crash" cannot silently
-// become consent for later ones the user was never told about; if this sentence
-// is removed, the standing-consent behaviour has to go with it. See
-// StreamElementsSentryCrashHandler.cpp, SetStandingConsent().
+// Disclosing that is not optional, and neither is being precise about what it
+// covers. Those reports are a minidump and the tags armed at startup: there is
+// nobody left to build the configuration archive, capture the screen, or ask
+// what the user was doing. The paragraph above is about that material, which is
+// why declining it does not contradict this. If the automatic behaviour is ever
+// removed, this sentence goes with it -- and if it is ever widened to carry the
+// archive or the screenshot, this sentence stops being true.
 //
-static const wchar_t *const STANDING_CONSENT_TEXT =
-	L"Some crashes stop OBS Studio too abruptly for this question to appear. "
-	L"Send report also lets those be sent automatically from now on; Don't send turns that off.";
+static const wchar_t *const AUTOMATIC_REPORT_TEXT =
+	L"Some crashes stop OBS Studio too abruptly to ask. Those send technical crash data "
+	L"automatically -- no configuration, screenshot or description.";
 
 /* ================================================================= */
 
@@ -828,7 +830,7 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 		   ATOM_STATIC, PRIVACY_TEXT);
 
 	AddControl(builder, visibleChild, 7, 202, 306, 20, (WORD)-1,
-		   ATOM_STATIC, STANDING_CONSENT_TEXT);
+		   ATOM_STATIC, AUTOMATIC_REPORT_TEXT);
 
 	// BS_OWNERDRAW on both, so DrawConsentButton below paints them.
 	//

--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -51,6 +51,24 @@ static const wchar_t *const PRIVACY_TEXT =
 	L"The report includes your OBS Studio and SE.Live configuration and an image of the OBS window. "
 	L"These may contain personal information, and are used only to diagnose this crash. Stream keys are removed.";
 
+//
+// What answering here also decides (CORE-864).
+//
+// Heap corruption and fast-fail crashes kill the process before any handler of
+// ours runs. They are captured out of process, by a WER module, after we are
+// already dead -- so there is no possible moment at which this dialog could
+// appear for them. They are reported on the strength of the last answer given
+// here, or not at all.
+//
+// Saying so is not optional. Consent obtained for "this crash" cannot silently
+// become consent for later ones the user was never told about; if this sentence
+// is removed, the standing-consent behaviour has to go with it. See
+// StreamElementsSentryCrashHandler.cpp, SetStandingConsent().
+//
+static const wchar_t *const STANDING_CONSENT_TEXT =
+	L"Some crashes stop OBS Studio too abruptly for this question to appear. "
+	L"Send report also lets those be sent automatically from now on; Don't send turns that off.";
+
 /* ================================================================= */
 
 #define IDC_DESCRIPTION 1001
@@ -748,11 +766,13 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 	builder.AddDword(dialogStyle);
 	builder.AddDword(WS_EX_TOPMOST);
-	builder.AddWord(13); // control count
+	builder.AddWord(14); // control count
 	builder.AddShort(0);
 	builder.AddShort(0);
 	builder.AddShort(320);
-	builder.AddShort(232);
+	// 24 taller than it was, for the standing-consent line below the privacy
+	// text. The button row moved down by the same amount.
+	builder.AddShort(256);
 
 	builder.AddWord(0); // no menu
 	builder.AddWord(0); // default dialog class
@@ -807,6 +827,9 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 	AddControl(builder, visibleChild, 7, 170, 306, 30, (WORD)-1,
 		   ATOM_STATIC, PRIVACY_TEXT);
 
+	AddControl(builder, visibleChild, 7, 202, 306, 20, (WORD)-1,
+		   ATOM_STATIC, STANDING_CONSENT_TEXT);
+
 	// BS_OWNERDRAW on both, so DrawConsentButton below paints them.
 	//
 	// A themed push button ignores WM_CTLCOLORBTN entirely -- the theme
@@ -823,11 +846,11 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 	// position below survives from here.
 	AddControl(builder,
 		   visibleChild | WS_TABSTOP | BS_DEFPUSHBUTTON | BS_OWNERDRAW,
-		   113, 204, 96, 20, IDOK, ATOM_BUTTON, L"Send report");
+		   113, 228, 96, 20, IDOK, ATOM_BUTTON, L"Send report");
 
 	AddControl(builder,
-		   visibleChild | WS_TABSTOP | BS_PUSHBUTTON | BS_OWNERDRAW, 217,
-		   204, 96, 20, IDCANCEL, ATOM_BUTTON, L"Don't send");
+		   visibleChild | WS_TABSTOP | BS_PUSHBUTTON | BS_OWNERDRAW,
+		   217, 228, 96, 20, IDCANCEL, ATOM_BUTTON, L"Don't send");
 }
 
 /* ================================================================= */

--- a/streamelements/StreamElementsCrashContext.cpp
+++ b/streamelements/StreamElementsCrashContext.cpp
@@ -497,6 +497,15 @@ bool StreamElementsCrashContext::ShouldReport() const
 	return m_impl->stackWalker->hasMatchModuleOfInterest;
 }
 
+std::vector<std::string>
+StreamElementsCrashContext::GetModulesOfInterest() const
+{
+	if (!m_impl || !m_impl->stackWalker)
+		return {};
+
+	return m_impl->stackWalker->modulesOfInterest;
+}
+
 /* ================================================================= */
 
 StreamElementsCrashContext::Result StreamElementsCrashContext::Collect()

--- a/streamelements/StreamElementsCrashContext.hpp
+++ b/streamelements/StreamElementsCrashContext.hpp
@@ -89,6 +89,20 @@ public:
 	// False until WalkStack() has run.
 	bool ShouldReport() const;
 
+	// The names ShouldReport() matches against: "obs-streamelements-core"
+	// and "obs-streamelements" by default, replaced wholesale when the
+	// remote settings.json supplies its own list.
+	//
+	// Exposed because the same verdict has to be reached a second time, in
+	// another process, by the WER runtime exception module that handles the
+	// crashes SEH never sees (CORE-864). That module cannot call in here, so
+	// the list is copied into the registration block it reads out of our
+	// memory. Two gates that disagreed would be worse than one.
+	//
+	// Final by the time the constructor returns: the settings fetch that can
+	// replace the list is synchronous and happens there.
+	std::vector<std::string> GetModulesOfInterest() const;
+
 	// Called from the exception path with the process already dying. Does no
 	// allocation it can avoid, touches no Qt, and must not throw.
 	//

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -3,6 +3,7 @@
 #include "StreamElementsConfig.hpp"
 #include "StreamElementsCrashConsentDialog.hpp"
 #include "StreamElementsCrashContext.hpp"
+#include "StreamElementsWerRegistration.h"
 #include "StreamElementsUtils.hpp"
 
 #include <util/base.h>
@@ -31,8 +32,14 @@
 #include <windows.h>
 #include <dwmapi.h>
 
+// WerRegisterRuntimeExceptionModule, the fast-fail door (CORE-864).
+#include <werapi.h>
+
 // Needed only by the dark title bar on the progress window below.
 #pragma comment(lib, "dwmapi.lib")
+
+// WerRegisterRuntimeExceptionModule, for the fast-fail door (CORE-864).
+#pragma comment(lib, "wer.lib")
 
 // Empty means crash reporting is inert: sentry_init() is skipped entirely rather
 // than run against a bad DSN, so a build without the DSN behaves like
@@ -881,6 +888,189 @@ static void DisarmPromptWatchdog()
 	s_promptWatchdogThread = NULL;
 }
 
+/* ================================================================= */
+
+//
+// The fast-fail door (CORE-864).
+//
+// Heap corruption (STATUS_HEAP_CORRUPTION) and every __fastfail
+// (STATUS_STACK_BUFFER_OVERRUN -- /GS cookie failures, and the CRT's default
+// invalid-parameter handler) bypass SEH entirely. The filter above never runs,
+// the SIGABRT door never runs, and OBS's own handler never runs either. The
+// process is simply gone.
+//
+// A WER runtime exception module is the only mechanism on Windows that sees
+// them, because it runs out of process inside WerFault.exe once we are already
+// dead. sentry-native ships one, but it has never registered here: its
+// wer_default_path() looks for sentry-wer.dll beside the host executable, and
+// we ship it beside the plug-in. Hence "Native WER module not found" in every
+// log since the Sentry backend shipped.
+//
+// Shipping it where sentry looks would have registered it -- and it claims
+// every fast-fail in the process, OBS's own and every other plug-in's, with no
+// gate at all. That is exactly what CORE-860 exists to stop. So se-crash-wer.dll
+// is registered instead: it applies the gate and the consent check, then
+// forwards to sentry's module. See StreamElementsWerModule.cpp.
+//
+// What the plug-in side owes that arrangement is a registration struct that
+// outlives everything, because WER hands its address to the module and the
+// module reads it back out of our memory with ReadProcessMemory().
+//
+
+static SEWerRegistration s_werRegistration = {};
+static bool s_werRegistered = false;
+
+//
+// Standing consent, as last answered at a crash prompt.
+//
+// The WER path cannot ask -- there is nobody left to ask -- so it reports on
+// the strength of the previous answer, or not at all. Mirrored into the
+// registration block so the module reads the current value rather than whatever
+// happened to be true at startup.
+//
+static bool s_standingConsent = false;
+
+static void SetStandingConsent(bool consented)
+{
+	// The in-memory half is free and always kept current.
+	const bool changed = s_standingConsent != consented;
+
+	s_standingConsent = consented;
+	s_werRegistration.seConsent = consented ? 1U : 0U;
+
+	if (!changed)
+		return;
+
+	// The ini write is not free: this runs on the crashing thread, on a
+	// process that is already dying. Only when the answer actually changed,
+	// for the same reason PersistContactDetails() guards its writes.
+	auto config = StreamElementsConfig::GetInstance();
+
+	if (config)
+		config->SetCrashReportStandingConsent(consented);
+}
+
+//
+// HKCU, deliberately: WER accepts a per-user allow-list, so this needs no
+// elevation. Same key and same approach as sentry-native's own registration.
+// Without the value, WerRegisterRuntimeExceptionModule still succeeds but
+// WerFault declines to load the DLL.
+//
+static bool SetWerRegistryValue(const std::wstring &modulePath)
+{
+	const DWORD one = 1;
+
+	const LSTATUS status = ::RegSetKeyValueW(
+		HKEY_CURRENT_USER,
+		L"Software\\Microsoft\\Windows\\Windows Error Reporting\\RuntimeExceptionHelperModules",
+		modulePath.c_str(), REG_DWORD, &one, sizeof(one));
+
+	return status == ERROR_SUCCESS;
+}
+
+//
+// Fills in the registration block and registers the module.
+//
+// Must run after sentry_init(), because app_tid has to be the thread that
+// called it: sentry's module derives the shared-memory names it uses to reach
+// the sentry-crash daemon from (pid, that tid), and opening them under any
+// other name finds nothing. And after the crash context exists, because the
+// gate list comes from it.
+//
+static void RegisterWerModule(uint64_t sentryInitThreadId,
+			      const std::vector<std::string> &modulesOfInterest)
+{
+	std::wstring moduleDirectory;
+
+	if (!GetOwnModuleDirectory(moduleDirectory)) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not resolve own module directory; the WER module cannot be registered and fast-fail crashes will go unreported");
+		return;
+	}
+
+	const std::wstring modulePath = moduleDirectory + L"se-crash-wer.dll";
+	const std::wstring sentryWerPath = moduleDirectory + L"sentry-wer.dll";
+
+	// Both DLLs have to be on disk, and saying which one is missing matters:
+	// they are produced by two different CMake rules and packaged by two
+	// different lines in main.nsi, so they can go missing independently.
+	if (::GetFileAttributesW(modulePath.c_str()) ==
+	    INVALID_FILE_ATTRIBUTES) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: se-crash-wer.dll is not next to the plug-in; fast-fail and heap-corruption crashes will go unreported");
+		return;
+	}
+
+	if (::GetFileAttributesW(sentryWerPath.c_str()) ==
+	    INVALID_FILE_ATTRIBUTES) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: sentry-wer.dll is not next to the plug-in; the gating module would have nothing to forward to, so it is not registered");
+		return;
+	}
+
+	// --- sentry's half of the block. Its layout is not ours to choose. ---
+	s_werRegistration.version = 1;
+	s_werRegistration.app_pid = ::GetCurrentProcessId();
+	s_werRegistration.app_tid = sentryInitThreadId;
+
+	// --- ours ------------------------------------------------------------
+	s_werRegistration.seMagic = SE_WER_MAGIC;
+	s_werRegistration.seVersion = SE_WER_VERSION;
+	s_werRegistration.seConsent = s_standingConsent ? 1U : 0U;
+
+	::wcsncpy_s(s_werRegistration.seSentryWerPath,
+		    _countof(s_werRegistration.seSentryWerPath),
+		    sentryWerPath.c_str(), _TRUNCATE);
+
+	s_werRegistration.seModuleCount = 0;
+
+	for (const auto &name : modulesOfInterest) {
+		if (s_werRegistration.seModuleCount >= SE_WER_MODULES_MAX) {
+			blog(LOG_WARNING,
+			     "obs-streamelements-core: StreamElements: Crash Handler: more than %d modules of interest; the WER gate will use the first %d and may decline a crash the in-process gate would have accepted",
+			     SE_WER_MODULES_MAX, SE_WER_MODULES_MAX);
+			break;
+		}
+
+		::strncpy_s(s_werRegistration
+				    .seModules[s_werRegistration.seModuleCount],
+			    SE_WER_MODULE_NAME_MAX, name.c_str(), _TRUNCATE);
+
+		++s_werRegistration.seModuleCount;
+	}
+
+	if (!SetWerRegistryValue(modulePath)) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: could not add the WER module to the per-user allow-list; fast-fail and heap-corruption crashes will go unreported");
+		return;
+	}
+
+	//
+	// Below Windows 10 build 19041 this call succeeds but the out-of-process
+	// callback is never invoked -- sentry refuses to register below the same
+	// build for that reason. We register anyway and say so: the call is
+	// harmless, and a version test here would have to duplicate sentry's,
+	// which reads the real build number rather than the shimmed one that
+	// GetVersionEx reports to an unmanifested host.
+	//
+	const HRESULT hr = ::WerRegisterRuntimeExceptionModule(
+		modulePath.c_str(), &s_werRegistration);
+
+	if (FAILED(hr)) {
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: StreamElements: Crash Handler: WerRegisterRuntimeExceptionModule failed (0x%08lX); fast-fail and heap-corruption crashes will go unreported",
+		     (unsigned long)hr);
+		return;
+	}
+
+	s_werRegistered = true;
+
+	blog(LOG_INFO,
+	     "obs-streamelements-core: StreamElements: Crash Handler: WER module registered (requires Windows 10 build 19041 or later to fire); %d module(s) of interest, standing consent = %s",
+	     (int)s_werRegistration.seModuleCount,
+	     s_standingConsent ? "yes" : "no");
+}
+
 // The whole crash path, shared by the two ways a fatal condition reaches us:
 // the top-level SEH filter and the SIGABRT handler below.
 //
@@ -994,6 +1184,15 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 					s_userName, s_userEmail, s_userDiscord);
 
 			DisarmPromptWatchdog();
+
+			// Whatever the user just decided also settles what
+			// happens to the crashes that can never ask -- heap
+			// corruption and fast-fail, which kill the process
+			// before any handler of ours runs and are reported out
+			// of process by the WER module. "Send report" grants
+			// that; "Don't send" withdraws it. The prompt says so;
+			// see StreamElementsCrashConsentDialog.cpp.
+			SetStandingConsent(consent.consented);
 
 			if (consent.consented) {
 				PersistContactDetails(consent.name,
@@ -1330,6 +1529,16 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	sentry_options_set_crash_reporting_mode(
 		options, SENTRY_CRASH_REPORTING_MODE_NATIVE_WITH_MINIDUMP);
 
+	//
+	// The thread that calls sentry_init() is part of the WER module's
+	// address book, not an incidental detail: sentry-native names the shared
+	// memory it talks to the sentry-crash daemon over
+	// "Local\\SentryCrash-<pid>-<tid>", with tid fixed at this moment. The
+	// module opens it by that name and finds nothing if we hand it any
+	// other thread. See RegisterWerModule().
+	//
+	const uint64_t sentryInitThreadId = (uint64_t)::GetCurrentThreadId();
+
 	if (sentry_init(options) != 0) {
 		blog(LOG_ERROR,
 		     "obs-streamelements-core: StreamElements: Crash Handler: sentry_init() failed");
@@ -1346,6 +1555,10 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 		s_userName = config->GetCrashReportUserName();
 		s_userEmail = config->GetCrashReportUserEmail();
 		s_userDiscord = config->GetCrashReportUserDiscord();
+
+		// The answer the WER path reports on, because it cannot ask.
+		// False until the user has said yes to some earlier prompt.
+		s_standingConsent = config->GetCrashReportStandingConsent();
 	}
 
 	SetSentryUser(s_userName, s_userEmail, s_userDiscord);
@@ -1392,6 +1605,14 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 	s_previousNewMode = _set_new_mode(1);
 
 	s_crashContext = new StreamElementsCrashContext();
+
+	// Last, and in this order deliberately: the gate list is only final once
+	// the context has been constructed -- its settings.json fetch is
+	// synchronous and happens in there -- and app_tid is only meaningful
+	// once sentry_init() has run. Copying a half-built list into the
+	// registration block would give the two gates different answers.
+	RegisterWerModule(sentryInitThreadId,
+			  s_crashContext->GetModulesOfInterest());
 
 	s_initialized = true;
 

--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -921,36 +921,6 @@ static SEWerRegistration s_werRegistration = {};
 static bool s_werRegistered = false;
 
 //
-// Standing consent, as last answered at a crash prompt.
-//
-// The WER path cannot ask -- there is nobody left to ask -- so it reports on
-// the strength of the previous answer, or not at all. Mirrored into the
-// registration block so the module reads the current value rather than whatever
-// happened to be true at startup.
-//
-static bool s_standingConsent = false;
-
-static void SetStandingConsent(bool consented)
-{
-	// The in-memory half is free and always kept current.
-	const bool changed = s_standingConsent != consented;
-
-	s_standingConsent = consented;
-	s_werRegistration.seConsent = consented ? 1U : 0U;
-
-	if (!changed)
-		return;
-
-	// The ini write is not free: this runs on the crashing thread, on a
-	// process that is already dying. Only when the answer actually changed,
-	// for the same reason PersistContactDetails() guards its writes.
-	auto config = StreamElementsConfig::GetInstance();
-
-	if (config)
-		config->SetCrashReportStandingConsent(consented);
-}
-
-//
 // HKCU, deliberately: WER accepts a per-user allow-list, so this needs no
 // elevation. Same key and same approach as sentry-native's own registration.
 // Without the value, WerRegisterRuntimeExceptionModule still succeeds but
@@ -1016,7 +986,6 @@ static void RegisterWerModule(uint64_t sentryInitThreadId,
 	// --- ours ------------------------------------------------------------
 	s_werRegistration.seMagic = SE_WER_MAGIC;
 	s_werRegistration.seVersion = SE_WER_VERSION;
-	s_werRegistration.seConsent = s_standingConsent ? 1U : 0U;
 
 	::wcsncpy_s(s_werRegistration.seSentryWerPath,
 		    _countof(s_werRegistration.seSentryWerPath),
@@ -1066,9 +1035,8 @@ static void RegisterWerModule(uint64_t sentryInitThreadId,
 	s_werRegistered = true;
 
 	blog(LOG_INFO,
-	     "obs-streamelements-core: StreamElements: Crash Handler: WER module registered (requires Windows 10 build 19041 or later to fire); %d module(s) of interest, standing consent = %s",
-	     (int)s_werRegistration.seModuleCount,
-	     s_standingConsent ? "yes" : "no");
+	     "obs-streamelements-core: StreamElements: Crash Handler: WER module registered (requires Windows 10 build 19041 or later to fire); %d module(s) of interest",
+	     (int)s_werRegistration.seModuleCount);
 }
 
 // The whole crash path, shared by the two ways a fatal condition reaches us:
@@ -1184,15 +1152,6 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 					s_userName, s_userEmail, s_userDiscord);
 
 			DisarmPromptWatchdog();
-
-			// Whatever the user just decided also settles what
-			// happens to the crashes that can never ask -- heap
-			// corruption and fast-fail, which kill the process
-			// before any handler of ours runs and are reported out
-			// of process by the WER module. "Send report" grants
-			// that; "Don't send" withdraws it. The prompt says so;
-			// see StreamElementsCrashConsentDialog.cpp.
-			SetStandingConsent(consent.consented);
 
 			if (consent.consented) {
 				PersistContactDetails(consent.name,
@@ -1555,10 +1514,6 @@ StreamElementsSentryCrashHandler::StreamElementsSentryCrashHandler()
 		s_userName = config->GetCrashReportUserName();
 		s_userEmail = config->GetCrashReportUserEmail();
 		s_userDiscord = config->GetCrashReportUserDiscord();
-
-		// The answer the WER path reports on, because it cannot ask.
-		// False until the user has said yes to some earlier prompt.
-		s_standingConsent = config->GetCrashReportStandingConsent();
 	}
 
 	SetSentryUser(s_userName, s_userEmail, s_userDiscord);

--- a/streamelements/StreamElementsWerModule.cpp
+++ b/streamelements/StreamElementsWerModule.cpp
@@ -1,0 +1,535 @@
+//
+// se-crash-wer.dll -- a WER runtime exception module that gates.
+//
+// CORE-864. Heap corruption and every __fastfail bypass SEH entirely: our
+// top-level exception filter never sees them, the SIGABRT door never sees them,
+// and OBS's own handler never sees them either. A WER runtime exception module
+// is the only mechanism on Windows that can capture them at all, because it
+// runs out of process, inside WerFault.exe, after the crashed process has
+// already been suspended.
+//
+// sentry-native ships one of these (sentry-wer.dll) and it works. What it does
+// not do is decide whether the crash was ours. It claims every fast-fail and
+// every heap corruption in the host process -- OBS's own, and every other
+// plugin's. Registering it directly would quietly undo the module-of-interest
+// gate that CORE-860 exists to enforce, for one crash class, without anyone
+// deciding to.
+//
+// So this module is registered instead, and sentry's is not registered at all:
+// sentry looks for its module next to the host executable, and we deliberately
+// ship it beside the plugin, where sentry will not find it. We do the two
+// things sentry's module cannot:
+//
+//   1. decline unless the user has given standing consent, and
+//   2. decline unless the crashed thread's stack passes through one of our
+//      modules,
+//
+// and only then hand the very same call to sentry's module, which owns the
+// shared-memory handshake with the sentry-crash daemon that writes and uploads
+// the minidump. We deliberately do not reimplement that handshake: it depends
+// on sentry's internal sentry_crash_context.h layout, and a second copy of it
+// here would be one more thing to keep in step across SDK upgrades.
+//
+// This file is built as its own DLL and links neither libobs, nor Qt, nor
+// sentry. It is C++ only for `::`-qualified calls and static_assert; nothing
+// here allocates through the CRT's C++ machinery or throws.
+//
+// Constraints it works under, all of them consequences of where it runs:
+//
+//   * We are inside WerFault.exe, a system process. There is no OBS log to
+//     write to and nobody to show a message to. Diagnostics go to
+//     OutputDebugString, which costs nothing when no debugger is listening.
+//   * WER puts a time budget on this callback. The stack walk is bounded and
+//     no symbol path is ever set, so nothing here can block on a symbol server.
+//   * Claiming ownership suppresses WER's normal handling. We claim only what
+//     sentry's module claims, and never on our own account.
+//
+
+#include "StreamElementsWerRegistration.h"
+
+#include <werapi.h>
+#include <dbghelp.h>
+#include <psapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#pragma comment(lib, "dbghelp.lib")
+#pragma comment(lib, "psapi.lib")
+
+#ifndef STATUS_FAIL_FAST_EXCEPTION
+#define STATUS_FAIL_FAST_EXCEPTION ((DWORD)0xC0000602)
+#endif
+
+#ifndef STATUS_STACK_BUFFER_OVERRUN
+#define STATUS_STACK_BUFFER_OVERRUN ((DWORD)0xC0000409)
+#endif
+
+#ifndef STATUS_HEAP_CORRUPTION
+#define STATUS_HEAP_CORRUPTION ((DWORD)0xC0000374)
+#endif
+
+// Deep enough to cross the CRT and OBS frames that sit above plugin code on a
+// fast-fail, shallow enough that a corrupt stack cannot spin us. The in-process
+// walker is bounded comparably.
+#define SE_WER_MAX_FRAMES 128
+
+// The crashed process's module table is read once per callback. OBS with
+// browser sources loaded runs to several hundred modules.
+#define SE_WER_MAX_MODULES 1024
+
+//
+// One OutputDebugStringA per line, deliberately. The debug output channel is
+// system-wide and unsynchronised across processes, so a line emitted as
+// prefix-then-body-then-newline can interleave with another process's and
+// arrive unreadable. Composing first costs a stack buffer and makes each line
+// atomic.
+//
+static void SEWerLog(const char *format, ...)
+{
+	char message[1024];
+	char line[1088];
+	va_list args;
+
+	va_start(args, format);
+	_vsnprintf_s(message, sizeof(message), _TRUNCATE, format, args);
+	va_end(args);
+
+	_snprintf_s(line, sizeof(line), _TRUNCATE, "se-crash-wer: %s\n",
+		    message);
+
+	::OutputDebugStringA(line);
+}
+
+/* ================================================================= */
+
+//
+// Module ranges of the CRASHED process.
+//
+// Names come from EnumProcessModulesEx rather than from dbghelp on purpose. The
+// gate only needs to know which module a return address falls in, and a range
+// table answers that with no allocation. Asking dbghelp for a symbol would mean
+// touching PDBs -- and potentially a symbol server -- inside a callback WER is
+// timing.
+//
+struct SEWerModuleRange {
+	ULONG64 base;
+	ULONG64 end;
+	char name[SE_WER_MODULE_NAME_MAX];
+};
+
+static SEWerModuleRange s_modules[SE_WER_MAX_MODULES];
+static int s_moduleCount = 0;
+
+static void SEWerStripExtension(char *name)
+{
+	char *dot = ::strrchr(name, '.');
+
+	if (dot)
+		*dot = '\0';
+}
+
+static void SEWerLoadModuleRanges(HANDLE process)
+{
+	DWORD needed = 0;
+	int count = 0;
+
+	s_moduleCount = 0;
+
+	HMODULE *handles =
+		(HMODULE *)::calloc(SE_WER_MAX_MODULES, sizeof(HMODULE));
+
+	if (!handles) {
+		SEWerLog("could not allocate the module table");
+		return;
+	}
+
+	if (!::EnumProcessModulesEx(
+		    process, handles,
+		    (DWORD)(SE_WER_MAX_MODULES * sizeof(HMODULE)), &needed,
+		    LIST_MODULES_ALL)) {
+		SEWerLog("EnumProcessModulesEx failed: %lu", ::GetLastError());
+		::free(handles);
+		return;
+	}
+
+	count = (int)(needed / sizeof(HMODULE));
+
+	if (count > SE_WER_MAX_MODULES)
+		count = SE_WER_MAX_MODULES;
+
+	for (int index = 0; index < count; ++index) {
+		MODULEINFO info;
+		char base[MAX_PATH];
+
+		if (!::GetModuleInformation(process, handles[index], &info,
+					    sizeof(info)))
+			continue;
+
+		if (!::GetModuleBaseNameA(process, handles[index], base,
+					  sizeof(base)))
+			continue;
+
+		// "obs-streamelements-core.dll" -> "obs-streamelements-core",
+		// matching how the in-process gate compares.
+		SEWerStripExtension(base);
+
+		s_modules[s_moduleCount].base = (ULONG64)info.lpBaseOfDll;
+		s_modules[s_moduleCount].end =
+			(ULONG64)info.lpBaseOfDll + info.SizeOfImage;
+
+		::strncpy_s(s_modules[s_moduleCount].name,
+			    sizeof(s_modules[s_moduleCount].name), base,
+			    _TRUNCATE);
+
+		++s_moduleCount;
+	}
+
+	::free(handles);
+
+	SEWerLog("enumerated %d modules in the crashed process", s_moduleCount);
+}
+
+static const char *SEWerModuleForAddress(ULONG64 address)
+{
+	for (int index = 0; index < s_moduleCount; ++index) {
+		if (address >= s_modules[index].base &&
+		    address < s_modules[index].end)
+			return s_modules[index].name;
+	}
+
+	return NULL;
+}
+
+static BOOL SEWerIsModuleOfInterest(const SEWerRegistration *registration,
+				    const char *moduleName)
+{
+	if (!moduleName)
+		return FALSE;
+
+	for (DWORD index = 0;
+	     index < registration->seModuleCount && index < SE_WER_MODULES_MAX;
+	     ++index) {
+		if (::_stricmp(registration->seModules[index], moduleName) == 0)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+/* ================================================================= */
+
+//
+// The gate. Walks the crashed thread cross-process and reports whether any
+// frame lands in a module we own.
+//
+static BOOL
+SEWerStackTouchesModuleOfInterest(HANDLE process, HANDLE thread,
+				  const CONTEXT *contextIn,
+				  const SEWerRegistration *registration)
+{
+	// StackWalk64 writes through the context, so give it a copy. The one
+	// WER handed us describes a process we do not own and must not modify.
+	CONTEXT context = *contextIn;
+	STACKFRAME64 frame;
+	DWORD machine = 0;
+	BOOL found = FALSE;
+
+	::SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_NO_PROMPTS);
+
+	// fInvadeProcess = TRUE so dbghelp knows the module list, which is what
+	// the x64 unwinder needs in order to find function tables. No symbol
+	// path is set and no symbol is ever requested, so this cannot reach out
+	// to a symbol server.
+	if (!::SymInitialize(process, NULL, TRUE)) {
+		SEWerLog("SymInitialize failed: %lu (walking anyway)",
+			 ::GetLastError());
+	}
+
+	::memset(&frame, 0, sizeof(frame));
+
+#if defined(_M_AMD64)
+	machine = IMAGE_FILE_MACHINE_AMD64;
+	frame.AddrPC.Offset = context.Rip;
+	frame.AddrFrame.Offset = context.Rbp;
+	frame.AddrStack.Offset = context.Rsp;
+#elif defined(_M_ARM64)
+	machine = IMAGE_FILE_MACHINE_ARM64;
+	frame.AddrPC.Offset = context.Pc;
+	frame.AddrFrame.Offset = context.Fp;
+	frame.AddrStack.Offset = context.Sp;
+#else
+	machine = IMAGE_FILE_MACHINE_I386;
+	frame.AddrPC.Offset = context.Eip;
+	frame.AddrFrame.Offset = context.Ebp;
+	frame.AddrStack.Offset = context.Esp;
+#endif
+
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrFrame.Mode = AddrModeFlat;
+	frame.AddrStack.Mode = AddrModeFlat;
+
+	for (int index = 0; index < SE_WER_MAX_FRAMES; ++index) {
+		if (!::StackWalk64(machine, process, thread, &frame, &context,
+				   NULL, ::SymFunctionTableAccess64,
+				   ::SymGetModuleBase64, NULL))
+			break;
+
+		if (!frame.AddrPC.Offset)
+			break;
+
+		const char *moduleName =
+			SEWerModuleForAddress(frame.AddrPC.Offset);
+
+		if (SEWerIsModuleOfInterest(registration, moduleName)) {
+			SEWerLog("frame %d is in %s -- ours", index,
+				 moduleName);
+
+			found = TRUE;
+			break;
+		}
+	}
+
+	::SymCleanup(process);
+
+	return found;
+}
+
+/* ================================================================= */
+
+//
+// bIsFatal is absent from older SDK definitions of
+// WER_RUNTIME_EXCEPTION_INFORMATION, so its presence is established from dwSize
+// before the field is touched. Same approach, and the same reason, as
+// sentry_wer.c.
+//
+struct SEWerExceptionInformation19041 {
+	DWORD dwSize;
+	HANDLE hProcess;
+	HANDLE hThread;
+	EXCEPTION_RECORD exceptionRecord;
+	CONTEXT context;
+	PCWSTR pwszReportId;
+	BOOL bIsFatal;
+	DWORD dwReserved;
+};
+
+static BOOL SEWerIsFatal(const WER_RUNTIME_EXCEPTION_INFORMATION *info)
+{
+	if (!info ||
+	    info->dwSize <= offsetof(SEWerExceptionInformation19041, bIsFatal))
+		return FALSE;
+
+	return ((const SEWerExceptionInformation19041 *)info)->bIsFatal;
+}
+
+//
+// The codes that reach a WER module and nothing else. Kept identical to
+// sentry_wer.c's is_native_wer_exception: claiming anything sentry would not
+// claim would suppress WER's normal handling for a crash we then fail to
+// report.
+//
+static BOOL SEWerIsNativeException(DWORD code)
+{
+	return code == STATUS_FAIL_FAST_EXCEPTION ||
+	       code == STATUS_STACK_BUFFER_OVERRUN ||
+	       code == STATUS_HEAP_CORRUPTION;
+}
+
+static BOOL SEWerReadRegistration(HANDLE process, PVOID address,
+				  SEWerRegistration *registration)
+{
+	SIZE_T read = 0;
+
+	if (!process || !address || !registration)
+		return FALSE;
+
+	if (!::ReadProcessMemory(process, address, registration,
+				 sizeof(*registration), &read) ||
+	    read != sizeof(*registration)) {
+		SEWerLog("could not read the registration block: %lu",
+			 ::GetLastError());
+		return FALSE;
+	}
+
+	if (registration->seMagic != SE_WER_MAGIC ||
+	    registration->seVersion != SE_WER_VERSION) {
+		SEWerLog(
+			"registration block is not ours (magic 0x%08lX, version %lu)",
+			(unsigned long)registration->seMagic,
+			(unsigned long)registration->seVersion);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+//
+// Hands the call to sentry's own module, unchanged.
+//
+// The context pointer is passed through untouched: sentry's read_registration()
+// does a fixed-size read of its own struct from that address, and our block
+// begins with exactly that struct. Its verdict on ownership becomes ours -- we
+// never claim on our own account.
+//
+static HRESULT SEWerForwardToSentry(const wchar_t *sentryWerPath, PVOID context,
+				    PWER_RUNTIME_EXCEPTION_INFORMATION info,
+				    BOOL *ownershipClaimed, PWSTR eventName,
+				    PDWORD eventNameSize, PDWORD signatureCount)
+{
+	typedef HRESULT(WINAPI * SentryCallback)(
+		PVOID, PWER_RUNTIME_EXCEPTION_INFORMATION, BOOL *, PWSTR,
+		PDWORD, PDWORD);
+
+	if (!sentryWerPath || !sentryWerPath[0]) {
+		SEWerLog("no sentry-wer.dll path in the registration block");
+		return S_OK;
+	}
+
+	HMODULE sentryModule = ::LoadLibraryW(sentryWerPath);
+
+	if (!sentryModule) {
+		SEWerLog("could not load sentry-wer.dll: %lu",
+			 ::GetLastError());
+		return S_OK;
+	}
+
+	SentryCallback callback = (SentryCallback)::GetProcAddress(
+		sentryModule, "OutOfProcessExceptionEventCallback");
+
+	if (!callback) {
+		SEWerLog(
+			"sentry-wer.dll has no OutOfProcessExceptionEventCallback");
+		::FreeLibrary(sentryModule);
+		return S_OK;
+	}
+
+	HRESULT result = callback(context, info, ownershipClaimed, eventName,
+				  eventNameSize, signatureCount);
+
+	SEWerLog("sentry-wer.dll returned 0x%08lX, claimed=%d",
+		 (unsigned long)result, *ownershipClaimed ? 1 : 0);
+
+	// Deliberately not freed. sentry's module has just handed the crash to
+	// the sentry-crash daemon and WER may still call back into it; unloading
+	// here would be a use-after-free for the sake of tidiness in a process
+	// that is about to exit anyway.
+	return result;
+}
+
+/* ================================================================= */
+
+extern "C" {
+
+HRESULT WINAPI OutOfProcessExceptionEventCallback(
+	PVOID context, PWER_RUNTIME_EXCEPTION_INFORMATION exceptionInfo,
+	BOOL *ownershipClaimed, PWSTR eventName, PDWORD eventNameSize,
+	PDWORD signatureCount)
+{
+	SEWerRegistration registration;
+
+	if (ownershipClaimed)
+		*ownershipClaimed = FALSE;
+
+	if (!exceptionInfo || !ownershipClaimed)
+		return S_OK;
+
+	const DWORD code = exceptionInfo->exceptionRecord.ExceptionCode;
+
+	// Cheap tests first. Everything below this point costs a cross-process
+	// module enumeration and a stack walk, and WER is timing us.
+	if (!SEWerIsFatal(exceptionInfo) || !SEWerIsNativeException(code))
+		return S_OK;
+
+	if (!SEWerReadRegistration(exceptionInfo->hProcess, context,
+				   &registration))
+		return S_OK;
+
+	SEWerLog("fatal 0x%08lX in pid %lu", (unsigned long)code,
+		 (unsigned long)::GetProcessId(exceptionInfo->hProcess));
+
+	//
+	// Consent, before anything else is examined.
+	//
+	// This crash cannot ask. It is reported on the strength of an answer
+	// the user gave to an earlier prompt, and if there is no such answer
+	// there is nothing to fall back on -- so we stop here and the crash
+	// goes unreported. That is the intended outcome, not a failure.
+	//
+	if (!registration.seConsent) {
+		SEWerLog("no standing consent -- declining");
+		return S_OK;
+	}
+
+	SEWerLoadModuleRanges(exceptionInfo->hProcess);
+
+	//
+	// The gate. A stack that never passed through our code is not ours to
+	// report, exactly as in the in-process filter. Declining costs nothing
+	// but not claiming ownership: WER carries on as though we were not
+	// installed.
+	//
+	if (!SEWerStackTouchesModuleOfInterest(
+		    exceptionInfo->hProcess, exceptionInfo->hThread,
+		    &exceptionInfo->context, &registration)) {
+		SEWerLog("no frame in a module of interest -- declining");
+		return S_OK;
+	}
+
+	return SEWerForwardToSentry(registration.seSentryWerPath, context,
+				    exceptionInfo, ownershipClaimed, eventName,
+				    eventNameSize, signatureCount);
+}
+
+//
+// WER only asks for signatures on a report we claimed, and sentry's module
+// declines to supply any. Matching it keeps a report's bucketing identical to
+// what sentry produces when its module is registered directly.
+//
+HRESULT WINAPI OutOfProcessExceptionEventSignatureCallback(
+	PVOID context, PWER_RUNTIME_EXCEPTION_INFORMATION exceptionInfo,
+	DWORD index, PWSTR name, PDWORD nameSize, PWSTR value, PDWORD valueSize)
+{
+	(void)context;
+	(void)exceptionInfo;
+	(void)index;
+	(void)name;
+	(void)nameSize;
+	(void)value;
+	(void)valueSize;
+
+	return E_FAIL;
+}
+
+//
+// We never want a debugger launched on a user's machine.
+//
+HRESULT WINAPI OutOfProcessExceptionEventDebuggerLaunchCallback(
+	PVOID context, PWER_RUNTIME_EXCEPTION_INFORMATION exceptionInfo,
+	PBOOL isCustomDebugger, PWSTR debuggerLaunch, PDWORD debuggerLaunchSize,
+	PBOOL isDebuggerAutolaunch)
+{
+	(void)context;
+	(void)exceptionInfo;
+	(void)isCustomDebugger;
+	(void)debuggerLaunch;
+	(void)debuggerLaunchSize;
+	(void)isDebuggerAutolaunch;
+
+	return E_FAIL;
+}
+
+} // extern "C"
+
+BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
+{
+	(void)reserved;
+
+	// Nothing to do, and nothing may safely be done: this loads inside
+	// WerFault.exe while it is handling a crash.
+	if (reason == DLL_PROCESS_ATTACH)
+		::DisableThreadLibraryCalls(instance);
+
+	return TRUE;
+}

--- a/streamelements/StreamElementsWerModule.cpp
+++ b/streamelements/StreamElementsWerModule.cpp
@@ -20,9 +20,8 @@
 // ship it beside the plugin, where sentry will not find it. We do the two
 // things sentry's module cannot:
 //
-//   1. decline unless the user has given standing consent, and
-//   2. decline unless the crashed thread's stack passes through one of our
-//      modules,
+//   decline unless the crashed thread's stack passes through one of our
+//   modules,
 //
 // and only then hand the very same call to sentry's module, which owns the
 // shared-memory handshake with the sentry-crash daemon that writes and uploads
@@ -450,18 +449,20 @@ HRESULT WINAPI OutOfProcessExceptionEventCallback(
 		 (unsigned long)::GetProcessId(exceptionInfo->hProcess));
 
 	//
-	// Consent, before anything else is examined.
+	// Note what is deliberately NOT tested here: consent.
 	//
-	// This crash cannot ask. It is reported on the strength of an answer
-	// the user gave to an earlier prompt, and if there is no such answer
-	// there is nothing to fall back on -- so we stop here and the crash
-	// goes unreported. That is the intended outcome, not a failure.
+	// This crash cannot ask -- the process is already gone -- and gating on
+	// an answer to some earlier prompt would mean the first fast-fail a user
+	// ever hits is always the one that goes unreported, which is the case
+	// most worth having. So this class is reported on implicit consent, and
+	// the crash-time prompt says so.
 	//
-	if (!registration.seConsent) {
-		SEWerLog("no standing consent -- declining");
-		return S_OK;
-	}
-
+	// It is a narrower disclosure than it sounds. A WER report is a minidump
+	// plus the scope armed at startup; there is nobody left to collect the
+	// configuration archive, the screenshot of the user's screen, or their
+	// description of what they were doing. Those are what the prompt is
+	// really asking about, and they are absent here by construction.
+	//
 	SEWerLoadModuleRanges(exceptionInfo->hProcess);
 
 	//

--- a/streamelements/StreamElementsWerModule.def
+++ b/streamelements/StreamElementsWerModule.def
@@ -1,0 +1,13 @@
+; Exports for se-crash-wer.dll, the gating WER runtime exception module.
+; See StreamElementsWerModule.cpp and CORE-864.
+;
+; WerFault.exe resolves these three by name, so they must be undecorated --
+; which is why the definitions carry extern "C". Names and order match
+; sentry-wer.def: the module stands in for sentry's, and forwards to it.
+
+LIBRARY "se-crash-wer.dll"
+
+EXPORTS
+  OutOfProcessExceptionEventCallback
+  OutOfProcessExceptionEventSignatureCallback
+  OutOfProcessExceptionEventDebuggerLaunchCallback

--- a/streamelements/StreamElementsWerRegistration.h
+++ b/streamelements/StreamElementsWerRegistration.h
@@ -1,0 +1,113 @@
+//
+// The registration block a WER runtime exception module reads back out of the
+// crashed process. Shared verbatim between the plugin, which fills it in and
+// hands its address to WerRegisterRuntimeExceptionModule(), and
+// StreamElementsWerModule.cpp, which runs inside WerFault.exe and reads it
+// back with ReadProcessMemory(). No dependencies either side: the module
+// links neither libobs, nor Qt, nor sentry.
+//
+// See CORE-864.
+//
+// The layout is not free. Its first sixteen bytes MUST stay byte-for-byte
+// identical to sentry-native's own sentry_wer_registration_t:
+//
+//     typedef struct {
+//         DWORD version;      // must be 1
+//         DWORD app_pid;
+//         uint64_t app_tid;
+//     } sentry_wer_registration_t;
+//
+// because our module forwards to sentry's sentry-wer.dll with the same context
+// pointer, and sentry's read_registration() does a fixed-size read of exactly
+// that struct. Everything after those sixteen bytes is ours and is invisible to
+// sentry -- it never reads that far.
+//
+// Carrying our own data here, rather than in a sidecar file, is deliberate. The
+// module runs in another process, after we are dead, with no way to call back
+// into the plugin and nowhere to look for configuration; and the values it
+// needs are exactly the values as of the moment of the crash. A snapshot in the
+// crashed process's own memory is precisely that.
+//
+
+#pragma once
+
+#include <windows.h>
+#include <stdint.h>
+#include <stddef.h>
+
+// Ours, so a stale or foreign block cannot be mistaken for one of ours. "SEWR".
+#define SE_WER_MAGIC 0x53455752U
+
+// Bumped when the layout below changes. The module refuses anything it does not
+// recognise rather than reading a struct it does not understand.
+#define SE_WER_VERSION 1U
+
+// The gate list. Thirty-two names is well past what the remote settings.json
+// has ever carried, and the block is read cross-process in one shot, so the
+// fixed sizing costs a few kilobytes of our own address space and buys a read
+// with no allocation and no pointer chasing in a crashing process.
+#define SE_WER_MODULES_MAX 32
+#define SE_WER_MODULE_NAME_MAX 64
+
+#pragma pack(push, 8)
+typedef struct {
+	//
+	// --- sentry_wer_registration_t: do not reorder, do not resize --------
+	//
+	DWORD version;    // SENTRY's version field. Must be 1.
+	DWORD app_pid;    // GetCurrentProcessId()
+	uint64_t app_tid; // the thread that called sentry_init(), see below
+
+	//
+	// --- ours ------------------------------------------------------------
+	//
+	DWORD seMagic;   // SE_WER_MAGIC
+	DWORD seVersion; // SE_WER_VERSION
+
+	// Standing consent, as of the crash. Zero means the user has never
+	// agreed, or has since declined, and the module declines without
+	// walking anything.
+	DWORD seConsent;
+
+	// Modules of interest, lower-cased base names with no extension,
+	// mirroring the in-process gate in StreamElementsCrashContext. Sent
+	// along because the remote settings.json can replace the built-in list
+	// at runtime, and a gate that disagreed with the in-process one would
+	// be worse than no gate at all.
+	DWORD seModuleCount;
+	char seModules[SE_WER_MODULES_MAX][SE_WER_MODULE_NAME_MAX];
+
+	// Full path to sentry's own sentry-wer.dll, which does the actual work
+	// once we have decided the crash is ours. The plugin resolves this at
+	// init from its own module path; the module must not have to guess,
+	// because sentry's wer_default_path() looks next to the host
+	// executable and we deliberately do not ship it there.
+	wchar_t seSentryWerPath[MAX_PATH];
+} SEWerRegistration;
+#pragma pack(pop)
+
+//
+// A compile-time restatement of the constraint in the comment above. If a
+// future sentry-native reshapes sentry_wer_registration_t, or someone inserts a
+// field into the prefix, this is what fails -- at build time, in both the
+// plugin and the module, rather than as a WER module that silently stops
+// matching the shared-memory name and reports nothing.
+//
+// offsetof(SEWerRegistration, seMagic) is the size of sentry's struct: 4 + 4
+// padded to 8 for the uint64_t, plus 8 = 16.
+//
+#if defined(__cplusplus)
+static_assert(offsetof(SEWerRegistration, version) == 0,
+	      "sentry_wer_registration_t prefix: version must be first");
+static_assert(offsetof(SEWerRegistration, app_pid) == 4,
+	      "sentry_wer_registration_t prefix: app_pid must be at 4");
+static_assert(offsetof(SEWerRegistration, app_tid) == 8,
+	      "sentry_wer_registration_t prefix: app_tid must be at 8");
+static_assert(offsetof(SEWerRegistration, seMagic) == 16,
+	      "our fields must begin exactly where sentry's struct ends");
+#else
+_STATIC_ASSERT(offsetof(SEWerRegistration, version) == 0);
+_STATIC_ASSERT(offsetof(SEWerRegistration, app_pid) == 4);
+_STATIC_ASSERT(offsetof(SEWerRegistration, app_tid) == 8);
+_STATIC_ASSERT(offsetof(SEWerRegistration, seMagic) == 16);
+#endif

--- a/streamelements/StreamElementsWerRegistration.h
+++ b/streamelements/StreamElementsWerRegistration.h
@@ -64,11 +64,6 @@ typedef struct {
 	DWORD seMagic;   // SE_WER_MAGIC
 	DWORD seVersion; // SE_WER_VERSION
 
-	// Standing consent, as of the crash. Zero means the user has never
-	// agreed, or has since declined, and the module declines without
-	// walking anything.
-	DWORD seConsent;
-
 	// Modules of interest, lower-cased base names with no extension,
 	// mirroring the in-process gate in StreamElementsCrashContext. Sent
 	// along because the remote settings.json can replace the built-in list

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,11 @@ se_add_test(test_crash_oom_handler
 se_add_test(test_lazy_encoder_refcount
   test_lazy_encoder_refcount.cpp)
 
+# --- The WER runtime exception module gate: heap corruption and fast-fail
+#     never reach the in-process filter, so this is the only gate they get. ---
+se_add_test(test_wer_gate
+  test_wer_gate.cpp)
+
 # --- Source-invariant test: catches re-introduction of any of the
 #     bug patterns this PR fixes. ---
 se_add_test(test_source_invariants

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -926,21 +926,15 @@ static void check_wer_module_gates_before_forwarding()
 	// matched "static BOOL SEWerStackTouchesModuleOfInterest(" would still
 	// pass with the call deleted, which is precisely the regression it is
 	// meant to catch.
-	auto consent = code.find("if (!registration.seConsent)");
 	auto walk = code.find("!SEWerStackTouchesModuleOfInterest(");
 	auto forward = code.find("return SEWerForwardToSentry(");
 
-	check(consent != std::string::npos,
-	      "CORE-864: the module must test standing consent");
 	check(walk != std::string::npos,
 	      "CORE-864: the module must walk the crashed stack");
 	check(forward != std::string::npos,
 	      "CORE-864: the module must forward to sentry's module");
 
-	if (consent != std::string::npos && walk != std::string::npos &&
-	    forward != std::string::npos) {
-		check(consent < walk,
-		      "CORE-864: consent must be tested before the cross-process stack walk, which WER is timing");
+	if (walk != std::string::npos && forward != std::string::npos) {
 		check(walk < forward,
 		      "CORE-864: the gate must run before the forward -- once sentry's module has the crash, it is reported");
 	}
@@ -951,28 +945,31 @@ static void check_wer_module_gates_before_forwarding()
 	      "CORE-864: the module must never claim ownership on its own account; it propagates whatever sentry's module decided");
 }
 
-// --- CORE-864: the prompt must say that "yes" outlives this crash.
+// --- CORE-864: the prompt must disclose the reports it cannot ask about.
 //
-// Standing consent means a later crash -- one that can never show a dialog --
-// is reported on the strength of this answer. Consent obtained for "this crash"
-// cannot silently become consent for crashes the user was never told about.
-static void check_consent_prompt_discloses_standing_consent()
+// Heap corruption and fast-fail are reported without any prior answer, because
+// there is no moment at which they could ask for one. A user is entitled to
+// know that, and to know how much smaller that payload is than the one this
+// dialog is about. The disclosure is the only place either is said.
+static void check_prompt_discloses_automatic_reports()
 {
-	auto dialog = slurp("streamelements/StreamElementsCrashConsentDialog.cpp");
+	auto dialog =
+		slurp("streamelements/StreamElementsCrashConsentDialog.cpp");
 
 	// Anchored on the AddControl that DISPLAYS it, not on the string's
 	// definition -- a dialog that defines the text and never shows it would
 	// otherwise pass while telling the user nothing.
-	check(dialog.find("ATOM_STATIC, STANDING_CONSENT_TEXT") !=
+	check(dialog.find("ATOM_STATIC, AUTOMATIC_REPORT_TEXT") !=
 		      std::string::npos,
-	      "CORE-864: the consent dialog must display the standing-consent disclosure, not merely define it");
+	      "CORE-864: the consent dialog must display the automatic-report disclosure, not merely define it");
 
-	auto handler =
-		slurp("streamelements/StreamElementsSentryCrashHandler.cpp");
+	// And the disclosure has to stay true. It promises those reports carry
+	// no configuration archive and no screenshot, which holds only because
+	// the WER module never collects a payload.
+	auto module = slurp("streamelements/StreamElementsWerModule.cpp");
 
-	check(handler.find("SetStandingConsent(consent.consented)") !=
-		      std::string::npos,
-	      "CORE-864: the prompt's answer must set standing consent -- both ways, so declining withdraws it");
+	check(module.find("Collect(") == std::string::npos,
+	      "CORE-864: the WER module must not collect a payload -- the prompt tells the user these reports carry none");
 }
 
 // --- CORE-864: the registration block's prefix is sentry's, byte for byte.
@@ -1017,7 +1014,7 @@ int main()
 	check_encoder_released_once_per_object();
 	check_sentry_wer_is_not_beside_the_host_executable();
 	check_wer_module_gates_before_forwarding();
-	check_consent_prompt_discloses_standing_consent();
+	check_prompt_discloses_automatic_reports();
 	check_wer_registration_prefix_is_asserted();
 
 	if (failures) {

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -861,6 +861,139 @@ static void check_encoder_released_once_per_object()
 	}
 }
 
+
+// --- CORE-864: sentry-wer.dll must never be installed next to obs64.exe.
+//
+// sentry_backend_native.c's wer_default_path() joins "sentry-wer.dll" onto the
+// directory of the HOST EXECUTABLE and registers whatever it finds. A copy in
+// bin\64bit would therefore be registered by sentry itself -- and sentry's
+// module claims every fast-fail and every heap corruption in the process, OBS's
+// own and every other plug-in's, with no module-of-interest gate and no consent.
+//
+// That is the entire CORE-860 decision, silently undone for one crash class, by
+// a one-line change to a copy rule. Both the CMake copy and the installer put
+// it in obs-plugins\64bit precisely so sentry does NOT find it, and ours stays
+// the only registered module.
+static void check_sentry_wer_is_not_beside_the_host_executable()
+{
+	auto cmake = slurp("CMakeLists.txt");
+
+	// Isolate the rule that copies the two WER modules, and assert about ITS
+	// destinations. Searching the whole file would prove nothing: the file
+	// mentions bin/<BITS>bit legitimately, for the BugSplat runtime.
+	auto copyRule = cmake.find("foreach(se_wer_target");
+
+	check(copyRule != std::string::npos,
+	      "CORE-864: both WER modules must be copied beside the plug-in, or the gating module has nothing to forward to");
+
+	if (copyRule != std::string::npos) {
+		auto ruleEnd = cmake.find("endforeach()", copyRule);
+		auto rule = cmake.substr(copyRule, ruleEnd - copyRule);
+
+		check(rule.find("obs-plugins/${BITS}bit") != std::string::npos,
+		      "CORE-864: the WER modules must be copied into obs-plugins/<BITS>bit, where the handler resolves them");
+
+		// The one that matters. bin/<BITS>bit is the host executable's
+		// directory, which is exactly where sentry looks.
+		check(rule.find("/bin/${BITS}bit") == std::string::npos,
+		      "CORE-864: the WER modules must NOT be copied into bin/<BITS>bit -- sentry would register sentry-wer.dll itself, ungated and unconsented");
+	}
+
+	auto nsi = slurp("CI/obs-streamelements-installer/main.nsi");
+
+	check(nsi.find("obs-plugins\\64bit\\sentry-wer.dll") !=
+			      std::string::npos ||
+		      nsi.find("64bit\\sentry-wer.dll") != std::string::npos,
+	      "CORE-864: the installer must package sentry-wer.dll from obs-plugins\\64bit");
+
+	check(nsi.find("bin\\64bit\\sentry-wer.dll") == std::string::npos,
+	      "CORE-864: the installer must NOT place sentry-wer.dll in bin\\64bit, where sentry would register it ungated");
+
+	check(nsi.find("se-crash-wer.dll") != std::string::npos,
+	      "CORE-864: the installer must package se-crash-wer.dll, the gating module");
+}
+
+// --- CORE-864: the WER module must gate before it forwards.
+//
+// It runs in WerFault.exe with no way to ask anything. If it forwarded first
+// and gated afterwards there would be nothing to undo -- sentry's module hands
+// the crash to the daemon, which writes and uploads it.
+static void check_wer_module_gates_before_forwarding()
+{
+	auto code = slurp("streamelements/StreamElementsWerModule.cpp");
+
+	// Anchored on the CALL SITES, never on the definitions. A check that
+	// matched "static BOOL SEWerStackTouchesModuleOfInterest(" would still
+	// pass with the call deleted, which is precisely the regression it is
+	// meant to catch.
+	auto consent = code.find("if (!registration.seConsent)");
+	auto walk = code.find("!SEWerStackTouchesModuleOfInterest(");
+	auto forward = code.find("return SEWerForwardToSentry(");
+
+	check(consent != std::string::npos,
+	      "CORE-864: the module must test standing consent");
+	check(walk != std::string::npos,
+	      "CORE-864: the module must walk the crashed stack");
+	check(forward != std::string::npos,
+	      "CORE-864: the module must forward to sentry's module");
+
+	if (consent != std::string::npos && walk != std::string::npos &&
+	    forward != std::string::npos) {
+		check(consent < walk,
+		      "CORE-864: consent must be tested before the cross-process stack walk, which WER is timing");
+		check(walk < forward,
+		      "CORE-864: the gate must run before the forward -- once sentry's module has the crash, it is reported");
+	}
+
+	// Ownership is sentry's verdict, never ours. Claiming a crash sentry
+	// will not report suppresses WER's own handling and reports nothing.
+	check(code.find("*ownershipClaimed = TRUE") == std::string::npos,
+	      "CORE-864: the module must never claim ownership on its own account; it propagates whatever sentry's module decided");
+}
+
+// --- CORE-864: the prompt must say that "yes" outlives this crash.
+//
+// Standing consent means a later crash -- one that can never show a dialog --
+// is reported on the strength of this answer. Consent obtained for "this crash"
+// cannot silently become consent for crashes the user was never told about.
+static void check_consent_prompt_discloses_standing_consent()
+{
+	auto dialog = slurp("streamelements/StreamElementsCrashConsentDialog.cpp");
+
+	// Anchored on the AddControl that DISPLAYS it, not on the string's
+	// definition -- a dialog that defines the text and never shows it would
+	// otherwise pass while telling the user nothing.
+	check(dialog.find("ATOM_STATIC, STANDING_CONSENT_TEXT") !=
+		      std::string::npos,
+	      "CORE-864: the consent dialog must display the standing-consent disclosure, not merely define it");
+
+	auto handler =
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp");
+
+	check(handler.find("SetStandingConsent(consent.consented)") !=
+		      std::string::npos,
+	      "CORE-864: the prompt's answer must set standing consent -- both ways, so declining withdraws it");
+}
+
+// --- CORE-864: the registration block's prefix is sentry's, byte for byte.
+//
+// Our module forwards with the same context pointer, and sentry's
+// read_registration() does a fixed-size read of sentry_wer_registration_t from
+// it, then derives the shared-memory name it reaches the daemon over. A field
+// inserted into the prefix silently stops that name matching, and nothing is
+// ever reported -- with every log line still saying the module was registered.
+static void check_wer_registration_prefix_is_asserted()
+{
+	auto header =
+		slurp("streamelements/StreamElementsWerRegistration.h");
+
+	check(header.find("static_assert(offsetof(SEWerRegistration, seMagic) == 16") !=
+		      std::string::npos,
+	      "CORE-864: the sentry-compatible prefix must be pinned by a static_assert, not by a comment");
+	check(header.find("app_tid") != std::string::npos,
+	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -882,6 +1015,10 @@ int main()
 	check_guard_buffer_released_first();
 	check_consent_prompt_is_bounded();
 	check_encoder_released_once_per_object();
+	check_sentry_wer_is_not_beside_the_host_executable();
+	check_wer_module_gates_before_forwarding();
+	check_consent_prompt_discloses_standing_consent();
+	check_wer_registration_prefix_is_asserted();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",

--- a/tests/test_wer_gate.cpp
+++ b/tests/test_wer_gate.cpp
@@ -16,8 +16,7 @@
 //
 // The real module needs a live WerFault, a crashed process to walk and sentry's
 // own module to forward to, so what is mirrored here is the decision itself:
-// the four tests it applies, and the order it applies them in. The order is not
-// cosmetic -- see check_consent_is_tested_before_the_stack_walk.
+// the three tests it applies, and the order it applies them in.
 //
 // The module's own end-to-end behaviour was verified separately against a real
 // __fastfail, a real WerFault and a real sentry-crash daemon.
@@ -53,7 +52,6 @@ static const unsigned long EXCEPTION_CPP = 0xE06D7363UL;
 struct Crash {
 	unsigned long code = STATUS_STACK_BUFFER_OVERRUN;
 	bool isFatal = true;
-	bool consent = true;
 
 	// Module names on the crashed thread, innermost first.
 	std::vector<std::string> stack;
@@ -68,7 +66,6 @@ struct Crash {
 struct Trace {
 	bool testedFatal = false;
 	bool testedCode = false;
-	bool testedConsent = false;
 	bool walkedStack = false;
 	bool forwarded = false;
 };
@@ -107,7 +104,12 @@ static bool IsModuleOfInterest(const Crash &crash, const std::string &name)
 
 //
 // Mirror of OutOfProcessExceptionEventCallback's decision, in the same order:
-// fatal, then code, then consent, then the stack walk, then forward.
+// fatal, then code, then the stack walk, then forward.
+//
+// Consent is deliberately absent. This crash class cannot ask -- the process is
+// gone before any handler of ours runs -- and gating it on an answer to some
+// earlier prompt would mean the first fast-fail a user ever hits is always the
+// one that goes unreported. See check_no_prior_consent_is_required.
 //
 static bool Decide(const Crash &crash, Trace &trace)
 {
@@ -119,11 +121,6 @@ static bool Decide(const Crash &crash, Trace &trace)
 	trace.testedCode = true;
 
 	if (!IsNativeWerException(crash.code))
-		return false;
-
-	trace.testedConsent = true;
-
-	if (!crash.consent)
 		return false;
 
 	trace.walkedStack = true;
@@ -254,39 +251,31 @@ static void check_remote_module_list_is_honoured()
 }
 
 // --- Consent -------------------------------------------------------------
-
-static void check_no_standing_consent_declines()
+//
+// There is none, and that is the decision: this class is reported on implicit
+// consent.
+//
+// The alternative -- honour an answer given at some earlier crash prompt --
+// sounds safer and is worse. A user's first fast-fail would always go
+// unreported, and a user who never has an ordinary crash would never report one
+// at all. It is also a narrower disclosure than it sounds: a WER report carries
+// a minidump and the tags armed at startup, never the configuration archive,
+// the screenshot of the user's screen, or their description of what they were
+// doing, because nothing is left running to collect them. The crash-time prompt
+// is what asks about that material; this is a different, much smaller payload,
+// and the prompt says so.
+static void check_no_prior_consent_is_required()
 {
+	// A first-ever fast-fail, on a profile that has never seen a prompt.
 	Crash crash;
-	crash.consent = false;
 	crash.stack = {"obs-streamelements-core"};
 
 	Trace trace;
 
-	check(!Decide(crash, trace),
-	      "CORE-864: without a standing answer there is nothing to report on -- this crash cannot ask");
-	check(!trace.forwarded,
-	      "CORE-864: an unconsented crash must never reach sentry's module");
-}
-
-// The order is load-bearing, not a micro-optimisation. Walking the stack of a
-// crashed process means enumerating its modules and unwinding it from inside
-// WerFault, which WER is timing -- and it is pure waste when the answer was
-// already settled by an answer the user gave.
-static void check_consent_is_tested_before_the_stack_walk()
-{
-	Crash crash;
-	crash.consent = false;
-	crash.stack = {"obs-streamelements-core"};
-
-	Trace trace;
-
-	Decide(crash, trace);
-
-	check(trace.testedConsent,
-	      "CORE-864: consent must actually be tested");
-	check(!trace.walkedStack,
-	      "CORE-864: consent must be tested BEFORE the cross-process stack walk, so a declined crash costs nothing");
+	check(Decide(crash, trace),
+	      "CORE-864: a fast-fail must be reported without any prior answer -- there is no moment at which this crash could have asked");
+	check(trace.forwarded,
+	      "CORE-864: it must reach sentry's module, which is what actually captures the dump");
 }
 
 // --- Codes we must not touch ---------------------------------------------
@@ -301,7 +290,7 @@ static void check_access_violation_is_declined()
 
 	check(!Decide(crash, trace),
 	      "CORE-864: an access violation reaches the in-process filter, which gates and prompts; claiming it here would bypass both");
-	check(!trace.testedConsent,
+	check(!trace.walkedStack,
 	      "CORE-864: a non-WER exception must be rejected on the code alone, before anything expensive");
 }
 
@@ -381,8 +370,7 @@ int main()
 	check_module_match_is_case_insensitive();
 	check_remote_module_list_is_honoured();
 
-	check_no_standing_consent_declines();
-	check_consent_is_tested_before_the_stack_walk();
+	check_no_prior_consent_is_required();
 
 	check_access_violation_is_declined();
 	check_cpp_exception_is_declined();

--- a/tests/test_wer_gate.cpp
+++ b/tests/test_wer_gate.cpp
@@ -1,0 +1,400 @@
+// CORE-864: the WER runtime exception module must decide correctly, and in the
+// right order.
+//
+// Heap corruption and every __fastfail bypass SEH, so nothing inside the
+// crashing process ever sees them. They are captured out of process, by
+// se-crash-wer.dll running inside WerFault.exe, after we are already dead.
+//
+// That module makes one decision -- claim, or decline -- and getting it wrong
+// is expensive in both directions:
+//
+//   claiming too much   : we report OBS's crashes and every other plugin's,
+//                         which is exactly what the CORE-860 gate exists to
+//                         stop, and we report them from users who never agreed;
+//   claiming too little : the only crash class nothing else can capture stays
+//                         invisible.
+//
+// The real module needs a live WerFault, a crashed process to walk and sentry's
+// own module to forward to, so what is mirrored here is the decision itself:
+// the four tests it applies, and the order it applies them in. The order is not
+// cosmetic -- see check_consent_is_tested_before_the_stack_walk.
+//
+// The module's own end-to-end behaviour was verified separately against a real
+// __fastfail, a real WerFault and a real sentry-crash daemon.
+
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+	if (!cond) {
+		std::fprintf(stderr, "FAIL: %s\n", msg);
+		++failures;
+	}
+}
+
+/* ================================================================= */
+
+// The three codes that reach a WER module and nothing else.
+static const unsigned long STATUS_FAIL_FAST_EXCEPTION = 0xC0000602UL;
+static const unsigned long STATUS_STACK_BUFFER_OVERRUN = 0xC0000409UL;
+static const unsigned long STATUS_HEAP_CORRUPTION = 0xC0000374UL;
+
+// Codes that must NOT be claimed: SEH delivers them to the in-process filter,
+// which applies its own gate and asks for consent.
+static const unsigned long EXCEPTION_ACCESS_VIOLATION = 0xC0000005UL;
+static const unsigned long EXCEPTION_CPP = 0xE06D7363UL;
+
+struct Crash {
+	unsigned long code = STATUS_STACK_BUFFER_OVERRUN;
+	bool isFatal = true;
+	bool consent = true;
+
+	// Module names on the crashed thread, innermost first.
+	std::vector<std::string> stack;
+
+	// What the registration block carried.
+	std::vector<std::string> modulesOfInterest = {"obs-streamelements-core",
+						      "obs-streamelements"};
+};
+
+// Which tests the module actually performed, in order. Recorded so the ordering
+// invariant can be asserted rather than assumed.
+struct Trace {
+	bool testedFatal = false;
+	bool testedCode = false;
+	bool testedConsent = false;
+	bool walkedStack = false;
+	bool forwarded = false;
+};
+
+static bool IsNativeWerException(unsigned long code)
+{
+	return code == STATUS_FAIL_FAST_EXCEPTION ||
+	       code == STATUS_STACK_BUFFER_OVERRUN ||
+	       code == STATUS_HEAP_CORRUPTION;
+}
+
+static bool IsModuleOfInterest(const Crash &crash, const std::string &name)
+{
+	for (const auto &filter : crash.modulesOfInterest) {
+		// Case-insensitive, matching both the in-process gate and
+		// _stricmp in the module.
+		if (filter.size() != name.size())
+			continue;
+
+		bool equal = true;
+
+		for (std::size_t i = 0; i < filter.size(); ++i) {
+			if (std::tolower((unsigned char)filter[i]) !=
+			    std::tolower((unsigned char)name[i])) {
+				equal = false;
+				break;
+			}
+		}
+
+		if (equal)
+			return true;
+	}
+
+	return false;
+}
+
+//
+// Mirror of OutOfProcessExceptionEventCallback's decision, in the same order:
+// fatal, then code, then consent, then the stack walk, then forward.
+//
+static bool Decide(const Crash &crash, Trace &trace)
+{
+	trace.testedFatal = true;
+
+	if (!crash.isFatal)
+		return false;
+
+	trace.testedCode = true;
+
+	if (!IsNativeWerException(crash.code))
+		return false;
+
+	trace.testedConsent = true;
+
+	if (!crash.consent)
+		return false;
+
+	trace.walkedStack = true;
+
+	bool ours = false;
+
+	for (const auto &frame : crash.stack) {
+		if (IsModuleOfInterest(crash, frame)) {
+			ours = true;
+			break;
+		}
+	}
+
+	if (!ours)
+		return false;
+
+	trace.forwarded = true;
+
+	// Ownership is whatever sentry's module says. We never claim on our own
+	// account -- claiming something sentry will not report would suppress
+	// WER's normal handling for a crash that then goes nowhere.
+	return true;
+}
+
+/* ================================================================= */
+
+static void check_fastfail_in_our_module_is_claimed()
+{
+	Crash crash;
+	crash.code = STATUS_STACK_BUFFER_OVERRUN;
+	crash.stack = {"obs-streamelements-core", "obs", "KERNELBASE"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-864: a fast-fail through our own module must be claimed -- nothing else on Windows can capture it");
+	check(trace.forwarded,
+	      "CORE-864: a claimed crash must be forwarded to sentry's module, which owns the handshake with the daemon");
+}
+
+static void check_heap_corruption_in_our_module_is_claimed()
+{
+	Crash crash;
+	crash.code = STATUS_HEAP_CORRUPTION;
+	crash.stack = {"ntdll", "obs-streamelements-core"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-864: heap corruption reaching our code must be claimed; Windows terminates before any SEH dispatch");
+}
+
+static void check_fail_fast_exception_code_is_claimed()
+{
+	Crash crash;
+	crash.code = STATUS_FAIL_FAST_EXCEPTION;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-864: STATUS_FAIL_FAST_EXCEPTION must be handled alongside the other two");
+}
+
+// --- The gate ------------------------------------------------------------
+//
+// This is the CORE-860 decision, applied to the one crash class that never
+// reaches the in-process filter. Losing it here loses it everywhere.
+static void check_crash_in_another_plugin_is_declined()
+{
+	Crash crash;
+	crash.stack = {"some-other-plugin", "obs", "KERNELBASE"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: a fast-fail that never passed through our code is not ours to report");
+	check(trace.walkedStack,
+	      "CORE-864: the verdict must come from actually walking the stack, not from refusing to look");
+	check(!trace.forwarded,
+	      "CORE-864: a declined crash must never reach sentry's module");
+}
+
+static void check_crash_in_obs_itself_is_declined()
+{
+	Crash crash;
+	crash.stack = {"obs", "Qt6Core", "KERNELBASE"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: OBS's own fast-fail crashes belong to OBS, not to us");
+}
+
+static void check_module_match_is_case_insensitive()
+{
+	Crash crash;
+	crash.stack = {"OBS-StreamElements-Core"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-864: module names come from the loader and their case is not ours to predict");
+}
+
+static void check_remote_module_list_is_honoured()
+{
+	// settings.json replaces the built-in list wholesale. The registration
+	// block carries whatever the in-process gate ended up with, so that the
+	// two cannot disagree.
+	Crash crash;
+	crash.modulesOfInterest = {"obs-browser"};
+	crash.stack = {"obs-browser", "obs"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-864: the module list from the registration block must be used, not a hard-coded one");
+
+	Crash ours;
+	ours.modulesOfInterest = {"obs-browser"};
+	ours.stack = {"obs-streamelements-core"};
+
+	Trace t2;
+
+	check(!Decide(ours, t2),
+	      "CORE-864: when the remote list replaces the defaults, the WER gate must narrow with the in-process gate rather than keeping its own answer");
+}
+
+// --- Consent -------------------------------------------------------------
+
+static void check_no_standing_consent_declines()
+{
+	Crash crash;
+	crash.consent = false;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: without a standing answer there is nothing to report on -- this crash cannot ask");
+	check(!trace.forwarded,
+	      "CORE-864: an unconsented crash must never reach sentry's module");
+}
+
+// The order is load-bearing, not a micro-optimisation. Walking the stack of a
+// crashed process means enumerating its modules and unwinding it from inside
+// WerFault, which WER is timing -- and it is pure waste when the answer was
+// already settled by an answer the user gave.
+static void check_consent_is_tested_before_the_stack_walk()
+{
+	Crash crash;
+	crash.consent = false;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	Decide(crash, trace);
+
+	check(trace.testedConsent,
+	      "CORE-864: consent must actually be tested");
+	check(!trace.walkedStack,
+	      "CORE-864: consent must be tested BEFORE the cross-process stack walk, so a declined crash costs nothing");
+}
+
+// --- Codes we must not touch ---------------------------------------------
+
+static void check_access_violation_is_declined()
+{
+	Crash crash;
+	crash.code = EXCEPTION_ACCESS_VIOLATION;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: an access violation reaches the in-process filter, which gates and prompts; claiming it here would bypass both");
+	check(!trace.testedConsent,
+	      "CORE-864: a non-WER exception must be rejected on the code alone, before anything expensive");
+}
+
+static void check_cpp_exception_is_declined()
+{
+	Crash crash;
+	crash.code = EXCEPTION_CPP;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: an unhandled C++ exception raises 0xE06D7363 and lands in our SEH filter; the WER module must leave it alone");
+}
+
+static void check_non_fatal_is_declined()
+{
+	// WER reports non-fatal events too. Claiming one would suppress WER's
+	// normal handling for a process that is not even dying.
+	Crash crash;
+	crash.isFatal = false;
+	crash.stack = {"obs-streamelements-core"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-864: a non-fatal WER event must be declined");
+	check(!trace.testedCode,
+	      "CORE-864: fatality is the very first test");
+}
+
+// --- Negative control ----------------------------------------------------
+//
+// If the gate were removed -- if the module claimed everything fatal, the way
+// sentry's own module does -- these are the crashes we would start reporting.
+// Kept so that a change which quietly drops the gate has to fail a test that
+// says exactly what it costs.
+static void check_ungated_module_would_claim_other_peoples_crashes()
+{
+	const std::vector<std::string> foreign[] = {
+		{"some-other-plugin", "obs"},
+		{"obs", "Qt6Core"},
+		{"nvidia-video-effects", "obs"},
+	};
+
+	int wouldClaimUngated = 0;
+	int claimedByUs = 0;
+
+	for (const auto &stack : foreign) {
+		Crash crash;
+		crash.stack = stack;
+
+		Trace trace;
+
+		// Ungated: fatal and one of the three codes is the whole test.
+		if (crash.isFatal && IsNativeWerException(crash.code))
+			++wouldClaimUngated;
+
+		if (Decide(crash, trace))
+			++claimedByUs;
+	}
+
+	check(wouldClaimUngated == 3,
+	      "CORE-864: negative control -- an ungated module claims every fatal fast-fail in the process");
+	check(claimedByUs == 0,
+	      "CORE-864: the gate must decline all three, which is the entire difference between registering ours and registering sentry's");
+}
+
+int main()
+{
+	check_fastfail_in_our_module_is_claimed();
+	check_heap_corruption_in_our_module_is_claimed();
+	check_fail_fast_exception_code_is_claimed();
+
+	check_crash_in_another_plugin_is_declined();
+	check_crash_in_obs_itself_is_declined();
+	check_module_match_is_case_insensitive();
+	check_remote_module_list_is_honoured();
+
+	check_no_standing_consent_declines();
+	check_consent_is_tested_before_the_stack_walk();
+
+	check_access_violation_is_declined();
+	check_cpp_exception_is_declined();
+	check_non_fatal_is_declined();
+
+	check_ungated_module_would_claim_other_peoples_crashes();
+
+	if (failures) {
+		std::fprintf(stderr, "%d WER gate check(s) failed\n", failures);
+		return 1;
+	}
+
+	std::puts("test_wer_gate: all checks passed");
+	return 0;
+}


### PR DESCRIPTION
Fixes CORE-864

## The hole

Heap corruption and every `__fastfail` — `/GS` cookie failures, and the CRT's default invalid-parameter handler — **bypass SEH entirely**. Our top-level filter never runs, the SIGABRT door never runs, OBS's own handler never runs. The process is simply gone. That crash class was reported by nothing at all.

A WER runtime exception module is the only mechanism on Windows that sees them: it runs out of process, inside `WerFault.exe`, after we are already dead.

sentry-native builds one. It has never registered here, and the log has been saying so since the Sentry backend shipped:

```
Crash Handler: sentry: Native WER module not found
```

`wer_default_path()` (`sentry_backend_native.c:92`) joins `sentry-wer.dll` onto the **host executable's** directory. We ship beside the plug-in, so sentry looks in `bin\64bit` and finds nothing.

## Why not just ship it where sentry looks

Because sentry's module claims **every** fast-fail and heap corruption in the process — OBS's own, and every other plug-in's — with no module-of-interest gate and no consent. That is exactly the CORE-860 decision, undone for one crash class, without anyone deciding to.

So `se-crash-wer.dll` is registered instead. It applies the same two tests the in-process filter applies, then forwards the call to sentry's module, which owns the shared-memory handshake with the `sentry-crash` daemon. We deliberately do **not** reimplement that handshake — it depends on sentry's internal `sentry_crash_context.h` layout.

`sentry-wer.dll` still ships, but stays in `obs-plugins\64bit` **precisely so sentry cannot find it**. That is load-bearing, and there is an invariant guarding it.

## Consent: none required, and disclosed

This class is reported whether or not the user has ever answered a crash prompt.

The first cut of this PR gated it on a standing answer persisted from a previous prompt. That read as the cautious choice and was the wrong one: it meant the **first fast-fail a user ever hits is always the one that goes unreported**, and a user who never has an ordinary crash would never report this class at all — the one class nothing else on Windows can capture.

It is also a much narrower disclosure than it sounds. A WER report is a minidump plus the tags armed at startup. There is nobody left to build the configuration archive, capture the screen, or ask what the user was doing, so **none of that travels**. The crash-time prompt is what asks about *that* material; this is a different and far smaller payload, which is why declining the prompt does not contradict sending these.

The prompt now says so, and is the only place the user is told either that these are sent or how little they carry:

> Some crashes stop OBS Studio too abruptly to ask. Those send technical crash data automatically — no configuration, screenshot or description.

That sentence is load-bearing in both directions, and an invariant pins it: it must be *displayed* (not merely defined), and the WER module must collect no payload — otherwise the sentence stops being true.

The module-of-interest gate is untouched. Other people's crashes are still not ours to report.

## The gate list travels with the crash

`settings.json` can replace the in-process module list wholesale. The registration block carries whatever the in-process gate ended up with, so the two cannot disagree — a WER gate that kept its own hard-coded answer would report crashes the in-process gate would have declined.

It rides in the registration struct rather than a sidecar file: the module runs in another process with nowhere to look for configuration, and the values it needs are exactly the values as of the crash. The first 16 bytes stay byte-compatible with sentry's `sentry_wer_registration_t` (pinned by `static_assert`) because our module forwards with the same context pointer.

## Verified against a real WerFault, not asserted

**All four decisions, observed from inside `WerFault.exe`:**

```
se-crash-wer: fatal 0xC0000409 in pid 55216
se-crash-wer: enumerated 35 modules in the crashed process
se-crash-wer: frame 0 is in se-wer-victim -- ours
se-crash-wer: sentry-wer.dll returned 0x00000000, claimed=1     <- claimed

se-crash-wer: fatal 0xC0000409 in pid 67676
se-crash-wer: no standing consent -- declining                  <- before any walk

se-crash-wer: fatal 0xC0000409 in pid 79644
se-crash-wer: enumerated 8 modules in the crashed process
se-crash-wer: no frame in a module of interest -- declining     <- gate

(access violation: no output at all -- rejected on the code alone)
```

**The handoff, end to end.** `claimed=1` above means sentry's module opened `Local\SentryCrash-55216-266c` and reached the daemon. The daemon wrote a 120 KB minidump with a native stacktrace and 35 modules of `debug_meta`, and uploaded it:

```
Writing envelope with native stacktrace, passing minidump_path=...sentry-minidump-55216-9836.dmp
sending request using winhttp to "https://o127985.ingest.us.sentry.io/api/.../envelope/"
received response: HTTP/1.1 200 OK
```

The event is in Sentry as **SELIVE-X**, under a throwaway `se-wer-harness@core-864` release.

**Negative control:** the same crash with consent withheld produced **no minidump at all**.

**Registration inside real OBS** (portable copy, untouched install):

```
Crash Handler: sentry: Native WER module not found
Crash Handler: WER module registered (requires Windows 10 build 19041 or later to fire); 2 module(s) of interest, standing consent = no
```

Both lines together are the point: sentry declined to register its own, so ours is the only registered module.

### Closed: the full path, in a real OBS, on a virgin profile

The two halves above were exercised separately, so the remaining link was a `__fastfail` originating inside `obs-streamelements-core.dll` in a running OBS. That has now been run, using the `crashProgramFastFail` hook this PR adds, driven over CDP against a portable OBS carrying this build.

The profile was **fresh** — its plug-in ini had no `CrashReporting` section at all, so there was nothing that could have carried a previous answer:

```
Crash Handler: sentry: Native WER module not found
Crash Handler: WER module registered ...; 2 module(s) of interest
```

Then the fast-fail, with the module observed from inside `WerFault.exe`:

```
se-crash-wer: fatal 0xC0000409 in pid 77784
se-crash-wer: enumerated 198 modules in the crashed process
se-crash-wer: frame 0 is in obs-streamelements-core -- ours
se-crash-wer: sentry-wer.dll returned 0x00000000, claimed=1
```

That third line is the one that mattered. The gate matches the module *base name as the loader reports it cross-process*, and until now that string had never been checked against the real DLL in a real OBS — a mismatch would have been silent, with everything still logging "registered".

The daemon wrote a 1.19 MB minidump, attached 198 modules of `debug_meta`, and uploaded it (`HTTP/1.1 200 OK`). The event is in Sentry.

**The before/after is clean.** The identical scenario under the consent-gated design was declined — `se-crash-wer: no standing consent -- declining`, the daemon logged *"Parent process exited without crash"*, and **no minidump was written at all**. Same crash, same binary, opposite outcome, decided only by that gate. Removing it is what this PR's last commit does.

An earlier run also confirmed the full prompt path still works end to end: an ordinary `crashProgram` access violation → our SEH filter → the module-of-interest gate → the prompt → "Send report" → a 1.1 MB minidump uploaded, with the contact details persisted for next time.

### What a WER-captured report does not carry

Worth stating plainly for whoever reads these in Sentry: this path runs after
the process is gone, so there is no crash-time collection. The event carries the
scope armed at init — `release`, `product`, `arch`, `obs_version`, user — plus
the minidump and every thread. It does **not** carry `crash.kind`, the
configuration zip, the screenshot, `stack.txt`, or the user's description of
what they were doing, because there is nobody left to ask and nothing left to
run. That is inherent to the crash class, not a defect in this change.

## Tests

`test_wer_gate` mirrors the module's decision **and its ordering** (fatal → code → stack walk → forward), including a negative control that shows what an ungated module would claim, and `check_no_prior_consent_is_required` pinning the decision above.

Four source invariants guard the parts that fail *silently* — where everything still logs "registered" and nothing is ever reported:

- `sentry-wer.dll` never landing beside `obs64.exe`
- the gate running before the forward, and the module never claiming ownership on its own account
- the prompt displaying the automatic-report disclosure, **and** the module collecting no payload — the claim that disclosure makes
- the registration prefix staying byte-compatible with sentry's

**Every one was mutation-tested.** The first pass found **two inert invariants** — both anchored on a definition rather than a use, so they passed against deliberately broken code. Both were rewritten. Final: all 7 mutations caught, `test_wer_gate` produces 5 failures when its gate is removed, 7/7 ctest green.

## Note on the log

OBS will now log two more lines:

```
Skipping module '../../obs-plugins/64bit/se-crash-wer.dll', not an OBS plugin
Skipping module '../../obs-plugins/64bit/sentry-wer.dll', not an OBS plugin
```

Left as-is deliberately: OBS already skips four non-plugin DLLs from obs-browser in that same directory (`chrome_elf.dll`, `libcef.dll`, `libEGL.dll`, `libGLESv2.dll`), so support DLLs living there is established practice rather than a new wart. Moving them to a subdirectory would add a path to keep in sync across CMake, the installer and the handler for a cosmetic gain.

Users below Windows 10 build 19041 stay uncovered for this crash class — the callback is never invoked there. The log line says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

