### PR TITLE
fix(crash): don't let our own handler's frames pass the WER gate (CORE-968)

### DIFF
--- a/streamelements/StreamElementsSentryCrashHandler.cpp
+++ b/streamelements/StreamElementsSentryCrashHandler.cpp
@@ -986,6 +986,7 @@ static void RegisterWerModule(uint64_t sentryInitThreadId,
 	// --- ours ------------------------------------------------------------
 	s_werRegistration.seMagic = SE_WER_MAGIC;
 	s_werRegistration.seVersion = SE_WER_VERSION;
+	s_werRegistration.seHandlerActive = 0;
 
 	::wcsncpy_s(s_werRegistration.seSentryWerPath,
 		    _countof(s_werRegistration.seSentryWerPath),
@@ -1130,6 +1131,12 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 	// IsCrashReportingInProgress().
 	SetCrashReportingInProgress();
 
+	// Tells the WER module that any of our frames at the top of the stack are
+	// this handler rather than the fault (CORE-968). Deliberately set before
+	// the depth test, so it is true even for a re-entrant call: what the
+	// module needs to know is that our handler is on the stack at all.
+	s_werRegistration.seHandlerActive = 1;
+
 	if (InterlockedIncrement(&s_insideExceptionFilter) == 1L) {
 		// The gate. A stack that never passed through our code is not
 		// ours to report: we skip sentry's filter entirely, so no event
@@ -1201,7 +1208,10 @@ static LONG HandleFatalException(PEXCEPTION_POINTERS pExceptionInfo,
 		abort();
 	}
 
-	InterlockedDecrement(&s_insideExceptionFilter);
+	// Only the outermost call clears it; a nested one leaving does not mean
+	// the handler is off the stack.
+	if (InterlockedDecrement(&s_insideExceptionFilter) == 0L)
+		s_werRegistration.seHandlerActive = 0;
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }

--- a/streamelements/StreamElementsWerModule.cpp
+++ b/streamelements/StreamElementsWerModule.cpp
@@ -220,8 +220,30 @@ static BOOL SEWerIsModuleOfInterest(const SEWerRegistration *registration,
 /* ================================================================= */
 
 //
-// The gate. Walks the crashed thread cross-process and reports whether any
-// frame lands in a module we own.
+// The gate. Walks the crashed thread cross-process and reports whether the crash
+// is ours.
+//
+// "Ours" deliberately does not mean "one of our frames is on the stack"
+// (CORE-968). When the fault happens inside our own crash handler our frames are
+// on the stack by construction, so that test passes for every crash in the
+// process -- including OBS's and other plug-ins'. Observed as SELIVE-1Y, where
+// obs-websocket's destructor called terminate(), our SIGABRT handler ran, and
+// the stack walk inside it died on an already-corrupt heap. Nothing about that
+// crash was ours; we claimed it because SentryAbortHandler was on the stack.
+//
+// So the leading run of our own frames is skipped, and the verdict is taken from
+// what lies beneath it. A fault genuinely inside our code still passes: our
+// frames reappear further down, below the CRT and OBS frames that called us.
+// This is the same discipline StreamElementsCrashContext::WalkStack applies
+// in-process via SetSkipLeadingOwnFrames, and for the same stated reason --
+// "That is not a gate, it is a rubber stamp."
+//
+// Applied only when the handler was actually running, which the registration
+// block reports in seHandlerActive. That condition is load-bearing: a
+// __fastfail raised directly by our own code also has our frame innermost, and
+// skipping unconditionally would decline the very crash class this module exists
+// to capture. Frame position cannot separate the two; the handler saying whether
+// it was on the stack can.
 //
 static BOOL
 SEWerStackTouchesModuleOfInterest(HANDLE process, HANDLE thread,
@@ -234,6 +256,17 @@ SEWerStackTouchesModuleOfInterest(HANDLE process, HANDLE thread,
 	STACKFRAME64 frame;
 	DWORD machine = 0;
 	BOOL found = FALSE;
+
+	// Only when our handler was running at the moment of the fault. See the
+	// note above -- unconditionally skipping would decline a fast-fail
+	// raised by our own code, which is the case this module is for.
+	BOOL skippingOwnLeadingFrames = registration->seHandlerActive ? TRUE
+								      : FALSE;
+
+	if (skippingOwnLeadingFrames) {
+		SEWerLog(
+			"our crash handler was running; skipping its frames before judging");
+	}
 
 	::SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_NO_PROMPTS);
 
@@ -281,7 +314,25 @@ SEWerStackTouchesModuleOfInterest(HANDLE process, HANDLE thread,
 		const char *moduleName =
 			SEWerModuleForAddress(frame.AddrPC.Offset);
 
-		if (SEWerIsModuleOfInterest(registration, moduleName)) {
+		const BOOL ours =
+			SEWerIsModuleOfInterest(registration, moduleName);
+
+		if (skippingOwnLeadingFrames) {
+			if (ours) {
+				// Still inside our own handler. Says nothing
+				// about whose crash this is.
+				SEWerLog(
+					"frame %d is in %s -- skipping our own leading frame",
+					index, moduleName);
+				continue;
+			}
+
+			// First frame that is not ours: everything below this
+			// point is the real stack.
+			skippingOwnLeadingFrames = FALSE;
+		}
+
+		if (ours) {
 			SEWerLog("frame %d is in %s -- ours", index,
 				 moduleName);
 

--- a/streamelements/StreamElementsWerRegistration.h
+++ b/streamelements/StreamElementsWerRegistration.h
@@ -64,6 +64,21 @@ typedef struct {
 	DWORD seMagic;   // SE_WER_MAGIC
 	DWORD seVersion; // SE_WER_VERSION
 
+	// Non-zero while our own crash handler is on the stack (CORE-968).
+	//
+	// Our frames being present is not evidence the crash is ours: when the
+	// fault happens inside the handler they are there by construction. The
+	// module needs to tell that case apart from a fault that genuinely
+	// started in our code, and frame position alone cannot -- both have our
+	// code innermost.
+	//
+	// So the handler publishes whether it was running. Read out of the
+	// crashed process at the moment of the fault, it is exactly the fact the
+	// gate needs, and it is the same thing the in-process walker relies on
+	// when it arms SetSkipLeadingOwnFrames for the abort door and only
+	// there.
+	DWORD seHandlerActive;
+
 	// Modules of interest, lower-cased base names with no extension,
 	// mirroring the in-process gate in StreamElementsCrashContext. Sent
 	// along because the remote settings.json can replace the built-in list

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -991,6 +991,47 @@ static void check_wer_registration_prefix_is_asserted()
 	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
 }
 
+
+// --- CORE-968: the WER gate's leading-frame skip must stay CONDITIONAL.
+//
+// Our frames being on the stack is not evidence the crash is ours -- when the
+// fault happens inside our handler they are there by construction (SELIVE-1Y,
+// where obs-websocket's destructor aborted and our handler died on its corrupt
+// heap). But skipping them unconditionally is just as wrong: a __fastfail
+// raised directly by our own code also has our frame innermost, and that is the
+// crash class this module exists to capture.
+//
+// Frame position cannot separate the two. Only seHandlerActive can, which is why
+// this check pins BOTH halves: the flag must be published by the handler, and
+// the module's skip must be derived from it rather than hard-coded either way.
+static void check_wer_skip_is_conditional_on_the_handler_flag()
+{
+	auto header = slurp("streamelements/StreamElementsWerRegistration.h");
+
+	check(header.find("DWORD seHandlerActive;") != std::string::npos,
+	      "CORE-968: the registration block must carry seHandlerActive");
+
+	auto handler =
+		slurp("streamelements/StreamElementsSentryCrashHandler.cpp");
+
+	check(handler.find("s_werRegistration.seHandlerActive = 1;") !=
+		      std::string::npos,
+	      "CORE-968: the crash handler must publish that it is on the stack");
+	check(handler.find("s_werRegistration.seHandlerActive = 0;") !=
+		      std::string::npos,
+	      "CORE-968: it must also clear the flag, or every later crash looks like one inside the handler");
+
+	auto module = slurp("streamelements/StreamElementsWerModule.cpp");
+
+	// The skip must be derived from the flag. Anchored on the assignment so
+	// that hard-coding it TRUE or FALSE -- the two ways to get this wrong --
+	// both fail here.
+	check(module.find(
+		      "BOOL skippingOwnLeadingFrames = registration->seHandlerActive") !=
+		      std::string::npos,
+	      "CORE-968: the skip must be conditional on seHandlerActive; hard-coding it FALSE reports other plug-ins' crashes as ours, and TRUE declines fast-fails raised by our own code");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -1016,6 +1057,7 @@ int main()
 	check_wer_module_gates_before_forwarding();
 	check_prompt_discloses_automatic_reports();
 	check_wer_registration_prefix_is_asserted();
+	check_wer_skip_is_conditional_on_the_handler_flag();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",

--- a/tests/test_wer_gate.cpp
+++ b/tests/test_wer_gate.cpp
@@ -53,6 +53,10 @@ struct Crash {
 	unsigned long code = STATUS_STACK_BUFFER_OVERRUN;
 	bool isFatal = true;
 
+	// What the registration block reports in seHandlerActive: whether our own
+	// crash handler was on the stack when the fault happened.
+	bool handlerWasActive = false;
+
 	// Module names on the crashed thread, innermost first.
 	std::vector<std::string> stack;
 
@@ -68,6 +72,7 @@ struct Trace {
 	bool testedCode = false;
 	bool walkedStack = false;
 	bool forwarded = false;
+	int skippedLeadingOwnFrames = 0;
 };
 
 static bool IsNativeWerException(unsigned long code)
@@ -125,10 +130,27 @@ static bool Decide(const Crash &crash, Trace &trace)
 
 	trace.walkedStack = true;
 
+	// When our handler was running, the leading run of our own frames is the
+	// handler rather than the fault, and says nothing about whose crash this
+	// is. When it was NOT running, our innermost frame is the fault -- which
+	// is the whole point of this module -- so the skip must not apply.
+	// Frame position cannot separate the two; only this flag can.
 	bool ours = false;
+	bool skippingOwnLeadingFrames = crash.handlerWasActive;
 
 	for (const auto &frame : crash.stack) {
-		if (IsModuleOfInterest(crash, frame)) {
+		const bool isOurs = IsModuleOfInterest(crash, frame);
+
+		if (skippingOwnLeadingFrames) {
+			if (isOurs) {
+				++trace.skippedLeadingOwnFrames;
+				continue;
+			}
+
+			skippingOwnLeadingFrames = false;
+		}
+
+		if (isOurs) {
 			ours = true;
 			break;
 		}
@@ -250,6 +272,90 @@ static void check_remote_module_list_is_honoured()
 	      "CORE-864: when the remote list replaces the defaults, the WER gate must narrow with the in-process gate rather than keeping its own answer");
 }
 
+// --- CORE-968: our own handler on the stack is not evidence ---------------
+//
+// The case that made this necessary, from SELIVE-1Y: obs-websocket's destructor
+// called terminate() during obs_shutdown, our SIGABRT handler ran, and the stack
+// walk inside it died on an already-corrupt heap. Every plug-in frame on that
+// stack belonged to our crash handler. Nothing about the crash was ours.
+static void check_crash_inside_our_own_handler_is_declined()
+{
+	Crash crash;
+	crash.code = STATUS_HEAP_CORRUPTION;
+	crash.handlerWasActive = true;
+	// Innermost first: our handler, then the abort machinery, then the
+	// plug-in that actually faulted.
+	crash.stack = {"obs-streamelements-core", // SentryAbortHandler
+		       "obs-streamelements-core", // HandleFatalException
+		       "ucrtbase",                // abort / raise
+		       "obs-websocket",           // the real culprit
+		       "obs"};
+
+	Trace trace;
+
+	check(!Decide(crash, trace),
+	      "CORE-968: a crash whose only plug-in frames are our own handler's is not ours to report");
+	check(trace.skippedLeadingOwnFrames == 2,
+	      "CORE-968: the leading run of our own frames must be skipped, not counted as evidence");
+	check(!trace.forwarded,
+	      "CORE-968: such a crash must never reach sentry's module");
+}
+
+// The other half: skipping must not swallow a real one. A fault genuinely inside
+// our code reappears below the CRT and OBS frames that called us.
+static void check_crash_in_our_code_still_claimed_below_the_handler()
+{
+	Crash crash;
+	crash.handlerWasActive = true;
+	crash.stack = {"obs-streamelements-core", // handler frames
+		       "ucrtbase",
+		       "obs-streamelements-core", // where it actually faulted
+		       "Qt6Core",
+		       "obs"};
+
+	Trace trace;
+
+	check(Decide(crash, trace),
+	      "CORE-968: skipping the leading frames must not hide a fault that is genuinely ours");
+	check(trace.forwarded,
+	      "CORE-968: it must still be forwarded to sentry's module");
+}
+
+// The condition is the whole fix. Same stack, same frames, opposite verdicts --
+// decided only by whether our handler was running.
+//
+// Getting this wrong is not academic: an unconditional skip declines a
+// __fastfail raised directly by our own code, which is the crash class this
+// module was built for. That is what the first cut of CORE-968 did, and these
+// are the checks that caught it.
+static void check_the_skip_is_conditional_on_the_handler_running()
+{
+	const std::vector<std::string> stack = {"obs-streamelements-core",
+						"ucrtbase", "obs"};
+
+	Crash fault;
+	fault.handlerWasActive = false;
+	fault.stack = stack;
+
+	Trace t1;
+
+	check(Decide(fault, t1),
+	      "CORE-968: with the handler NOT running, our innermost frame IS the fault and must be claimed");
+	check(t1.skippedLeadingOwnFrames == 0,
+	      "CORE-968: nothing may be skipped when the handler was not running");
+
+	Crash inHandler;
+	inHandler.handlerWasActive = true;
+	inHandler.stack = stack;
+
+	Trace t2;
+
+	check(!Decide(inHandler, t2),
+	      "CORE-968: with the handler running, the same leading frame is the handler and must not count");
+	check(t2.skippedLeadingOwnFrames == 1,
+	      "CORE-968: exactly the leading run of our frames is skipped");
+}
+
 // --- Consent -------------------------------------------------------------
 //
 // There is none, and that is the decision: this class is reported on implicit
@@ -369,6 +475,10 @@ int main()
 	check_crash_in_obs_itself_is_declined();
 	check_module_match_is_case_insensitive();
 	check_remote_module_list_is_honoured();
+
+	check_crash_inside_our_own_handler_is_declined();
+	check_crash_in_our_code_still_claimed_below_the_handler();
+	check_the_skip_is_conditional_on_the_handler_running();
 
 	check_no_prior_consent_is_required();
 


### PR DESCRIPTION
Fixes CORE-968

## The bug

The WER module claimed a crash if **any** frame landed in a module of interest. When the fault happens inside our own crash handler, our frames are on the stack by construction — so that test passed for every crash in the process, including other plug-ins'.

Observed in production as **SELIVE-1Y**:

```
obs_shutdown -> free_module -> obs_module_unload
  -> WebSocketServer::~WebSocketServer -> terminate -> abort
    -> SentryAbortHandler -> HandleFatalException
      -> sentry's walk_stack -> SymFromAddrW -> DIA -> LocalFree
        -> RtlFreeHeap -> STATUS_HEAP_CORRUPTION
```

The originating fault is **obs-websocket's** destructor. Nothing in it is ours. We claimed it because our handler was on the stack — the exact *"that is not a gate, it is a rubber stamp"* failure that `StreamElementsCrashContext::WalkStack` takes `skipOwnLeadingFrames` to avoid.

## Why the obvious fix is wrong

My first cut skipped the leading run of our frames unconditionally. **The tests rejected it, and they were right.**

A `__fastfail` raised directly by our own code *also* has our frame innermost — that's the crash class this module exists to capture. Skipping unconditionally declined it. Five CORE-864 checks failed immediately:

```
FAIL: CORE-864: a fast-fail through our own module must be claimed
FAIL: CORE-864: a claimed crash must be forwarded to sentry's module
FAIL: CORE-864: STATUS_FAIL_FAST_EXCEPTION must be handled alongside the other two
...
```

Frame position cannot separate the two cases. Both have our code at the top.

## What can separate them

Whether our handler was running — which only the handler knows, so it publishes it.

`seHandlerActive` is set on entry to `HandleFatalException` (deliberately *before* the re-entrancy test: what matters is that the handler is on the stack at all) and cleared when the outermost call unwinds. The module reads it out of the crashed process with the rest of the registration block, and skips the leading run of our frames **only when it is set**.

That mirrors the in-process design, where the skip is armed for the abort door and only there, because an SEH `CONTEXT` comes from the OS at the fault point with our handler absent.

| | handler NOT running | handler running |
|---|---|---|
| our frame innermost | **claimed** — it's the fault | **declined** — it's the handler |

Same stack, opposite verdicts, decided by one flag.

## Tests

The gate mirror gained the flag and three cases:

- a crash whose only plug-in frames are the handler's is **declined** (the SELIVE-1Y shape)
- one with a genuine plug-in frame *below* the handler is **still claimed**
- the same stack with the flag on and off produces **opposite verdicts**

Both wrong hard-codings were mutation-tested and both fail loudly:

| mutation | result |
|---|---|
| skip never applied (the bug being fixed) | 5 CORE-968 checks fail |
| skip always applied (my first cut) | 5 CORE-864 checks fail |

A source invariant pins the flag being published, cleared, and *used* — anchored on the assignment so hard-coding it either way fails — and was itself negative-tested (2/2 caught).

7/7 ctest green, plugin and both WER DLLs build clean.

## Not addressed here

The heap corruption in SELIVE-1Y is our handler dying mid-collection: sentry's client-side native stackwalk runs full DIA/PDB symbolisation on the crashing process's heap, and `LocalFree` trips the corruption check. `StreamElementsCrashContext` predicted this verbatim. Whether to drop the client-side stackwalk for minidump-only (`sentry_options_set_crash_reporting_mode`) is a separate decision, noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)