### PR TITLE
fix(updater): close the config handle on both early returns (CORE-979)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ tags
 
 #scratch dir the release workflows write recovered notes and changelogs into
 /.release-input/
+
+# Local, machine-specific agent notes (see CLAUDE.md)
+CLAUDE.local.md

--- a/streamelements/updater/updater.cpp
+++ b/streamelements/updater/updater.cpp
@@ -482,8 +482,18 @@ static bool prompt_for_update(const bool allowUseLastResponse,
 		uint64_t skip_version = config_get_uint(config, "update-prompt",
 							"skip_version");
 
-		if (avail_version_number == skip_version)
+		if (avail_version_number == skip_version) {
+			// Close before leaving. This early return used to
+			// walk out with the handle still open, which is
+			// where the "reference count balance = 1" reported
+			// at unload came from -- and it fires on every
+			// single start once the user has skipped a version,
+			// because skip_version is sticky.
+			config_close(SETRACE_DECREF(config));
+			config = NULL;
+
 			return false;
+		}
 	}
 
 	// Prompt the user with available update
@@ -803,6 +813,17 @@ static void check_for_updates_async(bool allowUseLastResponse, bool silent,
 							if (package_url.size()) {
 								if (!ensure_no_output(context->silent)) {
 									blog(LOG_INFO, "obs-streamelements-core: updater: can not update while streaming and/or recording are active");
+
+									// Same leak as above,
+									// on the manifest: this
+									// return is the only exit
+									// between the open and the
+									// close at the bottom of
+									// the lambda.
+									config_close(SETRACE_DECREF(
+										manifest));
+									manifest =
+										NULL;
 
 									context->callback();
 

--- a/tests/test_source_invariants.cpp
+++ b/tests/test_source_invariants.cpp
@@ -12,9 +12,11 @@
 #include <cassert>
 #include <cstdio>
 #include <fstream>
+#include <algorithm>
 #include <regex>
 #include <sstream>
 #include <string>
+#include <vector>
 
 static int failures = 0;
 
@@ -991,6 +993,93 @@ static void check_wer_registration_prefix_is_asserted()
 	      "CORE-864: the registration block must carry app_tid; the shared-memory name is derived from it");
 }
 
+// --- CORE-979: no config_t handle may escape through an early return.
+//
+// updater.cpp opens config_t handles and closes them at the bottom of the
+// function. Two `return` statements sat between an open and its close, and both
+// walked out with the handle still open:
+//
+//   prompt_for_update    -- the "Skip this version" path. skip_version is
+//                           sticky, so for anyone who has ever skipped a
+//                           version this leaked once per OBS start, forever.
+//   the manifest lambda  -- the "cannot update while streaming/recording"
+//                           path, which for a streaming tool is not an edge
+//                           case.
+//
+// The first is where the `reference count balance = 1 (0 is good)` logged at
+// every clean shutdown came from; a SETRACE level-2 dump named it outright:
+//
+//   + updater.cpp:467 : count(1) config   AddRefs (1), DecRefs (0)
+//
+// It is worth a static gate because the runtime signal is so easy to miss: it
+// needs ENABLE_SETRACE on, a clean shutdown, and someone reading the log --
+// and it does not reproduce at all on a fresh profile, where skip_version has
+// never been written and the early return is never taken.
+//
+// Walks the file in source order tracking which handles are open. Any `return`
+// reached while one is fails. Comments are stripped first, or the prose in the
+// fix ("this early return used to...") would trip the scan.
+static void check_no_config_handle_escapes_an_early_return()
+{
+	auto src = slurp("streamelements/updater/updater.cpp");
+
+	// Strip // comments line by line, then join. Joining is what lets the
+	// scan see a config_close(...) that clang-format has wrapped over three
+	// lines, as it does at the deeper indentation levels in this file.
+	std::string code;
+	std::istringstream lines(src);
+	std::string line;
+
+	while (std::getline(lines, line)) {
+		auto comment = line.find("//");
+
+		if (comment != std::string::npos)
+			line.erase(comment);
+
+		code += line;
+		code += ' ';
+	}
+
+	// Tokens of interest, matched in the order they appear.
+	std::regex token(
+		R"(config_open\s*\(\s*&\s*(\w+)|SETRACE_DECREF\s*\(\s*(\w+)|\breturn\b)");
+
+	std::vector<std::string> open;
+
+	for (auto it = std::sregex_iterator(code.begin(), code.end(), token);
+	     it != std::sregex_iterator(); ++it) {
+		const std::smatch &m = *it;
+
+		if (m[1].matched) {
+			open.push_back(m[1].str());
+			continue;
+		}
+
+		if (m[2].matched) {
+			auto found =
+				std::find(open.begin(), open.end(), m[2].str());
+
+			if (found != open.end())
+				open.erase(found);
+
+			continue;
+		}
+
+		// A return, with a handle still open.
+		if (!open.empty()) {
+			std::fprintf(
+				stderr,
+				"FAIL: CORE-979: updater.cpp returns with '%s' still open -- config_close it before leaving, or it leaks once per OBS start\n",
+				open.front().c_str());
+			++failures;
+
+			// Report each handle once; otherwise one missing close
+			// buries the output under every later return.
+			open.clear();
+		}
+	}
+}
+
 int main()
 {
 	check_c2_video_encoder_template_match();
@@ -1016,6 +1105,7 @@ int main()
 	check_wer_module_gates_before_forwarding();
 	check_prompt_discloses_automatic_reports();
 	check_wer_registration_prefix_is_asserted();
+	check_no_config_handle_escapes_an_early_return();
 
 	if (failures) {
 		std::fprintf(stderr, "%d source invariant(s) violated\n",


### PR DESCRIPTION
Fixes CORE-979.

`updater.cpp` opens `config_t` handles and closes them at the bottom of the function. Two `return` statements sit between an open and its close, and both walk out with the handle still open.

This is the source of the `reference count balance = 1 (0 is good)` logged at `obs-streamelements-core-plugin.cpp:380` on every clean shutdown.

## The two sites

**1. `prompt_for_update` — the "Skip this version" path.**

```c
config_open(&config, configFilePath, CONFIG_OPEN_ALWAYS);
SETRACE_ADDREF(config);
...
if (avail_version_number == skip_version)
        return false;                  // <-- leaks `config`
...
config_close(SETRACE_DECREF(config));  // the only close
```

`skip_version` is sticky — written once when the user clicks Skip, and it stays in `obs-streamelements-updater.ini` until they accept an update. So for anyone who has ever skipped a version, this leaks **once per OBS start, forever**.

**2. The manifest-download lambda — the "cannot update while streaming/recording" path.** Same shape, on `manifest`. Found by auditing the other handles in the file rather than by the counter. For a streaming tool, being live when an update is offered is not an edge case.

## Why it hid

It does not reproduce on a fresh profile: no ini, so `skip_version` reads back as 0, never matches, and the function falls through to the normal close. It needs a profile where the user has actually skipped a version.

## Evidence

Reproduced with `ENABLE_SETRACE 2`, which records file/line/statement per tracked pointer. Clean shutdown, profile carrying `skip_version=20260827000949`:

```
start of reference count trace dump for 1 pointers
unbalanced reference count (1) of data object:
    -> AddRefs (1):
        + updater.cpp:467 : count(1) config
    -> DecRefs (0):
```

A/B on one rig and one profile, only the DLL differing:

| build | dump |
| --- | --- |
| before | `1 pointers` — `updater.cpp:467`, 1 AddRef / 0 DecRefs |
| after | `0 pointers` |
| after, shipping `ENABLE_SETRACE 1` | `reference count balance = 0 (0 is good)` |

## Impact

Bounded — one handle per start, not a growing leak within a session. Worth fixing mainly because a permanently non-zero balance makes the counter useless for catching the next leak, which may not be bounded.

## Test

`check_no_config_handle_escapes_an_early_return` walks `updater.cpp` in source order tracking which handles are open, and fails on any `return` reached while one is. Comments are stripped first, or the prose in the fix ("this early return used to…") would trip the scan; lines are joined so a `config_close(...)` that clang-format wrapped over three lines is still seen.

Negative-tested — removing either close reproduces a failure naming that handle:

```
leak 1 re-introduced:  FAIL: CORE-979: updater.cpp returns with 'config' still open
leak 2 re-introduced:  FAIL: CORE-979: updater.cpp returns with 'manifest' still open
both restored:         test_source_invariants: all invariants hold
```

`ctest`: 7/7 pass. Plugin builds clean from this branch.

Also gitignores `CLAUDE.local.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)