### PR TITLE
fix(release): carry the overtaken releases' issues into the full release (CORE-954)

### DIFF
--- a/.github/actions/se-release/action.yml
+++ b/.github/actions/se-release/action.yml
@@ -113,6 +113,20 @@ outputs:
       overwrote it. Used as the Linear commit-scan base on `qa -> beta`. Empty when that
       version is unknown, untagged, or not older than the one being promoted.
     value: ${{ steps.run.outputs.previous_channel_tag }}
+  linear_base_tag:
+    description: >-
+      Lower bound for the Linear commit scan: the previous full release, falling back to
+      previous_channel_tag, and empty when neither resolves.
+
+      Declared here because a composite action exposes only the outputs it names.
+      resolve.sh has emitted this since CORE-783, but without this block
+      `steps.<id>.outputs.linear_base_tag` evaluated to the empty string in the caller --
+      so `base_ref` was never actually passed, the CLI fell back to its own scan base,
+      and every Linear release held only the issues of its own build instead of
+      everything since the last full release. That is the bug CORE-783 set out to fix,
+      and it was silently still present until CORE-954. The workflow log was no help
+      either way: resolve.sh logs the range it computed, which was always correct.
+    value: ${{ steps.run.outputs.linear_base_tag }}
   is_prerelease:
     description: 'Whether the release for this tag is currently a prerelease.'
     value: ${{ steps.run.outputs.is_prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,63 @@ jobs:
           dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
           log_level: verbose
 
+      # Take over the issues held by the releases this one overtook, before they are
+      # cancelled below (CORE-954).
+      #
+      # A build reaches `latest` while older builds are still sitting on Alpha or Open
+      # Beta. Their work shipped -- they are ancestors of this tag -- but the cancel
+      # sweep at the end of this job retires them, and without this step their issues go
+      # quiet with them: the release that actually delivered the work does not list it,
+      # and the release that lists it is Canceled.
+      #
+      # This is a second `sync` on the release that is shipping, and the only thing that
+      # makes it different from the one at signed -> qa is the scan range: base_ref is
+      # the previous FULL release, so the range covers every overtaken build in between
+      # rather than just this build's own commits.
+      #
+      # Deriving the set from commits rather than reading it off the old releases is not
+      # a shortcut, it is the only option. LINEAR_ACCESS_KEY is pipeline-scoped, and the
+      # five operations it can perform (releaseSyncByAccessKey,
+      # releaseUpdateByPipelineByAccessKey, releaseCompleteByAccessKey,
+      # pipelineSettingsByAccessKey, recentReleasesByAccessKey) include no way to list a
+      # release's issues -- recentReleasesByAccessKey returns id, name, createdAt and
+      # commitSha and nothing else. A workspace-scoped key in Actions was rejected on
+      # security grounds, so reading them is not available here at any price.
+      #
+      # Adding is safe because an issue may belong to more than one release in a
+      # pipeline: verified against the live workspace by attaching a second release to an
+      # issue that already had one and reading it back on both, then reverting. So this
+      # cannot take an issue away from a release that is still open, and it cannot fail
+      # on an issue another release already holds.
+      #
+      # The flip side is that the cancelled releases keep listing their issues too --
+      # there is no detach operation on this key. The release that shipped the work gains
+      # it, which is the traceability that was missing; a true move needs the Linear MCP.
+      #
+      # Runs BEFORE `complete`, so the release is already holding everything when
+      # completion fires the pipeline's autoGenerateReleaseNotesOnCompletion and
+      # rolloverIssuesOnCompletion settings.
+      - name: Adopt the issues of the releases this one overtook
+        id: linear_adopt
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_PROMOTE == 'true' && steps.linear_checkout.outputs.ok == 'true' && steps.version.outputs.linear_base_tag != ''
+        continue-on-error: true
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          version: ${{ steps.version.outputs.version_string }}
+          name: ${{ steps.version.outputs.version_string }}
+          # The whole point of this step. Deliberately NOT the previous build: the range
+          # has to reach back past every release that was overtaken.
+          base_ref: ${{ steps.version.outputs.linear_base_tag }}
+          issue_pattern: ${{ vars.LINEAR_ISSUE_PATTERN || '\b(CORE-[0-9]+)\b' }}
+          # Release notes are deliberately not passed. They were written by the
+          # signed -> qa sync and again into the GitHub release body above; this step
+          # exists to add issues, and re-sending them here would be a second source of
+          # truth for the same text.
+          dry_run: ${{ env.SE_LINEAR_DRY_RUN }}
+          log_level: verbose
+
       # `complete` rather than `update --stage=Released`: for a scheduled pipeline that
       # is what moves a release into the completed stage, and it is the only path that
       # fires the pipeline's autoGenerateReleaseNotesOnCompletion and
@@ -552,7 +609,11 @@ jobs:
       # most tagged builds are never promoted. Those failures are expected and swallowed
       # per version; only the count is reported.
       - name: Cancel releases left open behind this one
-        if: env.SE_HAS_LINEAR == 'true' && env.SE_PROMOTE == 'true' && steps.linear_complete.outcome == 'success'
+        # Gated on the adoption above as well as on completion. Cancelling a release
+        # whose issues were not taken over is the exact failure this pair exists to
+        # prevent -- better to leave it open and visible than to retire it quietly with
+        # work still attached to nothing that shipped.
+        if: env.SE_HAS_LINEAR == 'true' && env.SE_PROMOTE == 'true' && steps.linear_complete.outcome == 'success' && steps.linear_adopt.outcome == 'success'
         continue-on-error: true
         env:
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -991,6 +991,154 @@ static void check_wer_registration_prefix_is_asserted()
 	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
 }
 
+
+// --- CORE-954: every value resolve.sh emits must be declared as an action output.
+//
+// A composite action exposes only the outputs it names. `emit foo` writes to
+// GITHUB_OUTPUT of the inner step, but if action.yml has no `foo:` block then
+// `steps.<id>.outputs.foo` evaluates to the empty string in the caller -- with
+// no warning, no error, and a workflow log that looks correct because
+// resolve.sh logs what it computed rather than what the caller received.
+//
+// That is not hypothetical. linear_base_tag was emitted from CORE-783 onward
+// and never declared, so `base_ref` was silently empty on every Linear sync for
+// months: the CLI fell back to its own scan base and each release held only its
+// own build's issues -- exactly the bug CORE-783 was filed to fix. It surfaced
+// only because a later step guarded on the output being non-empty and was
+// skipped.
+//
+// This is the general form of that gate rather than a check for one key: any
+// future `emit` that someone forgets to declare fails here instead.
+static void check_every_emitted_output_is_declared()
+{
+	auto action = slurp(".github/actions/se-release/action.yml");
+
+	// The declarations live under a top-level `outputs:` block; everything
+	// after it up to the next top-level key is what the action exposes.
+	auto outputs_at = action.find("\noutputs:");
+	check(outputs_at != std::string::npos,
+	      "CORE-954: se-release/action.yml must declare an outputs block");
+
+	if (outputs_at == std::string::npos)
+		return;
+
+	// The block ends at the next line that starts in column 0 and is not a
+	// comment -- `runs:` in practice.
+	std::string outputs = action.substr(outputs_at + 1);
+	std::regex next_top_level(R"(\n(?=[a-z][a-z-]*:))");
+	std::smatch m;
+
+	if (std::regex_search(outputs, m, next_top_level))
+		outputs = outputs.substr(0, m.position(0));
+
+	// Every `emit <key>` across the action's shell scripts.
+	static const char *const scripts[] = {
+		".github/actions/se-release/resolve.sh",
+		".github/actions/se-release/prevtag.sh",
+		".github/actions/se-release/publish.sh",
+		".github/actions/se-release/notes.sh",
+		".github/actions/se-release/changelog.sh",
+		".github/actions/se-release/attach-assets.sh",
+		".github/actions/se-release/dispatch.sh",
+	};
+
+	// Anchored on a line start without std::regex::multiline, which this
+	// MSVC does not provide. Group 2 is the key.
+	std::regex emit(R"((^|\n)[ \t]*emit[ \t]+([a-z_]+))");
+
+	std::size_t emitted = 0;
+
+	for (const char *script : scripts) {
+		std::string src;
+
+		try {
+			src = slurp(script);
+		} catch (...) {
+			continue; // a script may legitimately not exist
+		}
+
+		auto begin = std::sregex_iterator(src.begin(), src.end(), emit);
+		auto end = std::sregex_iterator();
+
+		for (auto it = begin; it != end; ++it) {
+			const std::string key = (*it)[2].str();
+
+			++emitted;
+
+			const bool declared =
+				outputs.find("\n  " + key + ":") !=
+				std::string::npos;
+
+			if (!declared) {
+				std::fprintf(stderr,
+					     "FAIL: CORE-954: '%s' is emitted by %s but not declared in se-release/action.yml, so the caller reads an empty string\n",
+					     key.c_str(), script);
+				++failures;
+			}
+		}
+	}
+
+	check(emitted > 0,
+	      "CORE-954: no emitted outputs were found at all -- the emit pattern or the script list has moved");
+}
+
+// --- CORE-954: the full release must adopt the issues of the releases it
+//     overtakes BEFORE any of them are cancelled.
+//
+// Cancelling a release whose issues were not taken over is the failure this
+// pair exists to prevent: the work shipped, but the release that delivered it
+// does not list it and the one that does is Canceled.
+static void check_full_release_adopts_before_cancelling()
+{
+	auto wf = slurp(".github/workflows/release.yml");
+
+	// The ids are matched with their trailing newline. Without it,
+	// find("id: linear_adopt") is satisfied by "id: linear_adopt_ANYTHING",
+	// so renaming the step away would leave this check passing.
+	auto adopt = wf.find("id: linear_adopt\n");
+	auto complete = wf.find("id: linear_complete\n");
+	auto cancel = wf.find("name: Cancel releases left open behind this one");
+
+	check(adopt != std::string::npos,
+	      "CORE-954: the full-release hop must adopt the overtaken releases' issues");
+	check(cancel != std::string::npos,
+	      "CORE-954: the cancel sweep must still exist");
+
+	if (adopt == std::string::npos || cancel == std::string::npos)
+		return;
+
+	check(adopt < cancel,
+	      "CORE-954: issues must be adopted BEFORE the releases holding them are cancelled");
+
+	if (complete != std::string::npos) {
+		// Completion fires the pipeline's rolloverIssuesOnCompletion
+		// and autoGenerateReleaseNotesOnCompletion, so the release has
+		// to be holding everything by then.
+		check(adopt < complete,
+		      "CORE-954: adoption must precede `complete`, which is what fires the pipeline's rollover and notes generation");
+	}
+
+	// The scan range is the whole point: the previous full release, not the
+	// previous build. A narrower base would cover none of the overtaken
+	// releases and the step would be decorative.
+	auto adopt_block = wf.substr(adopt, 1400);
+
+	// The whole `base_ref:` line, not just the output name: the step's own
+	// `if:` guard also mentions linear_base_tag, so a bare substring search
+	// stays true even when base_ref is repointed at a narrower tag.
+	check(adopt_block.find(
+		      "base_ref: ${{ steps.version.outputs.linear_base_tag }}") !=
+		      std::string::npos,
+	      "CORE-954: the adopt step must scan from linear_base_tag (the previous FULL release), or it covers none of the overtaken builds");
+
+	// And the sweep must not run if adoption did not.
+	auto cancel_block = wf.substr(cancel, 900);
+
+	check(cancel_block.find("steps.linear_adopt.outcome == 'success'") !=
+		      std::string::npos,
+	      "CORE-954: the cancel sweep must be gated on the adoption succeeding -- otherwise a failed adopt still retires the releases holding the issues");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -1016,6 +1164,8 @@ int main()
 	check_wer_module_gates_before_forwarding();
 	check_prompt_discloses_automatic_reports();
 	check_wer_registration_prefix_is_asserted();
+	check_every_emitted_output_is_declared();
+	check_full_release_adopts_before_cancelling();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Fixes CORE-954

## The gap

A build reaches `latest` while older builds are still sitting on Alpha or Open Beta. `release.yml` already cancels those — right, they will never ship on their own. What it did not do is take their **issues** with it. That work is in the build that shipped (those builds are ancestors of the tag), but the release that delivered it did not list it, and the release that did was Canceled.

Live when this was written:

| release | stage | issues |
|---|---|---|
| 26.8.27.949 | Open Beta | 8 |
| 26.8.24.924 | Open Beta | 3 |
| 26.8.21.917 | Alpha | 5 |
| 26.8.20.897 | Alpha | 16 |

Promoting 949 to `latest` would have cancelled the other three and taken **24 issues** quiet with them.

## A second bug found on the way, and it is the bigger one

The new step guards on `steps.version.outputs.linear_base_tag` being non-empty. In the first dry run it was **skipped** — because that output was always empty.

`resolve.sh` has emitted `linear_base_tag` since CORE-783, but `.github/actions/se-release/action.yml` never declared it, and **a composite action exposes only the outputs it names**. So `base_ref` was never actually passed to the Linear sync. The CLI fell back to its own scan base and every release held only its own build's issues instead of everything since the last full release — which is precisely what CORE-783 was filed to fix. It has been inert ever since.

Nothing surfaced it: no warning, no error, and the workflow log looked correct because `resolve.sh` logs the range it *computed* (`linear: issue scan range 26.2.5.549..26.8.27.949`), not what the caller received. It also explains the tidy 16/5/3/8 partition above, which I had wrongly read as Linear refusing to re-link.

## Why the set is derived from commits

Not a shortcut — the only option. `LINEAR_ACCESS_KEY` is pipeline-scoped. Extracted from the CLI binary, it speaks exactly five operations:

`releaseSyncByAccessKey`, `releaseUpdateByPipelineByAccessKey`, `releaseCompleteByAccessKey`, `pipelineSettingsByAccessKey`, `recentReleasesByAccessKey`

None of them lists a release's issues — `recentReleasesByAccessKey` returns `id, name, createdAt, commitSha` and nothing else. CLAUDE.md records that a workspace-scoped key in Actions was rejected on security grounds, so reading them is not available here at any price.

But the set does not need reading: it is every issue referenced between the previous full release and this tag, which is exactly what a `sync` with a wide `base_ref` derives. So this is a second sync on the release that is shipping, differing from the signed→qa one only in scan range.

## Why adding is safe

Verified against the live workspace rather than assumed: I attached a second release to an issue that already had one, read it back on **both**, and reverted immediately. An issue is not limited to one release per pipeline, and `addReleases` adds rather than moves. So this cannot take an issue from a release that is still open, and cannot fail on one another release holds.

**Stated limitation:** the cancelled releases keep listing their issues too, because this key has no detach operation. The release that shipped the work gains it, which is the traceability that was missing; a true move needs the Linear MCP.

## Ordering

Adopt → `complete` → cancel sweep. Completion fires the pipeline's `rolloverIssuesOnCompletion` and `autoGenerateReleaseNotesOnCompletion`, so the release must be holding everything by then. The sweep is now **additionally gated on the adoption succeeding** — cancelling a release whose issues were not taken over is the exact failure this pair prevents, and leaving it open and visible is the better failure.

## Verified by dry run

`beta -> latest`, `dry-run=true`, dispatched from this branch. The step now runs and issues:

```
linear-release sync --name=26.8.27.949 --release-version=26.8.27.949 \
  --issue-pattern=\b(CORE-[0-9]+)\b --base-ref=26.2.5.549 --dry-run --verbose
```

and resolves **22 distinct issues** across the whole range:

```
CORE-123 266 414 416 554 557 600 635 700 718 724 729 735 777 783 786 860 861 862 863 864 865
```

against the 8 that 949 holds today — including everything currently stranded in 897, 917 and 924.

## Tests

Two source invariants, both mutation-tested, all 4 mutations caught:

- **`check_every_emitted_output_is_declared`** — the general form of the CORE-783 bug. Walks every `emit` in the action's scripts rather than checking one key, so the next forgotten declaration fails here instead of shipping inert.
- **`check_full_release_adopts_before_cancelling`** — adopt precedes `complete` and the sweep, scans from `linear_base_tag`, and the sweep stays gated on adoption.

Both anchors needed tightening after the first negative pass: `find("id: linear_adopt")` was satisfied by `id: linear_adopt_REMOVED`, and the `base_ref` check passed on the step's own `if:` guard, which also mentions `linear_base_tag`.

## One operational note for reviewers

`release.yml` cannot be dispatched from a long-named branch. The WIF subject is `repo:StreamElements/obs-streamelements-core:ref:refs/heads/<branch>` — 60 bytes of fixed prefix against a 127-byte limit. Linear's suggested branch name for this issue was 71 characters and the first dry run died on `The size of mapped attribute google.subject exceeds the 127 bytes limit`. Hence the shortened branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)