### PR TITLE
fix(crash): stop the consent prompt pumping foreign messages (CORE-967)

### DIFF
--- a/streamelements/StreamElementsCrashConsentDialog.cpp
+++ b/streamelements/StreamElementsCrashConsentDialog.cpp
@@ -169,6 +169,11 @@ struct DialogState {
 
 	std::wstring description;
 	bool consented = false;
+
+	// IDOK or IDCANCEL once answered, 0 until then. The dialog is modeless
+	// (see RunIsolatedDialogLoop), so there is no EndDialog return value to
+	// carry this and the loop below reads it from here instead.
+	int outcome = 0;
 };
 
 static std::wstring GetControlText(HWND dialog, int id)
@@ -745,7 +750,13 @@ static INT_PTR CALLBACK ConsentDialogProc(HWND dialog, UINT message,
 			state->consented = true;
 		}
 
-		::EndDialog(dialog, id);
+		// DestroyWindow rather than EndDialog: this dialog is modeless
+		// and pumped by RunIsolatedDialogLoop, which watches for the
+		// window going away. EndDialog only works for DialogBox*.
+		if (state)
+			state->outcome = id;
+
+		::DestroyWindow(dialog);
 
 		return TRUE;
 	}
@@ -857,6 +868,75 @@ static void BuildConsentDialogTemplate(DialogTemplateBuilder &builder)
 
 /* ================================================================= */
 
+//
+// A modal loop that dispatches ONLY this dialog's messages (CORE-967).
+//
+// DialogBoxIndirectParamW runs the standard modal loop, and that loop dispatches
+// every message queued for the thread -- including Qt's. On a crash path that is
+// not merely untidy, it is fatal: the fault that brought us here is frequently a
+// half-destroyed widget, and letting Qt repaint the main window inside the
+// prompt touches it again.
+//
+// Observed in production as SELIVE-1Z:
+//
+//     QMainWindow::restoreState -> QLayout::activate -> _purecall
+//       -> SentryPurecallHandler -> abort -> SentryAbortHandler
+//         -> HandleFatalException -> Prompt -> DialogBoxIndirectParamW
+//           -> DispatchMessageWorker -> QWidgetRepaintManager::paintAndFlush
+//             -> _purecall AGAIN -> SentryPurecallHandler -> abort
+//
+// The second purecall arrives on the same thread, nested inside the handler that
+// is still reporting the first. s_insideExceptionFilter correctly refuses to
+// report it again, so it returns EXCEPTION_CONTINUE_SEARCH, abort() resumes, and
+// the process fast-fails -- killing us in the middle of collecting the first
+// report. A re-entrancy counter cannot save this: same thread, so there is
+// nothing to wait for and nothing to unwind. The only fix is to not run the
+// foreign code at all.
+//
+// So the dialog is created modeless and pumped here, and anything that does not
+// belong to it is discarded rather than dispatched. Nothing else in this process
+// needs to run again -- it is already dying, and the one remaining job is to ask
+// the user a question.
+//
+// WM_PAINT for a foreign window is validated rather than merely dropped. WM_PAINT
+// is not removed from the queue by GetMessage; it is regenerated until the update
+// region is cleared, so dropping it would spin this loop at 100% CPU for as long
+// as the prompt is up -- which, with the CORE-862 watchdog, can be five minutes.
+//
+// The watchdog is unaffected and still bounds this: it runs on its own thread and
+// terminates the process if the prompt has not been answered in time.
+//
+static int RunIsolatedDialogLoop(HWND dialog, const DialogState &state)
+{
+	MSG msg;
+
+	while (::IsWindow(dialog)) {
+		if (!::GetMessageW(&msg, NULL, 0, 0)) {
+			// WM_QUIT. Someone is tearing the thread down; treat it
+			// as no answer, which means do not send.
+			break;
+		}
+
+		const HWND root = msg.hwnd ? ::GetAncestor(msg.hwnd, GA_ROOT)
+					   : NULL;
+
+		if (root == dialog) {
+			if (!::IsDialogMessageW(dialog, &msg)) {
+				::TranslateMessage(&msg);
+				::DispatchMessageW(&msg);
+			}
+
+			continue;
+		}
+
+		// Not ours. Deliberately not dispatched -- see above.
+		if (msg.message == WM_PAINT && msg.hwnd)
+			::ValidateRect(msg.hwnd, NULL);
+	}
+
+	return state.outcome;
+}
+
 StreamElementsCrashConsentDialog::Result
 StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 					 const std::string &email,
@@ -883,9 +963,21 @@ StreamElementsCrashConsentDialog::Prompt(const std::string &name,
 	// cost is that the dialog is not modal to OBS, which is why it is
 	// WS_EX_TOPMOST and calls SetForegroundWindow above.
 	//
-	const INT_PTR outcome = ::DialogBoxIndirectParamW(
-		::GetModuleHandleW(NULL), builder.Get(), NULL,
-		ConsentDialogProc, (LPARAM)&state);
+	// Modeless, then pumped by RunIsolatedDialogLoop above. The template
+	// carries no WS_VISIBLE -- DialogBox* used to show the window for us --
+	// so it is shown explicitly here.
+	HWND dialog = ::CreateDialogIndirectParamW(::GetModuleHandleW(NULL),
+						   builder.Get(), NULL,
+						   ConsentDialogProc,
+						   (LPARAM)&state);
+
+	int outcome = -1;
+
+	if (dialog) {
+		::ShowWindow(dialog, SW_SHOW);
+
+		outcome = RunIsolatedDialogLoop(dialog, state);
+	}
 
 	// IDOK and IDCANCEL both mean the dialog appeared and was answered; -1
 	// means Windows refused the template and it never did.

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -991,6 +991,54 @@ static void check_wer_registration_prefix_is_asserted()
 	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
 }
 
+
+// --- CORE-967: the consent prompt must not pump foreign messages.
+//
+// DialogBoxIndirectParamW runs the standard modal loop, which dispatches every
+// message queued for the thread. On a crash path that is fatal rather than
+// untidy: the fault that brought us here is frequently a half-destroyed widget,
+// and letting Qt repaint the main window inside the prompt touches it again.
+//
+// SELIVE-1Z is that loop, in production:
+//
+//   restoreState -> _purecall -> handler -> Prompt -> DispatchMessageWorker
+//     -> QWidgetRepaintManager::paintAndFlush -> _purecall AGAIN -> abort
+//
+// The second fault is on the same thread, nested inside the handler still
+// reporting the first, and kills the process mid-collection. s_insideExceptionFilter
+// cannot save it -- same thread, nothing to wait for.
+//
+// Measured before and after with a standalone harness: the DialogBox version
+// dispatched 202 foreign messages while the prompt was up; the isolated loop
+// dispatched 0, with the dialog behaving identically.
+static void check_consent_prompt_does_not_pump_foreign_messages()
+{
+	auto dialog = slurp("streamelements/StreamElementsCrashConsentDialog.cpp");
+
+	check(dialog.find("DialogBoxIndirectParamW(") == std::string::npos,
+	      "CORE-967: the prompt must not use DialogBoxIndirectParamW -- its modal loop dispatches Qt's messages and re-enters the crash");
+
+	check(dialog.find("RunIsolatedDialogLoop(dialog, state)") !=
+		      std::string::npos,
+	      "CORE-967: the prompt must be pumped by RunIsolatedDialogLoop, which dispatches only its own messages");
+
+	check(dialog.find("CreateDialogIndirectParamW(") != std::string::npos,
+	      "CORE-967: the dialog must be created modeless for that loop to drive it");
+
+	// The anti-spin measure. WM_PAINT is not consumed by GetMessage; it is
+	// regenerated until the update region is cleared, so discarding a
+	// foreign paint without validating it spins this loop at 100% CPU for
+	// as long as the prompt is up -- up to the five-minute CORE-862
+	// watchdog.
+	check(dialog.find("::ValidateRect(msg.hwnd, NULL)") != std::string::npos,
+	      "CORE-967: a discarded foreign WM_PAINT must be validated, or the isolated loop spins at 100% CPU");
+
+	// EndDialog only works for DialogBox*; leaving it behind would mean the
+	// prompt never closes and the watchdog kills the process every time.
+	check(dialog.find("::EndDialog(") == std::string::npos,
+	      "CORE-967: EndDialog does not end a modeless dialog -- the prompt would hang until the watchdog terminated the process");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -1015,6 +1063,7 @@ int main()
 	check_sentry_wer_is_not_beside_the_host_executable();
 	check_wer_module_gates_before_forwarding();
 	check_prompt_discloses_automatic_reports();
+	check_consent_prompt_does_not_pump_foreign_messages();
 	check_wer_registration_prefix_is_asserted();
 
 	if (failures) {


### PR DESCRIPTION
Partially addresses CORE-967 — this is the re-entrancy half. `#partial`

## The loop, in production

`DialogBoxIndirectParamW` runs the standard modal loop, which dispatches **every** message queued for the thread — including Qt's. On a crash path that is fatal rather than untidy: the fault that brought us here is frequently a half-destroyed widget, and letting Qt repaint the main window inside the prompt touches it again.

SELIVE-1Z:

```
QMainWindow::restoreState -> QLayout::activate -> _purecall
  -> SentryPurecallHandler -> abort -> SentryAbortHandler
    -> HandleFatalException -> Prompt -> DialogBoxIndirectParamW
      -> DispatchMessageWorker -> QWidgetRepaintManager::paintAndFlush
        -> _purecall AGAIN -> SentryPurecallHandler -> abort
```

## Why a re-entrancy guard can't fix it

My first proposal was to add an in-progress flag. **That was wrong — one already exists.** `s_insideExceptionFilter` correctly refuses to report the second crash. But the second fault is on the **same thread**, nested inside the handler still reporting the first: the guard returns `EXCEPTION_CONTINUE_SEARCH`, `abort()` resumes, and the process fast-fails *mid-collection*. There is nothing to wait for and nothing to unwind.

The only fix is to not run the foreign code at all.

## The fix

The dialog is created modeless and pumped by `RunIsolatedDialogLoop`, which dispatches only messages whose root window is the dialog. Everything else is discarded — nothing else in this process needs to run again; it is already dying and the one remaining job is to ask the user a question.

Foreign `WM_PAINT` is **validated**, not merely dropped. `WM_PAINT` isn't consumed by `GetMessage` — it regenerates until the update region is cleared, so discarding it would spin the loop at 100% CPU for as long as the prompt is up, i.e. up to the five-minute CORE-862 watchdog.

`EndDialog` goes with it (it only ends a `DialogBox*`); the answer travels out via `DialogState::outcome`.

## Measured, not asserted

The real risk here is breaking the prompt — a dialog that silently fails to appear suppresses every crash report, which the existing code comments warn about explicitly. So a standalone harness builds the dialog **twice**, once from `master` and once from this branch, puts a foreign window on the same thread, aims 200 posted messages plus repeated invalidations at it while the prompt is up, and counts what reaches its `WndProc`:

| | foreign messages dispatched | prompt shown | answer round-tripped |
|---|---|---|---|
| `master` | **202** (200 posts + 2 `WM_PAINT`) | yes | yes |
| this branch | **0** | yes | yes |

Identical dialog behaviour, zero foreign code. Re-run against the formatted final source, so the numbers are the shipped ones.

CPU, confirming the `ValidateRect` anti-spin:

```
master : wall 4,259 ms   CPU 125 ms   (2.9% of one core)
this   : wall 3,693 ms   CPU 203 ms   (5.5% of one core)
```

The harness is Windows-only and needs a desktop, so it stays out of `tests/` — that suite is documented as building and running on any platform without an obs-studio tree. The regression gate is a source invariant instead, pinning all five properties (no `DialogBoxIndirectParamW`, the loop present *and called*, modeless creation, the `ValidateRect`, no leftover `EndDialog`). Negative-tested, 2/2 caught. 7/7 ctest green.

## Scope

This does **not** fix the purecall itself — the dangling `QDockWidget` reached through `restoreState`. It stops one crash becoming a loop that kills the report, which is why CORE-967 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)