### PR TITLE
fix(ui): stop adding docks to Qt::NoDockWidgetArea (CORE-967)

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -485,13 +485,20 @@ void StreamElementsGlobalStateManager::Initialize(QMainWindow *obs_main_window)
 
 	m_appStateListener = new ApplicationStateListener();
 	m_themeChangeListener = new ThemeChangeListener();
-#ifdef WIN32
-	mainWindow()->addDockWidget(Qt::NoDockWidgetArea,
-					m_themeChangeListener);
-#else
+
+	// objectName, because QMainWindow::saveState() and restoreState()
+	// identify docks by it and Qt's documentation requires it to be set for
+	// every dock in the window. This one had none, so it was saved and
+	// matched under an empty key (CORE-967).
+	m_themeChangeListener->setObjectName("streamelements_theme_listener");
+
+	// Bottom on both platforms now. The Windows branch passed
+	// Qt::NoDockWidgetArea, which addDockWidget rejects -- the dock was
+	// never added at all, which is one of the four "invalid 'area'
+	// argument" warnings in every OBS log. It is invisible and floating
+	// either way; see StreamElementsWidgetManager::AddDockWidget.
 	mainWindow()->addDockWidget(Qt::BottomDockWidgetArea,
-					m_themeChangeListener);
-#endif
+				    m_themeChangeListener);
 
 	{
 		// Set up "Live Support" button

--- a/streamelements/StreamElementsWidgetManager.cpp
+++ b/streamelements/StreamElementsWidgetManager.cpp
@@ -273,17 +273,45 @@ bool StreamElementsWidgetManager::AddDockWidget(
 	dock->setWindowTitle(title);
 
 	dock->setWidget(widget);
-	m_parent->addDockWidget(area, dock);
+
+	//
+	// Qt::NoDockWidgetArea is not a valid argument to addDockWidget()
+	// (CORE-967).
+	//
+	// checkDockWidgetArea() accepts only Left/Right/Top/Bottom; anything
+	// else is rejected with "QMainWindow::addDockWidget: invalid 'area'
+	// argument" and the function returns having done nothing. The dock is
+	// then never registered in QMainWindowLayout -- and every OBS log on a
+	// machine running this carries four of those warnings per start.
+	//
+	// What followed made it worse. setFloating(false) on a dock the layout
+	// has never heard of, whose parent is nonetheless the main window, docks
+	// it through a path that skipped addDockWidget's bookkeeping; and the
+	// event-queue drains between the two setFloating() calls dispatched
+	// arbitrary posted events -- DeferredDelete included -- in the middle of
+	// manipulating dock layout. CORE-786 established what pumping there
+	// costs.
+	//
+	// The result is a QMainWindowLayout holding a half-registered dock, and
+	// that structure is exactly what QMainWindow::restoreState() walks on
+	// the next scene-collection change. SELIVE-1Z faults there, in
+	// QLayout::totalMinimumSize, on a pure virtual.
+	//
+	// A floating dock is made by adding it to a real area and then floating
+	// it, which is the documented sequence. The requested area is still
+	// recorded as-asked, so GetDockWidgetArea() and its "floating" spelling
+	// are unchanged.
+	//
+	const Qt::DockWidgetArea placementArea =
+		area == Qt::NoDockWidgetArea ? Qt::RightDockWidgetArea : area;
+
+	m_parent->addDockWidget(placementArea, dock);
 
 	m_dockWidgets[id] = dock;
 	m_dockWidgetAreas[id] = area;
 
-	if (area == Qt::NoDockWidgetArea) {
-		dock->setFloating(false);
-		SEDrainEventQueue();
+	if (area == Qt::NoDockWidgetArea)
 		dock->setFloating(true);
-		SEDrainEventQueue();
-	}
 
 	std::string savedId = id;
 

--- a/streamelements/StreamElementsWorkerManager.cpp
+++ b/streamelements/StreamElementsWorkerManager.cpp
@@ -46,7 +46,16 @@ public:
 		m_dockWidget->layout()->addWidget(browserWidget);
 		m_dockWidget->setGeometry(QRect(rec.width() * 2, rec.height() * 2, 1920, 1080));
 
-		mainWindow->addDockWidget(Qt::NoDockWidgetArea, m_dockWidget);
+		// Not NoDockWidgetArea: addDockWidget rejects it outright and
+		// the dock never enters QMainWindowLayout, leaving the
+		// structure restoreState walks inconsistent. Added to a real
+		// area and then floated, which is the documented way to get a
+		// floating dock. See CORE-967 and the note in
+		// StreamElementsWidgetManager::AddDockWidget.
+		m_dockWidget->setObjectName("streamelements_worker_dock");
+		mainWindow->addDockWidget(Qt::RightDockWidgetArea,
+					  m_dockWidget);
+		m_dockWidget->setFloating(true);
 
 		QTimer::singleShot(std::chrono::milliseconds(0), qApp, [this]() {
 			m_dockWidget->hide();

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -991,6 +991,59 @@ static void check_wer_registration_prefix_is_asserted()
 	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
 }
 
+
+// --- CORE-967: Qt::NoDockWidgetArea is not a valid addDockWidget() argument.
+//
+// checkDockWidgetArea() accepts only Left/Right/Top/Bottom. Anything else is
+// rejected with "QMainWindow::addDockWidget: invalid 'area' argument" and the
+// call returns having done nothing, so the dock is never registered in
+// QMainWindowLayout -- while the caller carries on treating it as though it
+// were, floating it and, in the worst version of this, draining the event queue
+// between two setFloating() calls.
+//
+// The layout is then inconsistent, and QMainWindow::restoreState() walks that
+// structure on the next scene-collection change. SELIVE-1Z faults there, in
+// QLayout::totalMinimumSize, on a pure virtual.
+//
+// This was not theoretical: every OBS log on an affected machine carried four of
+// those warnings per start. A portable A/B measured 1 before and 0 after (the
+// other three need SE.Live docks, which need a login).
+//
+// A floating dock is made by adding it to a real area and then floating it.
+static void check_no_dock_is_added_to_an_invalid_area()
+{
+	static const char *const sources[] = {
+		"streamelements/StreamElementsWidgetManager.cpp",
+		"streamelements/StreamElementsWorkerManager.cpp",
+		"streamelements/StreamElementsGlobalStateManager.cpp",
+		"streamelements/StreamElementsBrowserWidgetManager.cpp",
+	};
+
+	// Matches the argument as written at a call site, across the line break
+	// clang-format is fond of putting after the opening paren.
+	std::regex bad(R"(addDockWidget\(\s*Qt::NoDockWidgetArea)");
+
+	for (const char *src : sources) {
+		auto code = slurp(src);
+
+		if (std::regex_search(code, bad)) {
+			std::fprintf(stderr,
+				     "FAIL: CORE-967: %s calls addDockWidget(Qt::NoDockWidgetArea), which Qt rejects outright -- the dock is never added and the layout restoreState walks is left inconsistent\n",
+				     src);
+			++failures;
+		}
+	}
+
+	// The theme listener is a QDockWidget in the main window, so saveState()
+	// and restoreState() identify it by objectName. Qt requires one to be
+	// set for every dock in the window; this had none.
+	auto global = slurp("streamelements/StreamElementsGlobalStateManager.cpp");
+
+	check(global.find("m_themeChangeListener->setObjectName(") !=
+		      std::string::npos,
+	      "CORE-967: the theme-change dock must have an objectName -- saveState/restoreState identify docks by it");
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -1015,6 +1068,7 @@ int main()
 	check_sentry_wer_is_not_beside_the_host_executable();
 	check_wer_module_gates_before_forwarding();
 	check_prompt_discloses_automatic_reports();
+	check_no_dock_is_added_to_an_invalid_area();
 	check_wer_registration_prefix_is_asserted();
 
 	if (failures) {


### PR DESCRIPTION
Fixes CORE-967 — the purecall half. Pairs with #154, which fixed the re-entrancy half.

## Qt has been telling us this all along

`Qt::NoDockWidgetArea` is **not a valid argument** to `addDockWidget()`. `checkDockWidgetArea()` accepts only Left/Right/Top/Bottom; anything else is rejected with

```
QMainWindow::addDockWidget: invalid 'area' argument
```

and the call **returns having done nothing**. The dock is never registered in `QMainWindowLayout`.

Every OBS log on an affected machine carries **four of those per start**. They were in your logs the whole time.

## Why that becomes a purecall

`AddDockWidget` then did this to a dock the layout had never heard of, but whose parent was nonetheless the main window:

```cpp
m_parent->addDockWidget(area, dock);        // silently rejected
if (area == Qt::NoDockWidgetArea) {
    dock->setFloating(false);   // docks it via a path that skipped addDockWidget's bookkeeping
    SEDrainEventQueue();        // pumps arbitrary posted events, DeferredDelete included
    dock->setFloating(true);
    SEDrainEventQueue();
}
```

That leaves `QMainWindowLayout` holding a half-registered dock — and that structure is exactly what `QMainWindow::restoreState()` walks on the next scene-collection change. SELIVE-1Z faults there:

```
load_dock_state -> QMainWindow::restoreState -> QWidget::setVisible
  -> QLayout::activate -> QLayout::totalMinimumSize -> _purecall
```

CORE-786 already established what draining the event queue during widget manipulation costs.

## The fix

A floating dock is made the documented way: added to a **real** area, then floated. The requested area is still recorded as asked, so `GetDockWidgetArea()` and its `"floating"` spelling are unchanged, and both `SEDrainEventQueue()` calls are gone.

Three call sites — the general `AddDockWidget` path, the worker dock, and the theme-change listener, whose Windows branch passed `NoDockWidgetArea` and so was **never added at all**. It also had no `objectName`, which `saveState`/`restoreState` use to identify docks and which Qt requires for every dock in the window. It has one now, as does the worker dock.

## Measured

Portable A/B, verified DLL swap, fresh config each run:

| build | `invalid 'area'` warnings |
|---|---|
| 26.8.27.949 (shipped) | **1** |
| this branch | **0** |

Zero Qt warnings of any kind afterwards, plugin init clean. Portable reaches only one of the four sites; the other three need SE.Live docks, which need a login.

## What I am not claiming

The mechanism is evidenced end to end and the symptom is gone, but **I have not reproduced the purecall itself**, so this is not proven to be its only cause.

Four earlier candidates were investigated and disproven on the way here, which is why I am being careful:

- a missing `removeDockWidget` before delete — no, both deletion paths do it
- raw `QDockWidget*` dangling across the reorder — no synchronous deletion path found
- event pumping between the reorder's remove and re-add — none
- `WA_DeleteOnClose` docks — not set on any dock

None held. This one is backed by a warning Qt prints on every start.

CORE-967's own history records four wrong root causes chased before the right one, so the honest framing is: this fixes a real, documented, observable defect in precisely the code path the crash walks. Whether the purecall stops entirely is answered by the next beta window.

## Tests

A source invariant fails on any `addDockWidget(Qt::NoDockWidgetArea)` across the four files that touch docks, and on the theme listener losing its `objectName`. Both negative-tested (2/2 caught). 7/7 ctest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)