### PR TITLE
docs(api): correct getAllScenes, link data structures from signatures (CORE-1003)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -163,8 +163,8 @@ this tree is.
 | [`getAllReplayBufferOutputs(ResultCallback<{id: OutputInfo}>)`](host/replay-buffer-outputs.md#getallreplaybufferoutputsresultcallbackid-outputinfo) | [Replay Buffer Outputs](host/replay-buffer-outputs.md) |
 | [`getAllSceneCollections(ResultCallback<SceneCollectionInfo[]>)`](host/scene-collections.md#getallscenecollectionsresultcallbackscenecollectioninfo) | [Scene collections](host/scene-collections.md) |
 | [`getAllSceneItems(SceneInfo, ResultCallback<SceneItemInfo[]>)`](host/scene-items.md#getallsceneitemssceneinfo-resultcallbacksceneiteminfo) | [Scene items](host/scene-items.md) |
+| [`getAllScenes(ResultCallback<SceneInfo[]>)`](host/scenes.md#getallscenesresultcallbacksceneinfo) | [Scenes](host/scenes.md) |
 | [`getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)`](host/scenes.md#getallscenes-videocompositionid-resultcallbacksceneinfo) | [Scenes](host/scenes.md) |
-| [`getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)`](host/scenes.md#getallscenes-videocompositionid-resultcallbacksceneinfo_1) | [Scenes](host/scenes.md) |
 | [`getAllScopedStorageJsonItems(ScopedStorageItemInfo, ResultCallback< ScopedStorageItemInfo [] \| null>)`](host/scoped-storage.md#getallscopedstoragejsonitemsscopedstorageiteminfo-resultcallback-scopedstorageiteminfo-null) | [Scoped Storage](host/scoped-storage.md) |
 | [`getAllSharedVideoCompositions(ResultCallback<{ id: SharedVideoCompositionInfo }>)`](host/shared-video-compositions.md#getallsharedvideocompositionsresultcallback-id-sharedvideocompositioninfo) | [Shared Video Compositions](host/shared-video-compositions.md) |
 | [`getAllStreamingOutputs(ResultCallback<{id: OutputInfo}>)`](host/streaming-outputs.md#getallstreamingoutputsresultcallbackid-outputinfo) | [Streaming Outputs](host/streaming-outputs.md) |
@@ -205,7 +205,7 @@ this tree is.
 | [`getSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`](host/scene-items.md#getsceneitempropertiesbyidsceneiteminfo-resultcallbacksuccess) | [Scene items](host/scene-items.md) |
 | [`getSceneItemRotationInViewport(SceneItemInfo or ViewportSceneItemRotationInfo, ResultCallback<ViewportSceneItemRotationInfo>)`](host/scene-items.md#getsceneitemrotationinviewportsceneiteminfo-or-viewportsceneitemrotationinfo-resultcallbackviewportsceneitemrotationinfo) | [Scene items](host/scene-items.md) |
 | [`getScenesAuxiliaryActions(ResultCallback<ActionInfo[]>)`](host/scenes.md#getscenesauxiliaryactionsresultcallbackactioninfo) | [Scenes](host/scenes.md) |
-| [`getShowBuildInMenuItems(ResultCallback<bool>)`](host/menu.md#getshowbuildinmenuitemsresultcallbackbool) | [Menu](host/menu.md) |
+| [`getShowBuiltInMenuItems(ResultCallback<bool>)`](host/menu.md#getshowbuiltinmenuitemsresultcallbackbool) | [Menu](host/menu.md) |
 | [`getSourceClassProperties(SceneItemInfo, RestulCallback<ObsPropertyInfo[]>)`](host/scene-items.md#getsourceclasspropertiessceneiteminfo-restulcallbackobspropertyinfo) | [Scene items](host/scene-items.md) |
 | [`getStartupFlags(ResultCallback<number<flags>>)`](host/startup-flags.md#getstartupflagsresultcallbacknumberflags) | [Startup flags](host/startup-flags.md) |
 | [`getStreamingStatus(ResultCallback<StreamingStatusInfo>)`](host/streaming.md#getstreamingstatusresultcallbackstreamingstatusinfo) | [Streaming](host/streaming.md) |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -90,6 +90,10 @@ this tree is.
 
 ### All `window.host` calls, alphabetically
 
+Calls marked ⚠️ are documented but **not registered by the plug-in** — deprecated and removed, or never implemented. Open one to see which.
+
+
+
 | Call | Group |
 | --- | --- |
 | [`addAudioComposition(AudioCompositionInfo, ResultCallback< AudioCompositionInfo \| null>)`](host/audio-compositions.md#addaudiocompositionaudiocompositioninfo-resultcallback-audiocompositioninfo-null) | [Audio Compositions](host/audio-compositions.md) |
@@ -135,8 +139,8 @@ this tree is.
 | [`disableReplayBufferOutputsByIds(Array<id>, ResultCallback<success>)`](host/replay-buffer-outputs.md#disablereplaybufferoutputsbyidsarrayid-resultcallbacksuccess) | [Replay Buffer Outputs](host/replay-buffer-outputs.md) |
 | [`disableStreamingOutputsByIds(Array<id>, ResultCallback<success>)`](host/streaming-outputs.md#disablestreamingoutputsbyidsarrayid-resultcallbacksuccess) | [Streaming Outputs](host/streaming-outputs.md) |
 | [`disconnectVideoCompositionsFromSharedVideoCompositionsByIds(Array<string>, ResultCallback<success>)`](host/shared-video-compositions.md#disconnectvideocompositionsfromsharedvideocompositionsbyidsarraystring-resultcallbacksuccess) | [Shared Video Compositions](host/shared-video-compositions.md) |
-| [`dispatchKeyboardEvent(KeyboardEventInfo, ResultCallback<success>)`](host/synthetic-input.md#dispatchkeyboardeventkeyboardeventinfo-resultcallbacksuccess) | [Synthetic input](host/synthetic-input.md) |
-| [`dispatchMouseEvent(MouseEventInfo, ResultCallback<success>)`](host/synthetic-input.md#dispatchmouseeventmouseeventinfo-resultcallbacksuccess) | [Synthetic input](host/synthetic-input.md) |
+| [`⚠️ dispatchKeyboardEvent(KeyboardEventInfo, ResultCallback<success>)`](host/synthetic-input.md#dispatchkeyboardeventkeyboardeventinfo-resultcallbacksuccess) | [Synthetic input](host/synthetic-input.md) |
+| [`⚠️ dispatchMouseEvent(MouseEventInfo, ResultCallback<success>)`](host/synthetic-input.md#dispatchmouseeventmouseeventinfo-resultcallbacksuccess) | [Synthetic input](host/synthetic-input.md) |
 | [`enableRecordingOutputsByIds(Array<id>, ResultCallback<success>)`](host/recording-outputs.md#enablerecordingoutputsbyidsarrayid-resultcallbacksuccess) | [Recording Outputs](host/recording-outputs.md) |
 | [`enableReplayBufferOutputsByIds(Array<id>, ResultCallback<success>)`](host/replay-buffer-outputs.md#enablereplaybufferoutputsbyidsarrayid-resultcallbacksuccess) | [Replay Buffer Outputs](host/replay-buffer-outputs.md) |
 | [`enableStreamingOutputsByIds(Array<id>, ResultCallback<success>)`](host/streaming-outputs.md#enablestreamingoutputsbyidsarrayid-resultcallbacksuccess) | [Streaming Outputs](host/streaming-outputs.md) |
@@ -183,7 +187,7 @@ this tree is.
 | [`getAvailableVideoEncoders(ResultCallback<EncoderInfo[]>)`](host/encoders.md#getavailablevideoencodersresultcallbackencoderinfo) | [Encoders](host/encoders.md) |
 | [`getAvailableVideoFilterSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`](host/filter-source-types.md#getavailablevideofiltersourcetypesresultcallbackinputsourcetypeinfo) | [Filter source types](host/filter-source-types.md) |
 | [`getAvailableVideoInputSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`](host/input-source-types.md#getavailablevideoinputsourcetypesresultcallbackinputsourcetypeinfo) | [Input source types](host/input-source-types.md) |
-| [`getContainerForeignPopupWindowsProperties(ResultCallback<ForeignPopupWindowsInfo>)`](host/popup-window.md#getcontainerforeignpopupwindowspropertiesresultcallbackforeignpopupwindowsinfo) | [Popup window](host/popup-window.md) |
+| [`⚠️ getContainerForeignPopupWindowsProperties(ResultCallback<ForeignPopupWindowsInfo>)`](host/popup-window.md#getcontainerforeignpopupwindowspropertiesresultcallbackforeignpopupwindowsinfo) | [Popup window](host/popup-window.md) |
 | [`getCurrentContainerProperties(ResultCallback<ContainerInfo>)`](host/container-information.md#getcurrentcontainerpropertiesresultcallbackcontainerinfo) | [Container information](host/container-information.md) |
 | [`getCurrentProfile(ResultCallback<ProfileInfo>)`](host/profiles.md#getcurrentprofileresultcallbackprofileinfo) | [Profiles](host/profiles.md) |
 | [`getCurrentScene(ResultCallback<SceneInfo>)`](host/scenes.md#getcurrentsceneresultcallbacksceneinfo) | [Scenes](host/scenes.md) |
@@ -196,7 +200,7 @@ this tree is.
 | [`getExternalSceneDataSceneCollectionContent(ExternalSceneDataSceneCollectionInfo, ResultCallback<ExternalSceneDataSceneCollectionContent>)`](host/external-scene-data.md#getexternalscenedatascenecollectioncontentexternalscenedatascenecollectioninfo-resultcallbackexternalscenedatascenecollectioncontent) | [External Scene Data](host/external-scene-data.md) |
 | [`getExternalSceneDataSceneCollections(ExternalSceneDataProviderInfo, ResultCallback<ExternalSceneDataSceneCollectionInfo>)`](host/external-scene-data.md#getexternalscenedatascenecollectionsexternalscenedataproviderinfo-resultcallbackexternalscenedatascenecollectioninfo) | [External Scene Data](host/external-scene-data.md) |
 | [`getFilterSourceProperties(InputSourceTypeInfo, ResultCallback<InputSourceTypeInfo \| null>)`](host/filter-source-types.md#getfiltersourcepropertiesinputsourcetypeinfo-resultcallbackinputsourcetypeinfo-null) | [Filter source types](host/filter-source-types.md) |
-| [`getHostCapabilities(ResultCallback<HostCapabilities>)`](host/host-information.md#gethostcapabilitiesresultcallbackhostcapabilities) | [Host information](host/host-information.md) |
+| [`⚠️ getHostCapabilities(ResultCallback<HostCapabilities>)`](host/host-information.md#gethostcapabilitiesresultcallbackhostcapabilities) | [Host information](host/host-information.md) |
 | [`getHostProperties(ResultCallback<HostInfo>)`](host/host-information.md#gethostpropertiesresultcallbackhostinfo) | [Host information](host/host-information.md) |
 | [`getHostReleaseGroupProperties(ResultCallback<ReleaseGroupInfo>)`](host/release-groups.md#gethostreleasegrouppropertiesresultcallbackreleasegroupinfo) | [Release groups](host/release-groups.md) |
 | [`getInputSourceProperties(InputSourceTypeInfo, ResultCallback<InputSourceTypeInfo \| null>)`](host/input-source-types.md#getinputsourcepropertiesinputsourcetypeinfo-resultcallbackinputsourcetypeinfo-null) | [Input source types](host/input-source-types.md) |
@@ -239,7 +243,7 @@ this tree is.
 | [`queryUserEnvironmentBackupPackageContent(BackupContentInfo, ResultCallback<BackupContentInfo>)`](host/backup-restore.md#queryuserenvironmentbackuppackagecontentbackupcontentinfo-resultcallbackbackupcontentinfo) | [Backup/Restore](host/backup-restore.md) |
 | [`queryUserEnvironmentBackupReferencedFiles (BackupRequestInfo, ResultCallback<BackupContentInfo>)`](host/backup-restore.md#queryuserenvironmentbackupreferencedfiles-backuprequestinfo-resultcallbackbackupcontentinfo) | [Backup/Restore](host/backup-restore.md) |
 | [`readScopedStorageJsonItem(ScopedStorageItemInfo, ResultCallback< ScopedStorageItemInfo \| null>)`](host/scoped-storage.md#readscopedstoragejsonitemscopedstorageiteminfo-resultcallback-scopedstorageiteminfo-null) | [Scoped Storage](host/scoped-storage.md) |
-| [`reloadAllBrowserSources(ResultCallback<success>)`](host/browser-sources.md#reloadallbrowsersourcesresultcallbacksuccess) | [Browser Sources](host/browser-sources.md) |
+| [`⚠️ reloadAllBrowserSources(ResultCallback<success>)`](host/browser-sources.md#reloadallbrowsersourcesresultcallbacksuccess) | [Browser Sources](host/browser-sources.md) |
 | [`removeAudioCompositionsByIds(Array<audioCompositionId>, ResultCallback<success>)`](host/audio-compositions.md#removeaudiocompositionsbyidsarrayaudiocompositionid-resultcallbacksuccess) | [Audio Compositions](host/audio-compositions.md) |
 | [`removeBackgroundWorkersByIds(array<workerId>, ResultCallback<success>)`](host/background-workers.md#removebackgroundworkersbyidsarrayworkerid-resultcallbacksuccess) | [Background workers](host/background-workers.md) |
 | [`removeBrowserScopedHttpServersByIds(<string\|string[]>, ResultCallback<success>)`](host/http-server.md#removebrowserscopedhttpserversbyidsstringstring-resultcallbacksuccess) | [HTTP server](host/http-server.md) |
@@ -261,8 +265,8 @@ this tree is.
 | [`sendHttpRequestResponse(string<id>, HTTPResponseInfo, ResultCallback<success>)`](host/http-server.md#sendhttprequestresponsestringid-httpresponseinfo-resultcallbacksuccess) | [HTTP server](host/http-server.md) |
 | [`setAudioCompositionProperties(AudioCompositionInfo, ResultCallback< AudioCompositionInfo \| null>)`](host/audio-compositions.md#setaudiocompositionpropertiesaudiocompositioninfo-resultcallback-audiocompositioninfo-null) | [Audio Compositions](host/audio-compositions.md) |
 | [`setAuxiliaryMenuItems(MenuItemInfo[], ResultCallback<success>)`](host/menu.md#setauxiliarymenuitemsmenuiteminfo-resultcallbacksuccess) | [Menu](host/menu.md) |
-| [`setContainerForeignPopupWindowsProperties(ForeignPopupWindowsInfo, ResultCallback<success>)`](host/popup-window.md#setcontainerforeignpopupwindowspropertiesforeignpopupwindowsinfo-resultcallbacksuccess) | [Popup window](host/popup-window.md) |
-| [`setCurrentProfileById(ProfileInfo, ResultCallback<success>)`](host/profiles.md#setcurrentprofilebyidprofileinfo-resultcallbacksuccess) | [Profiles](host/profiles.md) |
+| [`⚠️ setContainerForeignPopupWindowsProperties(ForeignPopupWindowsInfo, ResultCallback<success>)`](host/popup-window.md#setcontainerforeignpopupwindowspropertiesforeignpopupwindowsinfo-resultcallbacksuccess) | [Popup window](host/popup-window.md) |
+| [`⚠️ setCurrentProfileById(ProfileInfo, ResultCallback<success>)`](host/profiles.md#setcurrentprofilebyidprofileinfo-resultcallbacksuccess) | [Profiles](host/profiles.md) |
 | [`setCurrentSceneById(sceneId, ResultCallback<success>)`](host/scenes.md#setcurrentscenebyidsceneid-resultcallbacksuccess) | [Scenes](host/scenes.md) |
 | [`setCurrentSceneCollectionById(sceneCollectionId, ResultCallback<success>)`](host/scene-collections.md#setcurrentscenecollectionbyidscenecollectionid-resultcallbacksuccess) | [Scene collections](host/scene-collections.md) |
 | [`setCurrentSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`](host/scene-items.md#setcurrentsceneitempropertiesbyidsceneiteminfo-resultcallbacksuccess) | [Scene items](host/scene-items.md) |

--- a/docs/api/host/audio-compositions.md
+++ b/docs/api/host/audio-compositions.md
@@ -8,6 +8,8 @@ Get all currently existing audio compositions. The result of this API call is a 
 
 **Available since API version 6.0**
 
+**Data structures:** [`AudioCompositionInfo`](../types/AudioCompositionInfo.md)
+
 ## `removeAudioCompositionsByIds(Array<audioCompositionId>, ResultCallback<success>)`
 
 Remove audio compositions by their IDs. If an ID does not exist, it is ignored. If at least one audio composition specified by an ID cannot be removed (*canRemove = false*), the whole call will fail.
@@ -20,6 +22,8 @@ Add an audio composition. Returns the full composition info upon success, or *nu
 
 **Available since API version 6.0**
 
+**Data structures:** [`AudioCompositionInfo`](../types/AudioCompositionInfo.md)
+
 ## `setAudioCompositionProperties(AudioCompositionInfo, ResultCallback< AudioCompositionInfo | null>)`
 
 Modifies audio composition properties. Returns the full composition info upon success, or *null* on failure.
@@ -27,3 +31,5 @@ Modifies audio composition properties. Returns the full composition info upon su
 Currently only updating “name” is supported.
 
 **Available since API version 6.0**
+
+**Data structures:** [`AudioCompositionInfo`](../types/AudioCompositionInfo.md)

--- a/docs/api/host/audio-video-composition-encoders.md
+++ b/docs/api/host/audio-video-composition-encoders.md
@@ -8,11 +8,15 @@ Get list of all available video encoder classes, along with their properties sui
 
 **Available since API version 6.0**
 
+**Data structures:** [`ObsEncoderInfo`](../types/ObsEncoderInfo.md)
+
 ## `getAllAvailableAudioEncoderClasses(ResultCallback<ObsEncoderInfo[]>)`
 
 Get list of all available audio encoder classes, along with their properties suitable for building a UI.
 
 **Available since API version 6.0**
+
+**Data structures:** [`ObsEncoderInfo`](../types/ObsEncoderInfo.md)
 
 ## `getAvailableVideoEncoderClassProperties(ObsEncoderInfo, ResultCallback<ObsEncoderInfo>)`
 
@@ -22,6 +26,8 @@ This can be used to construct dynamic encoder property sheets.
 
 **Available since API version 6.3**
 
+**Data structures:** [`ObsEncoderInfo`](../types/ObsEncoderInfo.md)
+
 ## `getAvailableAudioEncoderClassProperties(ObsEncoderInfo, ResultCallback<ObsEncoderInfo>)`
 
 Takes an *ObsEncoderInfo* description of an ***audio*** encoder, with *settings* set, and returns an *ObsEncoderInfo* for the same encoder, with *properties* set according to input defined by *settings* property.
@@ -29,3 +35,5 @@ Takes an *ObsEncoderInfo* description of an ***audio*** encoder, with *settings*
 This can be used to construct dynamic encoder property sheets.
 
 **Available since API version 6.3**
+
+**Data structures:** [`ObsEncoderInfo`](../types/ObsEncoderInfo.md)

--- a/docs/api/host/background-workers.md
+++ b/docs/api/host/background-workers.md
@@ -14,9 +14,13 @@ The URL supplied as part of the background worker initialization is used to dete
 
 Add a background worker according to specified info.
 
+**Data structures:** [`BackgroundWorkerInfo`](../types/BackgroundWorkerInfo.md)
+
 ## `getAllBackgroundWorkers(ResultCallback<{id:BackgroundWorkerInfo}>)`
 
 Get all background workers.
+
+**Data structures:** [`BackgroundWorkerInfo`](../types/BackgroundWorkerInfo.md)
 
 ## `removeBackgroundWorkersByIds(array<workerId>, ResultCallback<success>)`
 

--- a/docs/api/host/backup-restore.md
+++ b/docs/api/host/backup-restore.md
@@ -10,11 +10,15 @@ Query user environment (scene collections, media files) for referenced files.
 
 This method can be used to determine whether referenced files requested by a backup operation are too large to be included in the backup package.
 
+**Data structures:** [`BackupRequestInfo`](../types/BackupRequestInfo.md), [`BackupContentInfo`](../types/BackupContentInfo.md)
+
 ## `createUserEnvironmentBackupPackage(BackupRequestInfo, ResultCallback<BackupContentInfo>)`
 
 **Available since API version 1.22**
 
 Create user environment (profiles, scene collections, media files) backup package.
+
+**Data structures:** [`BackupRequestInfo`](../types/BackupRequestInfo.md), [`BackupContentInfo`](../types/BackupContentInfo.md)
 
 ## `queryUserEnvironmentBackupPackageContent(BackupContentInfo, ResultCallback<BackupContentInfo>)`
 
@@ -23,6 +27,8 @@ Create user environment (profiles, scene collections, media files) backup packag
 Retrieve scene collection names & profile names from backup package.
 
 **Note:** If *BackupContentInfo.url* points to remote package, it will be downloaded and a new *BackupContentInfo.url* pointing to the local downloaded file will be generated.
+
+**Data structures:** [`BackupContentInfo`](../types/BackupContentInfo.md)
 
 ## `restoreUserEnvironmentBackupPackageContent(BackupContentInfo, ResultCallback<success>)`
 
@@ -35,3 +41,5 @@ Restore backup package from *BackupContentInfo* previously obtained via a call t
 **Important:** the restore operation will cause OBS to restart!
 
 **Important:** attempt to restore while OBS is streaming or recording **will fail**.
+
+**Data structures:** [`BackupContentInfo`](../types/BackupContentInfo.md)

--- a/docs/api/host/browser-sources.md
+++ b/docs/api/host/browser-sources.md
@@ -4,6 +4,8 @@
 
 ## `reloadAllBrowserSources(ResultCallback<success>)`
 
+> ⚠️ **Not implemented.** No handler by this name is registered anywhere in `streamelements/`, so calling it will not resolve. Neither deprecated nor implemented — most likely specified and never built.
+
 **Removed in API 3.0**
 
 Reload all browser sources from server.

--- a/docs/api/host/central-widget.md
+++ b/docs/api/host/central-widget.md
@@ -6,6 +6,8 @@
 
 Show central widget according to the specified info.
 
+**Data structures:** [`CentralWidgetInfo`](../types/CentralWidgetInfo.md)
+
 ## `hideCentralWidget(ResultCallback<success>)`
 
 Close currently open central widget.

--- a/docs/api/host/container-information.md
+++ b/docs/api/host/container-information.md
@@ -5,3 +5,5 @@
 ## `getCurrentContainerProperties(ResultCallback<ContainerInfo>)`
 
 Retrieve current browser container information.
+
+**Data structures:** [`ContainerInfo`](../types/ContainerInfo.md)

--- a/docs/api/host/docking-widgets.md
+++ b/docs/api/host/docking-widgets.md
@@ -6,9 +6,13 @@
 
 Add docking widget to OBS UI according to specified info.
 
+**Data structures:** [`DockingWidgetInfo`](../types/DockingWidgetInfo.md)
+
 ## `getAllDockingWidgets(ResultCallback<{id:DockingWidgetInfo}>)`
 
 Get all docking browser widgets.
+
+**Data structures:** [`DockingWidgetInfo`](../types/DockingWidgetInfo.md)
 
 ## `removeDockingWidgetsByIds(array<widgetId>, ResultCallback<success>)`
 
@@ -30,6 +34,8 @@ Set docking widget width and height by widget Id.
 
 **Note:** setting widget dimensions is allowed only when the widget is in floating state.
 
+**Data structures:** [`DimensionsInfo`](../types/DimensionsInfo.md)
+
 ## `setDockingWidgetPositionById(widgetId, PositionInfo, ResultCallback<success>)`
 
 **Available since API version 1.8**
@@ -37,6 +43,8 @@ Set docking widget width and height by widget Id.
 Set docking widget left and top coordinates by widget Id.
 
 **Note:** setting widget position is allowed only when the widget is in floating state.
+
+**Data structures:** [`PositionInfo`](../types/PositionInfo.md)
 
 ## `setDockingWidgetUrlById(widgetId, url, ResultCallback<success>)`
 

--- a/docs/api/host/encoders.md
+++ b/docs/api/host/encoders.md
@@ -6,16 +6,24 @@
 
 Get a list of available encoders.
 
+**Data structures:** [`EncoderInfo`](../types/EncoderInfo.md)
+
 ## `getAvailableVideoEncoders(ResultCallback<EncoderInfo[]>)`
 
 Get a list of available video encoders.
 
+**Data structures:** [`EncoderInfo`](../types/EncoderInfo.md)
+
 ## `getAvailableAudioEncoders(ResultCallback<EncoderInfo[]>)`
 
 Get a list of available audio encoders.
+
+**Data structures:** [`EncoderInfo`](../types/EncoderInfo.md)
 
 ## `getEncoderProperties(EncoderInfo, ResultCallback<ObsEncoderInfo | null>)`
 
 Get the properties and default settings of an encoder, which can be used for building a UI and also setting encoders up when creating Audio and Video Compositions.
 
 Available since API version 6.0
+
+**Data structures:** [`EncoderInfo`](../types/EncoderInfo.md), [`ObsEncoderInfo`](../types/ObsEncoderInfo.md)

--- a/docs/api/host/existing-input-sources.md
+++ b/docs/api/host/existing-input-sources.md
@@ -12,6 +12,8 @@ Get a list of existing **audio or video** input sources, which can be later refe
 
 The result of this API call may be used to reference specific existing source instances as scene items.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getAllExistingVideoInputSources(ResultCallback<InputSourceTypeInfo[]>)`
 
 **Available since API version 6.0**
@@ -22,6 +24,8 @@ Get a list of existing **video** input sources, which can be later referenced by
 
 The result of this API call may be used to reference specific existing source instances as scene items.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getAllExistingAudioInputSources(ResultCallback<InputSourceTypeInfo[]>)`
 
 **Available since API version 6.0**
@@ -31,3 +35,5 @@ Get a list of existing **audio** input sources, which can be later referenced by
 .
 
 The result of this API call may be used to reference specific existing source instances to an audio mix.
+
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)

--- a/docs/api/host/external-scene-data.md
+++ b/docs/api/host/external-scene-data.md
@@ -10,14 +10,20 @@ This section describes API methods available to retrieve scene data from externa
 
 Get available external scene data providers. Different data providers understand and read data from different sources.
 
+**Data structures:** [`ExternalSceneDataProviderInfo`](../types/ExternalSceneDataProviderInfo.md)
+
 ## `getExternalSceneDataSceneCollections(ExternalSceneDataProviderInfo, ResultCallback<ExternalSceneDataSceneCollectionInfo>)`
 
 **Available since API version 1.15**
 
 Get scene collections available through a specific external scene data provider. Use this method to retrieve a list of scene collections for specific scene data provider.
 
+**Data structures:** [`ExternalSceneDataProviderInfo`](../types/ExternalSceneDataProviderInfo.md), [`ExternalSceneDataSceneCollectionInfo`](../types/ExternalSceneDataSceneCollectionInfo.md)
+
 ## `getExternalSceneDataSceneCollectionContent(ExternalSceneDataSceneCollectionInfo, ResultCallback<ExternalSceneDataSceneCollectionContent>)`
 
 **Available since API version 1.15**
 
 Get specific external scene data provider’s specific scene collection content. The resulting object contains the provider Id, collection Id, collection name, metadata files and their content, and any referenced local files with a special URL which can be used to access those local files using standard XMLHttpRequest2 API.
+
+**Data structures:** [`ExternalSceneDataSceneCollectionInfo`](../types/ExternalSceneDataSceneCollectionInfo.md), [`ExternalSceneDataSceneCollectionContent`](../types/ExternalSceneDataSceneCollectionContent.md)

--- a/docs/api/host/filter-source-types.md
+++ b/docs/api/host/filter-source-types.md
@@ -10,6 +10,8 @@ Get a list of available audio or video filter source types.
 
 Filter source types can be added as items to the *filters* collection of a *SceneItemInfo*.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getAvailableAudioFilterSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`
 
 Available since API version 6.0
@@ -17,6 +19,8 @@ Available since API version 6.0
 Get a list of available audio filter source types.
 
 Filter source types can be added as items to the *filters* collection of a *SceneItemInfo*.
+
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
 
 ## `getAvailableVideoFilterSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`
 
@@ -26,6 +30,8 @@ Get a list of available video filter source types.
 
 Filter source types can be added as items to the *filters* collection of a *SceneItemInfo*.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getFilterSourceProperties(InputSourceTypeInfo, ResultCallback<InputSourceTypeInfo | null>)`
 
 **Available since API version 6.0**
@@ -33,3 +39,5 @@ Filter source types can be added as items to the *filters* collection of a *Scen
 Get **filter** source type’s properties.
 
 This works by creating a filter source of *InputSourceTypeInfo.class* with *InputSourceTypeInfo.settings* applied to it, and returning an *InputSourceTypeInfo* with *InputSourceTypeInfo.properties* field adjusted to the source settings.
+
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)

--- a/docs/api/host/host-information.md
+++ b/docs/api/host/host-information.md
@@ -8,8 +8,12 @@ Available since API version 1.4
 
 Get host platform properties, including platform, architecture, component versions & API version.
 
+**Data structures:** [`HostInfo`](../types/HostInfo.md)
+
 ## `getHostCapabilities(ResultCallback<HostCapabilities>)`
 
 Available since API version 1.8
 
 Get host platform capabilities
+
+**Data structures:** [`HostCapabilities`](../types/HostCapabilities.md)

--- a/docs/api/host/host-information.md
+++ b/docs/api/host/host-information.md
@@ -12,6 +12,8 @@ Get host platform properties, including platform, architecture, component versio
 
 ## `getHostCapabilities(ResultCallback<HostCapabilities>)`
 
+> ⚠️ **Not implemented.** No handler by this name is registered anywhere in `streamelements/`, so calling it will not resolve. Neither deprecated nor implemented — most likely specified and never built.
+
 Available since API version 1.8
 
 Get host platform capabilities

--- a/docs/api/host/hotkey-bindings.md
+++ b/docs/api/host/hotkey-bindings.md
@@ -8,6 +8,8 @@ Available since API version 1.3
 
 Get all OBS hotkey bindings.
 
+**Data structures:** [`HotkeyBindingInfo`](../types/HotkeyBindingInfo.md)
+
 ## `addHotkeyBinding(HotkeyBindingInfo, ResultCallback<boundHotkeyId>)`
 
 Available since API version 1.3
@@ -102,6 +104,8 @@ window.host.addHotkeyBinding(bindingByKeyName, function(boundHotkeyId) {});
 window.host.addHotkeyBinding(bindingByVirtualKeyCode, function(boundHotkeyId) {});
 ```
 
+**Data structures:** [`HotkeyBindingInfo`](../types/HotkeyBindingInfo.md)
+
 ## `removeHotkeyBindingById(hotkeyId, ResultCallback<success>)`
 
 Available since API version 1.3
@@ -114,6 +118,8 @@ Available since API version 1.3
 
 Get all OBS hotkey bindings managed by OBS.Live. This method can be used to **store hotkey bindings in the cloud** for later retrieval and restoration by calls to *addHotkeyBinding()*.
 
+**Data structures:** [`HotkeyBindingInfo`](../types/HotkeyBindingInfo.md)
+
 ## `setHotkeyBindingTriggers(Pick<HotkeyBindingInfo, ‘id’ | ‘triggers’>, ResultCallback<success>)`
 
 **Available since API version 6.5**
@@ -121,3 +127,5 @@ Get all OBS hotkey bindings managed by OBS.Live. This method can be used to **st
 Replaces existing hotkey binding triggers with specified list of triggers.
 
 Hotkey selection is done by hotkey *id*, which allows selecting _any_ hotkey, including those defined by OBS itself.
+
+**Data structures:** [`HotkeyBindingInfo`](../types/HotkeyBindingInfo.md)

--- a/docs/api/host/http-requests.md
+++ b/docs/api/host/http-requests.md
@@ -15,3 +15,5 @@ This method can be used to make cross-domain HTTP requests with custom HTTP head
 - Subsequent API calls in the current window are *blocked* until the request completes or fails.
 
 - All request and response data is sent and interpreted as UTF-8 encoded text. Binary responses may lead to empty results if UTF-8 decoding fails.
+
+**Data structures:** [`HTTPRequestInfo`](../types/HTTPRequestInfo.md), [`HTTPResponseInfo`](../types/HTTPResponseInfo.md)

--- a/docs/api/host/http-server.md
+++ b/docs/api/host/http-server.md
@@ -26,11 +26,15 @@ Remove the listening HTTP service before navigating away to another domain.
 
 **Available since API version 1.37**
 
+**Data structures:** [`GenericNetworkServiceInfo`](../types/GenericNetworkServiceInfo.md)
+
 ## `getAllBrowserScopedHttpServers(ResultCallback<GenericNetworkServiceInfo[]>)`
 
 Retrieve a list of currently running HTTP servers scoped to the current browser.
 
 **Available since API version 1.37**
+
+**Data structures:** [`GenericNetworkServiceInfo`](../types/GenericNetworkServiceInfo.md)
 
 ## `removeBrowserScopedHttpServersByIds(<string|string[]>, ResultCallback<success>)`
 
@@ -51,3 +55,5 @@ Send a response to an HTTP request received by a *hostMessageReceived* event han
 The HTTP listener service waits for up to 15 seconds for a response to be sent. Afterwards it responds with a default HTTP 404 Request Not Handled status (a variation of HTTP 404 Not Found).
 
 **Available since API version 1.37**
+
+**Data structures:** [`HTTPResponseInfo`](../types/HTTPResponseInfo.md)

--- a/docs/api/host/input-source-types.md
+++ b/docs/api/host/input-source-types.md
@@ -12,6 +12,8 @@ An input source type may provide video and/or audio input.
 
 Examples of input source types include the Browser Source, Video Capture Devices, and the Game Capture Source.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getAvailableVideoInputSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`
 
 Available since API version 6.0
@@ -19,6 +21,8 @@ Available since API version 6.0
 Get a list of available video input source types.
 
 An input source type may provide **video** input.
+
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
 
 ## `getAvailableAudioInputSourceTypes(ResultCallback<InputSourceTypeInfo[]>)`
 
@@ -28,6 +32,8 @@ Get a list of available audio input source types.
 
 An input source type may provide **audio** input.
 
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)
+
 ## `getInputSourceProperties(InputSourceTypeInfo, ResultCallback<InputSourceTypeInfo | null>)`
 
 **Available since API version 6.0**
@@ -35,3 +41,5 @@ An input source type may provide **audio** input.
 Get **input** source type’s properties.
 
 This works by creating a source of *InputSourceTypeInfo.class* with *InputSourceTypeInfo.settings* applied to it, and returning an *InputSourceTypeInfo* with *InputSourceTypeInfo.properties* field adjusted to the source settings.
+
+**Data structures:** [`InputSourceTypeInfo`](../types/InputSourceTypeInfo.md)

--- a/docs/api/host/invoke-api-methods-in-batch-mode.md
+++ b/docs/api/host/invoke-api-methods-in-batch-mode.md
@@ -11,3 +11,5 @@ In case *InvokeInfo.invoke* refers to an API method which does not exist, the ca
 Saving of OBS front-end state will be suspended before API methods execution begins, and will be resumed once execution of all methods in the array completes.
 
 **Available since API version 1.35**
+
+**Data structures:** [`InvokeInfo`](../types/InvokeInfo.md)

--- a/docs/api/host/menu.md
+++ b/docs/api/host/menu.md
@@ -14,11 +14,15 @@ See *MenuItemInfo* for further details.
 
 **Note**: auxiliary menu items will be reset upon host state reset (logout, after version upgrade, etc.).
 
+**Data structures:** [`MenuItemInfo`](../types/MenuItemInfo.md)
+
 ## `getAuxiliaryMenuItems(ResultCallback<MenuItemInfo[]>)`
 
 **Available since API version 1.22**
 
 Get currently active auxiliary menu items previously set by *setAuxiliaryMenuItems*.
+
+**Data structures:** [`MenuItemInfo`](../types/MenuItemInfo.md)
 
 ## `setShowBuiltInMenuItems(bool<show>, ResultCallback<success>)`
 
@@ -26,7 +30,7 @@ Get currently active auxiliary menu items previously set by *setAuxiliaryMenuIte
 
 Specify whether to show built-in menu items.
 
-## `getShowBuildInMenuItems(ResultCallback<bool>)`
+## `getShowBuiltInMenuItems(ResultCallback<bool>)`
 
 **Available since API version 1.38**
 

--- a/docs/api/host/menus.md
+++ b/docs/api/host/menus.md
@@ -7,3 +7,5 @@
 Shows a native pop-up menu at the current position of the mouse cursor on screen.
 
 **Available since API version 6.0**
+
+**Data structures:** [`MenuItemInfo`](../types/MenuItemInfo.md)

--- a/docs/api/host/message-bus.md
+++ b/docs/api/host/message-bus.md
@@ -25,3 +25,5 @@ External controllers will receive the event according to the external controller
 **Note: this API call is not available in the Browser Source.**
 
 When you need to communicate with the Browser Source, use *broadcastMessage*.
+
+**Data structures:** [`EventInfo`](../types/EventInfo.md)

--- a/docs/api/host/modal-dialog.md
+++ b/docs/api/host/modal-dialog.md
@@ -6,6 +6,8 @@
 
 Open modal dialog with specified info, on result, execute specified callback.
 
+**Data structures:** [`DialogInfo`](../types/DialogInfo.md)
+
 ## `endModalDialog(object, ResultCallback<success>)`
 
 Within a modal dialog opened with showModalDialog(), signal the dialog has ended with the specified result. The first parameter value is the dialog result.

--- a/docs/api/host/modules.md
+++ b/docs/api/host/modules.md
@@ -8,6 +8,8 @@ Retrieves a list of all modules loaded in OBS with their paths and descriptions.
 
 **Available since API version 6.5**
 
+**Data structures:** [`LoadedHostModuleInfo`](../types/LoadedHostModuleInfo.md)
+
 ## `openFileLocationInHostFileManager(string<filePath>, ResultCallback<success>)`
 
 Opens the specified file path in the host’s file manager so the user can do something with it.

--- a/docs/api/host/native-integration-with-streaming-services.md
+++ b/docs/api/host/native-integration-with-streaming-services.md
@@ -3,3 +3,5 @@
 `window.host`
 
 ## `getNativeStreamingServiceIntegrationStatus(ResultCallback<NativeStreamingServiceIntegrationInfo>`
+
+**Data structures:** [`NativeStreamingServiceIntegrationInfo`](../types/NativeStreamingServiceIntegrationInfo.md)

--- a/docs/api/host/non-modal-dialog.md
+++ b/docs/api/host/non-modal-dialog.md
@@ -8,6 +8,8 @@ Open non-modal dialog with specified info, on result, execute specified callback
 
 **Available since API version 3.2**
 
+**Data structures:** [`DialogInfo`](../types/DialogInfo.md)
+
 ## `endNonModalDialog(object, ResultCallback<success>)`
 
 Within a modal dialog opened with showNonModalDialog(), signal the dialog has ended with the specified result. The first parameter value is the dialog result.
@@ -19,6 +21,8 @@ Within a modal dialog opened with showNonModalDialog(), signal the dialog has en
 Retrieve an object who’s keys are non-modal dialog *id*, and values are *DialogInfo* structures for all currently open non-modal dialogs.
 
 **Available since API version 3.3**
+
+**Data structures:** [`DialogInfo`](../types/DialogInfo.md)
 
 ## `closeNonModalDialogsByIds(array<id>, ResultCallback<success>)`
 
@@ -35,3 +39,5 @@ Accepts an *id* of a non-modal dialog and focuses input on it (brings it to fron
 Accepts an *id* of a non-modal dialog and new *DimensionsInfo* and adjusts the non-modal dialog dimensions.
 
 **Available since API version 3.3**
+
+**Data structures:** [`DimensionsInfo`](../types/DimensionsInfo.md)

--- a/docs/api/host/notification-bar.md
+++ b/docs/api/host/notification-bar.md
@@ -6,6 +6,8 @@
 
 Show notification bar with the given URL and height. In effect this shows a new toolbar at the top of the window (above any widgets).
 
+**Data structures:** [`NotificationBarInfo`](../types/NotificationBarInfo.md)
+
 ## `hideNotificationBar(ResultCallback<success>)`
 
 Hide previously open notification bar.

--- a/docs/api/host/output-preview-area-frame.md
+++ b/docs/api/host/output-preview-area-frame.md
@@ -10,6 +10,8 @@
 
 Show a frame around the OBS output preview area (central widget) with the given width, color and style.
 
+**Data structures:** [`FrameInfo`](../types/FrameInfo.md)
+
 ## `hideOutputPreviewFrame (ResultCallback<success>)`
 
 **Available since API version 2.1**

--- a/docs/api/host/output-preview-area-title-bar.md
+++ b/docs/api/host/output-preview-area-title-bar.md
@@ -10,6 +10,8 @@
 
 Show a title bar in the OBS output preview area (central widget) with the given URL and height.
 
+**Data structures:** [`NotificationBarInfo`](../types/NotificationBarInfo.md)
+
 ## `hideOutputPreviewTitleBar (ResultCallback<success>)`
 
 **Available since API version 2.1**

--- a/docs/api/host/output-settings.md
+++ b/docs/api/host/output-settings.md
@@ -6,11 +6,15 @@
 
 Set audio/video encoding settings.
 
+**Data structures:** [`EncodingSettings`](../types/EncodingSettings.md)
+
 ## `getEncodingSettings(ResultCallback<EncodingSettings>)`
 
 Available since API version 1.19
 
 Get audio/video encoding settings.
+
+**Data structures:** [`EncodingSettings`](../types/EncodingSettings.md)
 
 ## `setStreamingSettings(ResultCallback<success>)`
 

--- a/docs/api/host/popup-window.md
+++ b/docs/api/host/popup-window.md
@@ -6,14 +6,20 @@
 
 Open pop-up window with specified info.
 
+**Data structures:** [`PopupWindowInfo`](../types/PopupWindowInfo.md)
+
 ## `setContainerForeignPopupWindowsProperties(ForeignPopupWindowsInfo, ResultCallback<success>)`
 
 Deprecated in API 3.0
 
 Set properties for foreign pop-up windows (popup windows opened using standard HTML DOM API and not via this API)
 
+**Data structures:** [`ForeignPopupWindowsInfo`](../types/ForeignPopupWindowsInfo.md)
+
 ## `getContainerForeignPopupWindowsProperties(ResultCallback<ForeignPopupWindowsInfo>)`
 
 Deprecated in API 3.0
 
 Get properties for foreign pop-up windows (popup windows opened using standard HTML DOM API and not via this API)
+
+**Data structures:** [`ForeignPopupWindowsInfo`](../types/ForeignPopupWindowsInfo.md)

--- a/docs/api/host/popup-window.md
+++ b/docs/api/host/popup-window.md
@@ -10,6 +10,8 @@ Open pop-up window with specified info.
 
 ## `setContainerForeignPopupWindowsProperties(ForeignPopupWindowsInfo, ResultCallback<success>)`
 
+> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+
 Deprecated in API 3.0
 
 Set properties for foreign pop-up windows (popup windows opened using standard HTML DOM API and not via this API)
@@ -17,6 +19,8 @@ Set properties for foreign pop-up windows (popup windows opened using standard H
 **Data structures:** [`ForeignPopupWindowsInfo`](../types/ForeignPopupWindowsInfo.md)
 
 ## `getContainerForeignPopupWindowsProperties(ResultCallback<ForeignPopupWindowsInfo>)`
+
+> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
 
 Deprecated in API 3.0
 

--- a/docs/api/host/profiles.md
+++ b/docs/api/host/profiles.md
@@ -20,6 +20,8 @@ Get current OBS profile.
 
 ## `setCurrentProfileById(ProfileInfo, ResultCallback<success>)`
 
+> ⚠️ **Name does not match the implementation.** The registered handler is `setCurrentProfile`, which does what is described here; no handler named `setCurrentProfileById` exists.
+
 **Available since API version 1.22**
 
 Set current OBS profile by ID.

--- a/docs/api/host/profiles.md
+++ b/docs/api/host/profiles.md
@@ -8,11 +8,15 @@
 
 Get all available OBS profiles.
 
+**Data structures:** [`ProfileInfo`](../types/ProfileInfo.md)
+
 ## `getCurrentProfile(ResultCallback<ProfileInfo>)`
 
 **Available since API version 1.22**
 
 Get current OBS profile.
+
+**Data structures:** [`ProfileInfo`](../types/ProfileInfo.md)
 
 ## `setCurrentProfileById(ProfileInfo, ResultCallback<success>)`
 
@@ -23,3 +27,5 @@ Set current OBS profile by ID.
 Profile ID is indicated by *ProfileInfo.id*.
 
 **Note**: profiles cannot be switched while Streaming and/or Recording are active.
+
+**Data structures:** [`ProfileInfo`](../types/ProfileInfo.md)

--- a/docs/api/host/recording-outputs.md
+++ b/docs/api/host/recording-outputs.md
@@ -8,11 +8,15 @@ Available since API version 6.0
 
 Get all recording outputs.
 
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
+
 ## `addRecordingOutput(OutputInfo, ResultCallback<success>)`
 
 Available since API version 6.0
 
 Add a recording output.
+
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
 
 ## `removeRecordingOutputsByIds(Array<id>, ResultCallback<success>)`
 

--- a/docs/api/host/release-groups.md
+++ b/docs/api/host/release-groups.md
@@ -8,6 +8,8 @@
 
 Set host release group properties. See ReleaseGroupInfo data structure for additional information.
 
+**Data structures:** [`ReleaseGroupInfo`](../types/ReleaseGroupInfo.md)
+
 ## `getHostReleaseGroupProperties(ResultCallback<ReleaseGroupInfo>)`
 
 **Available since API version 1.11**
@@ -16,8 +18,12 @@ Retrieve host release group properties. See ReleaseGroupInfo data structure for 
 
 **Note:** In case no release group information is available for the current computer, *ResultCallback* is called with *null* as parameter.
 
+**Data structures:** [`ReleaseGroupInfo`](../types/ReleaseGroupInfo.md)
+
 ## `queryHostReleaseGroupUpdateAvailability([QuerySoftwareUpdateArgs], ResultCallback<success>)`
 
 **Available since API version 1.11**
 
 Query whether an update is available for the current host release group. If an update is available, the “OBS.Live needs an update” window will show.
+
+**Data structures:** [`QuerySoftwareUpdateArgs`](../types/QuerySoftwareUpdateArgs.md)

--- a/docs/api/host/replay-buffer-outputs.md
+++ b/docs/api/host/replay-buffer-outputs.md
@@ -8,6 +8,8 @@ Available since API version 6.1
 
 Get all replay buffer outputs.
 
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
+
 ## `addReplayBufferOutput(OutputInfo, ResultCallback<success>)`
 
 Available since API version 6.1
@@ -17,6 +19,8 @@ Add a replay buffer output.
 Replay buffer outputs are set up similar to Recording outputs, and are using the same encoders as Recording outputs, with the only difference that *recordingSettings.settings.* *splitAtMaximumDurationSeconds* and *recordingSettings.settings.splitAtMaximumMegabytes* specify the maximum size of the cyclical replay buffer, and not the spit points of a recording made to local files.
 
 To get the contents of the replay buffer, one should call *triggerReplayBufferOutputSaveById* and wait for *hostReplayBufferOutputSavedToLocalFile* event to be dispatched in case they are interested in the file path of the saved replay buffer contents.
+
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
 
 ## `removeReplayBufferOutputsByIds(Array<id>, ResultCallback<success>)`
 

--- a/docs/api/host/scene-collections.md
+++ b/docs/api/host/scene-collections.md
@@ -14,6 +14,8 @@ getCurrentSceneCollectionProperties(ResultCallback\<SceneCollectionInfo>)
 
 Get current scene collection properties.
 
+**Data structures:** [`SceneCollectionInfo`](../types/SceneCollectionInfo.md)
+
 ## `addSceneCollection(SceneCollectionInfo, ResultCallback<success>)`
 
 **Available since API version 1.22**
@@ -23,6 +25,8 @@ Add a new scene collection according to specified info, and select the new scene
 **Warning:** as of OBS 24.0.3, this API is **broken** due to bugs in obs_frontend_add_scene_collection OBS front-end API.
 
 Will be resolved in OBS 25.
+
+**Data structures:** [`SceneCollectionInfo`](../types/SceneCollectionInfo.md)
 
 ## `setCurrentSceneCollectionById(sceneCollectionId, ResultCallback<success>)`
 

--- a/docs/api/host/scene-items.md
+++ b/docs/api/host/scene-items.md
@@ -8,11 +8,15 @@
 
 Get all items in the current scene.
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `getAllSceneItems(SceneInfo, ResultCallback<SceneItemInfo[]>)`
 
 **Available since API version 1.26**
 
 Get all items in the scene specified by *SceneInfo.id*
+
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md), [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `removeCurrentSceneItemsByIds(array<sceneItemId>, ResultCallback<success>)`
 
@@ -34,6 +38,8 @@ Set scene item properties described by SceneItemInfo.
 
 **Note:** the scene item to update is located by the value of *SceneItemInfo.id*.
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `setSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`
 
 **Available since API version 1.26**
@@ -41,6 +47,8 @@ Set scene item properties described by SceneItemInfo.
 Set scene item properties described by SceneItemInfo.
 
 **Note:** the scene item to update is located by the value of *SceneItemInfo.id*.
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `getCurrentSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`
 
@@ -54,6 +62,8 @@ The reason we do this is that some source plug-ins do not implement *obs_source_
 
 **Note:** the scene item to retrieve is located by the value of *SceneItemInfo.id*.
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `getSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`
 
 **Available since API version 6.0**
@@ -65,6 +75,8 @@ This call will retrieve _ALL_ available information for the *SceneItemInfo*, inc
 The reason we do this is that some source plug-ins do not implement *obs_source_get_properties* properly, and we want to minimize the amount of calls to this OBS API while still allowing fine-grained control where applicable.
 
 **Note:** the scene item to retrieve is located by the value of *SceneItemInfo.id*.
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addCurrentSceneItemGameCaptureSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -82,6 +94,8 @@ Add a game capture source scene item (id: “game_capture”)
 | capture_cursor | bool | Capture cursor |
 | anti_cheat_hook | bool | Use anti-cheat compatibility hook |
 | capture_overlays | bool | Capture third-party overlays (such as steam) |
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addSceneItemGameCaptureSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -102,6 +116,8 @@ Add a game capture source scene item (id: “game_capture”)
 
 **Note**: scene to add the game capture source to is specified by *SceneItemInfo.sceneId*
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `addCurrentSceneItemBrowserSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
 **Available since API version 1.10**
@@ -121,6 +137,8 @@ Add browser source scene item (source class: “browser_source”)
 | shutdown | bool | Shutdown source when not visible<br>Optional |
 | restart_when_active | bool | Refresh browser when scene becomes active<br>Optional |
 | reroute_audio | bool | Control audio via OBS<br>Optional |
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addSceneItemBrowserSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -144,6 +162,8 @@ Add browser source scene item (source class: “browser_source”)
 
 **Note**: scene to add the browser source to is specified by *SceneItemInfo.sceneId*
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `addCurrentSceneItemVideoCaptureSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
 **Available since API version 1.21**
@@ -157,6 +177,8 @@ Add video capture source scene item (source id: “dshow_input” on Windows)
 | video_device_id | string | Video capture device identifier obtained via getAvailableVideoCaptureDevices() call |
 
 **Note:** you should set *SceneItemInfo.preferExistingSourceReference = true* when adding video capture sources.
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addSceneItemVideoCaptureSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -173,6 +195,8 @@ Add video capture source scene item (source id: “dshow_input” on Windows)
 **Note:** you should set *SceneItemInfo.preferExistingSourceReference = true* when adding video capture sources.
 
 **Note**: scene to add the video capture source to is specified by *SceneItemInfo.sceneId*
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addCurrentSceneItemObsNativeSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -194,6 +218,8 @@ This method is provided as **last resort**, where time-to-market is of critical 
 
 **One should plan for replacing the call to this method with a more streamlined alternative as soon as it becomes available.**
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `addSceneItemObsNativeSource(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
 **Available since API version 1.26**
@@ -212,6 +238,8 @@ This method is provided as **last resort**, where time-to-market is of critical 
 
 **Note**: scene to add the OBS Native source to is specified by *SceneItemInfo.sceneId*
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `addCurrentSceneItemGroup(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
 **Available since API version 1.21**
@@ -219,6 +247,8 @@ This method is provided as **last resort**, where time-to-market is of critical 
 Add OBS scene item group to the list of scene items.
 
 **Note**: only *SceneItemInfo.name* and *SceneItemInfo.composition* members are honored and required.
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `addSceneItemGroup(SceneItemInfo, ResultCallback<SceneItemInfo>)`
 
@@ -229,6 +259,8 @@ Add OBS scene item group to the list of scene items.
 **Note**: only *SceneItemInfo.name* and *SceneItemInfo.composition* members are honored and required.
 
 **Note**: scene to add the source group to is specified by *SceneItemInfo.sceneId*
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `getAvailableInputSourceClasses(ResultCallback<string[]>)`
 
@@ -244,6 +276,8 @@ Retrieve list of settings properties which a specified source class expects alon
 
 **Note:** the only *SceneItemInfo* properties respected by this API method are *SceneItemInfo.class* (required) and *SceneItemInfo.settings* (optional).
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md), [`ObsPropertyInfo`](../types/ObsPropertyInfo.md)
+
 ## `ungroupCurrentSceneItemGroupById(SceneItemInfo, ResultCallback<success>)`
 
 **Available since API version 1.21**
@@ -252,6 +286,8 @@ Extract scene items from scene item group referenced by *SceneItemInfo.id* into 
 
 **Note:** only *SceneItemInfo.id* is respected by the API method.
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
+
 ## `ungroupSceneItemGroupById(SceneItemInfo, ResultCallback<success>)`
 
 **Available since API version 1.26**
@@ -259,6 +295,8 @@ Extract scene items from scene item group referenced by *SceneItemInfo.id* into 
 Extract scene items from scene item group referenced by *SceneItemInfo.id* into the top level and remove the scene item group.
 
 **Note:** only *SceneItemInfo.id* is respected by the API method.
+
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md)
 
 ## `invokeCurrentSceneItemDefaultActionById(string<sceneItemId>, ResultCallback<success>)`
 
@@ -282,11 +320,15 @@ This method is useful when *SceneItemInfo.contextMenu* for the item was set, but
 
 Set auxiliary actions available at the bottom-right corner of the OBS Scene Items (Sources) dock.
 
+**Data structures:** [`ActionInfo`](../types/ActionInfo.md)
+
 ## `getCurrentSceneItemsAuxiliaryActions(ResultCallback<ActionInfo[]>)`
 
 **Available since API version 1.24**
 
 Get auxiliary actions available at the bottom-right corner of the OBS Scene Items (Sources) dock.
+
+**Data structures:** [`ActionInfo`](../types/ActionInfo.md)
 
 ## `openSceneItemPropertiesDialogById(string<sceneItemId>, ResultCallback<success>)`
 
@@ -318,6 +360,8 @@ Open OBS native source transform editor dialog for the specified scene item ID.
 
 Retrieve scene item rotation in absolute degrees (rotation relative to viewport, taking any additional rotations from parent groups into account).
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md), [`ViewportSceneItemRotationInfo`](../types/ViewportSceneItemRotationInfo.md)
+
 ## `setSceneItemRotationInViewport(ViewportSceneItemRotationInfo, ResultCallback< ViewportSceneItemRotationInfo>)`
 
 **Available since API version 6.0**
@@ -326,14 +370,20 @@ Set scene item rotation in absolute degrees (rotation relative to viewport, taki
 
 **NOTE: Rotation will always be performed around the item’s center**.
 
+**Data structures:** [`ViewportSceneItemRotationInfo`](../types/ViewportSceneItemRotationInfo.md)
+
 ## `getSceneItemBoundingBoxInViewport(SceneItemInfo or ViewportSceneItemGeometryInfo, ResultCallback<ViewportSceneItemGeometryInfo>)`
 
 **Available since API version 6.0**
 
 Retrieve scene item bounding box in absolute coordinates (relative to viewport top-left (0,0), taking any additional transformations from parent groups and the scene item itself into account).
 
+**Data structures:** [`SceneItemInfo`](../types/SceneItemInfo.md), [`ViewportSceneItemGeometryInfo`](../types/ViewportSceneItemGeometryInfo.md)
+
 ## `setSceneItemPositionInViewport(ViewportSceneItemGeometryInfo, ResultCallback< ViewportSceneItemGeometryInfo>)`
 
 **Available since API version 6.0**
 
 Set scene item (top, left) position in absolute coordinates (relative to viewport top-left (0,0), taking any additional transformations from parent groups and the scene item itself into account).
+
+**Data structures:** [`ViewportSceneItemGeometryInfo`](../types/ViewportSceneItemGeometryInfo.md)

--- a/docs/api/host/scenes.md
+++ b/docs/api/host/scenes.md
@@ -2,11 +2,13 @@
 
 `window.host`
 
-## `getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)`
+## `getAllScenes(ResultCallback<SceneInfo[]>)`
 
 **Available since API version 1.21**
 
 Get all scenes in the scene collection.
+
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
 
 ## `getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)`
 
@@ -14,11 +16,15 @@ Get all scenes in the scene collection.
 
 Get all scenes in the specified *videoCompositionId*.
 
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
+
 ## `getCurrentScene(ResultCallback<SceneInfo>)`
 
 **Available since API version 1.21**
 
 Get current scene info.
+
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
 
 ## `getCurrentScene({ videoCompositionId }, ResultCallback<SceneInfo>)`
 
@@ -26,11 +32,15 @@ Get current scene info.
 
 Get current scene info in the specified *videoCompositionId*.
 
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
+
 ## `addScene(SceneInfo, ResultCallback<sceneId>)`
 
 **Available since API version 1.21**
 
 Add a scene to the scene collection according to specified info.
+
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
 
 ## `setCurrentSceneById(sceneId, ResultCallback<success>)`
 
@@ -54,14 +64,20 @@ Remove scenes by their Ids.
 
 Set scene properties by scene Id (*SceneInfo.id* specifies the scene Id to update).
 
+**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
+
 ## `setScenesAuxiliaryActions(ActionInfo[], ResultCallback<success>)`
 
 **Available since API version 1.24**
 
 Set Scenes list auxiliary actions (shown in the bottom-right corner of the OBS Scenes dock).
 
+**Data structures:** [`ActionInfo`](../types/ActionInfo.md)
+
 ## `getScenesAuxiliaryActions(ResultCallback<ActionInfo[]>)`
 
 **Available since API version 1.24**
 
 Get Scenes list auxiliary actions (shown in the bottom-right corner of the OBS Scenes dock).
+
+**Data structures:** [`ActionInfo`](../types/ActionInfo.md)

--- a/docs/api/host/scoped-storage.md
+++ b/docs/api/host/scoped-storage.md
@@ -20,14 +20,20 @@ Read content of scoped storage text item.
 
 **Available since API version 5.0**
 
+**Data structures:** [`ScopedStorageItemInfo`](../types/ScopedStorageItemInfo.md)
+
 ## `removeScopedStorageJsonItem(ScopedStorageItemInfo, ResultCallback< ScopedStorageItemInfo | null>)`
 
 Remove a scoped storage item.
 
 **Available since API version 5.0**
 
+**Data structures:** [`ScopedStorageItemInfo`](../types/ScopedStorageItemInfo.md)
+
 ## `getAllScopedStorageJsonItems(ScopedStorageItemInfo, ResultCallback< ScopedStorageItemInfo [] | null>)`
 
 Get list of scoped storage items from specific scope and container.
 
 **Available since API version 5.0**
+
+**Data structures:** [`ScopedStorageItemInfo`](../types/ScopedStorageItemInfo.md)

--- a/docs/api/host/shared-video-compositions.md
+++ b/docs/api/host/shared-video-compositions.md
@@ -18,6 +18,8 @@ Shared Video Composition name is assigned automatically to reflect it’s status
 
 Available since API version 6.6
 
+**Data structures:** [`SharedVideoCompositionInfo`](../types/SharedVideoCompositionInfo.md)
+
 ## `setSharedVideoCompositionProperties(SharedVideoCompositionInfo, ResultCallback<SharedVideoCompositionInfo | null>)`
 
 Set Shared Video Composition properties. At the time of this writing, only setting “name” is supported.
@@ -27,6 +29,8 @@ This is the only way to change the automatically assigned Shared Video Compositi
 SharedVideoComposition.id field is always required.
 
 Available since API version 6.6
+
+**Data structures:** [`SharedVideoCompositionInfo`](../types/SharedVideoCompositionInfo.md)
 
 ## `removeSharedVideoCompositionsByIds(Array<string>, ResultCallback<success>)`
 
@@ -40,6 +44,8 @@ Retrieve all existing Shared Video Compositions as an object, where it’s key i
 
 Available since API version 6.6
 
+**Data structures:** [`SharedVideoCompositionInfo`](../types/SharedVideoCompositionInfo.md)
+
 ## `connectVideoCompositionToSharedVideoComposition({ sharedVideoCompositionId: string, videoCompositionId: string }, ResultCallback<SharedVideoCompositionInfo>)`
 
 Connect an existing Video Composition to an existing Shared Video Composition.
@@ -51,6 +57,8 @@ One VC can be shared by multiple SVCs. In this sense, an SVC works very much lik
 Calling this API while OBS video output is active (streaming, recording) is not allowed.
 
 Available since API version 6.6
+
+**Data structures:** [`SharedVideoCompositionInfo`](../types/SharedVideoCompositionInfo.md)
 
 ## `disconnectVideoCompositionsFromSharedVideoCompositionsByIds(Array<string>, ResultCallback<success>)`
 

--- a/docs/api/host/status-bar.md
+++ b/docs/api/host/status-bar.md
@@ -5,3 +5,5 @@
 ## `showStatusBarTemporaryMessage(StatusBarMessageInfo, ResultCallback<success>)`
 
 Show time-limited message on the status bar.
+
+**Data structures:** [`StatusBarMessageInfo`](../types/StatusBarMessageInfo.md)

--- a/docs/api/host/streaming-bandwidth-test.md
+++ b/docs/api/host/streaming-bandwidth-test.md
@@ -6,10 +6,16 @@
 
 Begin streaming bandwidth test with specified maximum bitrate and test duration.
 
+**Data structures:** [`BandwidthTestSettings`](../types/BandwidthTestSettings.md), [`ServerInfo`](../types/ServerInfo.md)
+
 ## `streamingBandwidthTestEnd(stopIfRunning, ResultCallback<BandwidthTestStatus>)`
 
 Complete streaming bandwidth test. If *stopIfRunning* == true, bandwidth test which is currently in progress will stop, discarding remaining servers to be tested, and will present only the data which has been accumulated so far.
 
+**Data structures:** [`BandwidthTestStatus`](../types/BandwidthTestStatus.md)
+
 ## `streamingBandwidthTestGetStatus(ResultCallback<BandwidthTestStatus>)`
 
 Present the bandwidth test results which have been accumulated so far.
+
+**Data structures:** [`BandwidthTestStatus`](../types/BandwidthTestStatus.md)

--- a/docs/api/host/streaming-outputs.md
+++ b/docs/api/host/streaming-outputs.md
@@ -8,11 +8,15 @@ Available since API version 5.0
 
 Get all streaming outputs.
 
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
+
 ## `addStreamingOutput(OutputInfo, ResultCallback<success>)`
 
 Available since API version 5.0
 
 Add a streaming output.
+
+**Data structures:** [`OutputInfo`](../types/OutputInfo.md)
 
 ## `removeStreamingOutputsByIds(Array<id>, ResultCallback<success>)`
 

--- a/docs/api/host/streaming.md
+++ b/docs/api/host/streaming.md
@@ -8,6 +8,8 @@ Available since API version 1.17
 
 Retrieve current streaming status, including whether streaming is currently active.
 
+**Data structures:** [`StreamingStatusInfo`](../types/StreamingStatusInfo.md)
+
 ## `requestStreamingStart(ResultCallback<success>)`
 
 Available since API version 1.18
@@ -31,6 +33,8 @@ Changes how UI-triggered streaming start behaves.
 This method mainly controls whether triggering streaming start actually starts streaming or sends the hostStreamingStartRequested event for one of the JavaScript pages to handle as it sees fit.
 
 The JavaScript page may choose to present additional user interface, alter streaming destination, etc.
+
+**Data structures:** [`StreamingStartUIHandlerProperties`](../types/StreamingStartUIHandlerProperties.md)
 
 ## `adviseStreamingStartUIRequestAccepted (ResultCallback<success>)`
 

--- a/docs/api/host/synthetic-input.md
+++ b/docs/api/host/synthetic-input.md
@@ -4,6 +4,8 @@
 
 ## `dispatchKeyboardEvent(KeyboardEventInfo, ResultCallback<success>)`
 
+> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+
 Dispatch synthetic keyboard event.
 
 Deprecated in API 3.0
@@ -11,6 +13,8 @@ Deprecated in API 3.0
 **Data structures:** [`KeyboardEventInfo`](../types/KeyboardEventInfo.md)
 
 ## `dispatchMouseEvent(MouseEventInfo, ResultCallback<success>)`
+
+> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
 
 Dispatch synthetic mouse event.
 

--- a/docs/api/host/synthetic-input.md
+++ b/docs/api/host/synthetic-input.md
@@ -8,8 +8,12 @@ Dispatch synthetic keyboard event.
 
 Deprecated in API 3.0
 
+**Data structures:** [`KeyboardEventInfo`](../types/KeyboardEventInfo.md)
+
 ## `dispatchMouseEvent(MouseEventInfo, ResultCallback<success>)`
 
 Dispatch synthetic mouse event.
 
 Deprecated in API 3.0
+
+**Data structures:** [`MouseEventInfo`](../types/MouseEventInfo.md)

--- a/docs/api/host/system-resources.md
+++ b/docs/api/host/system-resources.md
@@ -25,14 +25,20 @@ var cpuUsagePercentage = busyDelta * 100 / totalDelta;
 
 This technique allows retrieving CPU usage times of different parts and states of the program.
 
+**Data structures:** [`SystemCPUUsageTimes`](../types/SystemCPUUsageTimes.md)
+
 ## `getSystemMemoryUsage(ResultCallback<SystemMemoryUsageInfo>)`
 
 Available since API version 1.1
 
 Get current system memory usage information.
 
+**Data structures:** [`SystemMemoryUsageInfo`](../types/SystemMemoryUsageInfo.md)
+
 ## `getSystemHardwareProperties(ResultCallback<SystemHardwareInfo>)`
 
 Available since API version 1.1
 
 Get current system hardware information.
+
+**Data structures:** [`SystemHardwareInfo`](../types/SystemHardwareInfo.md)

--- a/docs/api/host/transitions.md
+++ b/docs/api/host/transitions.md
@@ -8,17 +8,23 @@ Get available transition classes (types).
 
 **Available since API version 6.0**
 
+**Data structures:** [`TransitionInfo`](../types/TransitionInfo.md)
+
 ## `getVideoCompositionTransition(object<{ videoCompositionId }>, ResultCallback<TransitionInfo | null | false>)`
 
 Get active transition on the specified *videoCompositionId*.
 
 **Available since API version 6.0**
 
+**Data structures:** [`TransitionInfo`](../types/TransitionInfo.md)
+
 ## `setVideoCompositionTransition(TransitionInfo, ResultCallback<TransitionInfo | null | false>)`
 
 Set active transition on the specified *videoCompositionId*.
 
 **Available since API version 6.0**
+
+**Data structures:** [`TransitionInfo`](../types/TransitionInfo.md)
 
 ## `showVideoCompositionTransitionPropertiesDialog(object<{ videoCompositionId }>, ResultCallback<success>)`
 

--- a/docs/api/host/user-interface-state.md
+++ b/docs/api/host/user-interface-state.md
@@ -8,8 +8,12 @@
 
 Get current user interface state, this is used to save main window geometry and state of dock widgets.
 
+**Data structures:** [`UserInterfaceStateProperties`](../types/UserInterfaceStateProperties.md)
+
 ## `setUserInterfaceState(UserInterfaceStateProperties , ResultCallback<success>)`
 
 **Available since API version 1.20**
 
 Set (restore) current user interface state, from data previously obtained from *getUserInterfaceState*.
+
+**Data structures:** [`UserInterfaceStateProperties`](../types/UserInterfaceStateProperties.md)

--- a/docs/api/host/video-composition-view-overlays.md
+++ b/docs/api/host/video-composition-view-overlays.md
@@ -12,11 +12,15 @@ Show or modify current video composition view overlay over the current calling b
 
 **Available since API version 6.0**
 
+**Data structures:** [`VideoCompositionViewOverlayInfo`](../types/VideoCompositionViewOverlayInfo.md)
+
 ## `getVideoCompositionViewOverlayProperties(ResultCallback<VideoCompositionViewOverlayInfo | null>)`
 
 Get current browser widget’s currently active video composition view overlay’s properties or *null* if none is active.
 
 **Available since API version 6.0**
+
+**Data structures:** [`VideoCompositionViewOverlayInfo`](../types/VideoCompositionViewOverlayInfo.md)
 
 ## `removeVideoCompositionViewOverlay(ResultCallback<success>)`
 

--- a/docs/api/host/video-compositions.md
+++ b/docs/api/host/video-compositions.md
@@ -8,6 +8,8 @@ Get all currently existing video compositions. The result of this API call is a 
 
 **Available since API version 6.0**
 
+**Data structures:** [`VideoCompositionInfo`](../types/VideoCompositionInfo.md)
+
 ## `removeVideoCompositionsByIds(Array<videoCompositionId>, ResultCallback<success>)`
 
 Remove video compositions by their IDs. If an ID does not exist, it is ignored. If at least one video composition specified by an ID cannot be removed (*canRemove = false*), the whole call will fail.
@@ -20,6 +22,8 @@ Add a video composition. Returns the full composition info upon success, or *nul
 
 **Available since API version 6.0**
 
+**Data structures:** [`VideoCompositionInfo`](../types/VideoCompositionInfo.md)
+
 ## `setVideoCompositionProperties(VideoCompositionInfo, ResultCallback< VideoCompositionInfo | null>)`
 
 Modifies video composition properties. Returns the full composition info upon success, or *null* on failure.
@@ -27,3 +31,5 @@ Modifies video composition properties. Returns the full composition info upon su
 Currently only updating “name” is supported.
 
 **Available since API version 6.0**
+
+**Data structures:** [`VideoCompositionInfo`](../types/VideoCompositionInfo.md)

--- a/tools/docx-to-markdown/README.md
+++ b/tools/docx-to-markdown/README.md
@@ -81,4 +81,15 @@ both corrections above. It also lists calls documented but absent from the code
 `setContainerForeignPopupWindowsProperties`, `setCurrentProfileById`), one
 registered but undocumented (`getCurrentSceneCollectionProperties`), and three
 debug-only handlers that are undocumented on purpose (`crashProgram`,
-`crashProgramFastFail`, `deadlockProgram`). Those are unresolved, not fixed.
+`crashProgramFastFail`, `deadlockProgram`). Those are now **marked in the docs themselves** by
+`mark_unimplemented.py`, which derives the list rather than hard-coding it, so
+re-running it after a code change adds and removes markers on its own. It
+distinguishes three cases: deprecated-and-removed (four calls, which say so in
+their own text), a name that does not match the implementation
+(`setCurrentProfileById` -> `setCurrentProfile`), and genuinely unexplained
+(`getHostCapabilities`, `reloadAllBrowserSources` -- neither deprecated nor
+ever built).
+
+`getCurrentSceneCollectionProperties` is registered but undocumented, and is
+still unresolved: writing an entry for it needs someone who knows what it
+returns.

--- a/tools/docx-to-markdown/README.md
+++ b/tools/docx-to-markdown/README.md
@@ -47,3 +47,38 @@ else.
 Signatures are emitted as inline code — ``## `getAllScenes(...)` `` — which is
 both the modern convention and the thing that keeps
 `ResultCallback<SceneInfo[]>` from being eaten as raw HTML.
+
+## Corrections made after conversion
+
+The tree is the source of truth, so these were fixed in the Markdown, not the
+Word document. **Re-running `build_docs.py` would revert them**, and would also
+drop the type cross-links; run `link_types.py` afterwards and re-apply these by
+hand.
+
+- **`getAllScenes`** — the document listed the same signature twice, once under
+  API 1.21 and once under 6.0. The implementation takes the argument as
+  optional (`if (args->GetSize()) input = args->GetValue(0); else
+  input->SetNull();`, and `GetVideoComposition()` falls back to the native
+  composition), so the 1.21 form is `getAllScenes(ResultCallback<SceneInfo[]>)`
+  with no argument — exactly as the neighbouring `getCurrentScene` pair is
+  already written.
+- **`getShowBuiltInMenuItems`** — documented as `getShowBuil**d**InMenuItems`.
+  No such handler exists; the setter beside it was already spelled correctly.
+
+## Verifying the docs against the implementation
+
+The handlers are registered in two files, not one -- missing the second reports
+`endDialog`, `endModalDialog` and `endNonModalDialog` as undocumented:
+
+```sh
+grep -rho 'API_HANDLER_BEGIN("[^"]*"' streamelements/ | sed 's/.*("//;s/"//' | sort -u
+```
+
+Diffing that against the `##` signatures under `docs/api/host/` is what found
+both corrections above. It also lists calls documented but absent from the code
+(`dispatchKeyboardEvent`, `dispatchMouseEvent`, `getHostCapabilities`,
+`reloadAllBrowserSources`, `getContainerForeignPopupWindowsProperties`,
+`setContainerForeignPopupWindowsProperties`, `setCurrentProfileById`), one
+registered but undocumented (`getCurrentSceneCollectionProperties`), and three
+debug-only handlers that are undocumented on purpose (`crashProgram`,
+`crashProgramFastFail`, `deadlockProgram`). Those are unresolved, not fixed.

--- a/tools/docx-to-markdown/link_types.py
+++ b/tools/docx-to-markdown/link_types.py
@@ -1,0 +1,103 @@
+"""Cross-link the data structures named in each API call's signature.
+
+A signature like
+
+    ## `getAllScenes(ResultCallback<SceneInfo[]>)`
+
+names a type the reader almost always wants to look at next, and in the Word
+document that meant scrolling to find it. The signature is a code span, and a
+code span cannot contain a link, so the types are listed on their own line at
+the end of the entry instead.
+
+Idempotent: re-running replaces the generated line rather than stacking another
+one, so this can be applied again after any edit.
+
+    python tools/docx-to-markdown/link_types.py .
+"""
+
+import io
+import os
+import re
+import sys
+
+REPO = sys.argv[1] if len(sys.argv) > 1 else '.'
+API = os.path.join(REPO, 'docs', 'api')
+TYPES = os.path.join(API, 'types')
+
+MARKER = '**Data structures:** '
+
+known = sorted(
+    (os.path.splitext(f)[0] for f in os.listdir(TYPES)
+     if f.endswith('.md') and f != 'README.md'),
+    key=len, reverse=True)
+
+# Word boundaries matter: VideoCompositionInfo is a substring of
+# SharedVideoCompositionInfo, and matching the short one inside the long one
+# would link the wrong page. \b prevents that -- the character before is a word
+# character, so the match fails.
+PATTERN = re.compile(r'\b(%s)\b' % '|'.join(re.escape(t) for t in known))
+
+
+def rewrite(path, depth):
+    """depth: how many directories up types/ is from this file."""
+    text = io.open(path, encoding='utf-8', newline='').read()
+    nl = '\r\n' if '\r\n' in text else '\n'
+    lines = text.split(nl)
+
+    prefix = '../' * depth + 'types/'
+
+    out = []
+    i = 0
+    added = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        i += 1
+
+        m = re.match(r'^(#{2,3}) `(.+)`$', line)
+        if not m:
+            continue
+
+        # Collect the entry body, dropping any previously generated line so a
+        # re-run does not stack them.
+        body = []
+        while i < len(lines) and not re.match(r'^#{1,3} ', lines[i]):
+            if not lines[i].startswith(MARKER):
+                body.append(lines[i])
+            i += 1
+
+        while body and not body[-1].strip():
+            body.pop()
+
+        types = []
+        for t in PATTERN.findall(m.group(2)):
+            if t not in types:
+                types.append(t)
+
+        if types:
+            body.append('')
+            body.append(MARKER + ', '.join(
+                '[`%s`](%s%s.md)' % (t, prefix, t) for t in types))
+            added += 1
+
+        body.append('')
+        out.extend(body)
+
+    io.open(path, 'w', encoding='utf-8', newline='').write(nl.join(out))
+    return added
+
+
+total = files = 0
+for root, _, names in os.walk(API):
+    if os.path.basename(root) == 'types':
+        continue
+    depth = 0 if os.path.abspath(root) == os.path.abspath(API) else 1
+    for name in sorted(names):
+        if not name.endswith('.md') or name == 'README.md':
+            continue
+        n = rewrite(os.path.join(root, name), depth)
+        if n:
+            files += 1
+            total += n
+
+print('linked data structures on %d entries across %d files' % (total, files))

--- a/tools/docx-to-markdown/mark_unimplemented.py
+++ b/tools/docx-to-markdown/mark_unimplemented.py
@@ -1,0 +1,190 @@
+"""Mark documented API calls that the plug-in does not actually register.
+
+The reference was maintained in Word for seven years with no way to check it
+against the code, so it accumulated calls that do not exist. A reader cannot
+tell those from the working ones, and finds out by calling one.
+
+The list is DERIVED, not hard-coded, so re-running this after a code change
+adds and removes markers by itself:
+
+    python tools/docx-to-markdown/mark_unimplemented.py .
+
+Two things are deliberately not flagged, both distinguished structurally rather
+than by an allow-list:
+
+  * Properties -- hostReady, apiMajorVersion and friends are values on
+    window.host, not calls, and their headings carry no "(".
+  * batchInvokeSeries, which is registered by calling
+    RegisterIncomingApiCallHandler() directly instead of going through the
+    API_HANDLER_BEGIN macro. Scanning only for the macro reports it as missing.
+
+Handlers live in more than one file (StreamElementsBrowserDialog.cpp registers
+the dialog ones), so the whole streamelements/ tree is scanned. Missing that
+falsely flags endDialog, endModalDialog and endNonModalDialog.
+
+Idempotent: an existing marker is replaced, never stacked.
+"""
+
+import io
+import os
+import re
+import sys
+
+REPO = sys.argv[1] if len(sys.argv) > 1 else '.'
+SRC = os.path.join(REPO, 'streamelements')
+HOST = os.path.join(REPO, 'docs', 'api', 'host')
+
+MARK = '> ⚠️ **Not implemented.**'
+
+# Documented under a name the code does not use, but the behaviour described
+# does exist under the name given here. Kept as a note rather than renamed: the
+# heading is what people copy, and which of the two names is meant to win is a
+# question for whoever owns the API, not something to infer from the source.
+ALIASES = {
+    'setCurrentProfileById': 'setCurrentProfile',
+}
+
+
+def registered_names():
+    names = set()
+    pat = re.compile(
+        r'(?:API_HANDLER_BEGIN|RegisterIncomingApiCallHandler)\(\s*"([^"]+)"')
+    for root, _, files in os.walk(SRC):
+        for f in files:
+            if not f.endswith(('.cpp', '.hpp', '.mm', '.h')):
+                continue
+            text = io.open(os.path.join(root, f), encoding='utf-8',
+                           errors='replace').read()
+            names |= set(pat.findall(text))
+    return names
+
+
+REGISTERED = registered_names()
+
+
+def note_for(name, deprecated):
+    """The marker, worded for what is actually known about this call.
+
+    Four of the seven absent calls carry "Deprecated in API 3.0" in their own
+    text, so their absence is a removal that already happened rather than a
+    documentation defect, and saying "not implemented" would understate what is
+    known. The remaining ones are genuinely unexplained and should read as such.
+    """
+    if name in ALIASES:
+        return ('> ⚠️ **Name does not match the implementation.** The '
+                'registered handler is `%s`, which does what is described '
+                'here; no handler named `%s` exists.'
+                % (ALIASES[name], name))
+
+    if deprecated:
+        return ('> ⚠️ **Removed.** Deprecated as noted below, and no handler '
+                'by this name is registered anywhere in `streamelements/` any '
+                'more. Kept for the record; calling it will not resolve.')
+
+    return ('%s No handler by this name is registered anywhere in '
+            '`streamelements/`, so calling it will not resolve. Neither '
+            'deprecated nor implemented — most likely specified and never '
+            'built.' % MARK)
+
+
+def rewrite(path):
+    text = io.open(path, encoding='utf-8', newline='').read()
+    nl = '\r\n' if '\r\n' in text else '\n'
+    lines = text.split(nl)
+
+    out = []
+    marked = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        i += 1
+
+        m = re.match(r'^## `(.+)`$', line)
+        if not m:
+            continue
+
+        sig = m.group(1)
+
+        # Drop any previous marker so a re-run refreshes rather than stacks,
+        # and so a call that has since been implemented loses its warning.
+        while i < len(lines) and (lines[i].startswith('> ⚠')
+                                  or (lines[i] == '' and i + 1 < len(lines)
+                                      and lines[i + 1].startswith('> ⚠'))):
+            i += 1
+
+        if '(' not in sig:          # a property, not a call
+            continue
+
+        name = re.match(r'\s*([A-Za-z_][A-Za-z0-9_]*)', sig)
+        if not name or name.group(1) in REGISTERED:
+            continue
+
+        # Look ahead over this entry's own text, without consuming it, to see
+        # whether it already declares itself deprecated.
+        j = i
+        deprecated = False
+        while j < len(lines) and not lines[j].startswith('## '):
+            if 'deprecat' in lines[j].lower():
+                deprecated = True
+                break
+            j += 1
+
+        out.append('')
+        out.append(note_for(name.group(1), deprecated))
+        marked.append((name.group(1), deprecated))
+
+    io.open(path, 'w', encoding='utf-8', newline='').write(nl.join(out))
+    return marked
+
+
+def mark_index(names):
+    """Flag the same calls in the front-page index, so a reader browsing the
+    list of 217 sees which ones are dead before clicking into them."""
+    p = os.path.join(REPO, 'docs', 'api', 'README.md')
+    text = io.open(p, encoding='utf-8', newline='').read()
+    nl = '\r\n' if '\r\n' in text else '\n'
+
+    legend = ('Calls marked ⚠️ are documented but **not registered by the '
+              'plug-in** — deprecated and removed, or never implemented. Open '
+              'one to see which.')
+
+    out = []
+    for line in text.split(nl):
+        # Strip any existing marker BEFORE matching. Matching first would look
+        # at a line whose name is preceded by the marker, fail, and then drop
+        # the marker without putting it back -- a re-run would quietly unmark
+        # everything.
+        line = line.replace('| [`⚠️ ', '| [`')
+        m = re.match(r'^\| \[`([A-Za-z_][A-Za-z0-9_]*)', line)
+        if m and m.group(1) in names:
+            line = line.replace('| [`', '| [`⚠️ ', 1)
+        if line.strip() == legend:
+            continue
+        out.append(line)
+
+    text = nl.join(out)
+    anchor = '### All `window.host` calls, alphabetically' + nl
+    if anchor in text and legend not in text:
+        text = text.replace(anchor, anchor + nl + legend + nl, 1)
+
+    io.open(p, 'w', encoding='utf-8', newline='').write(text)
+
+
+total = []
+for f in sorted(os.listdir(HOST)):
+    if f.endswith('.md') and f != 'README.md':
+        total += rewrite(os.path.join(HOST, f))
+
+mark_index({n for n, _ in total})
+
+print('registered handlers: %d' % len(REGISTERED))
+print('marked %d call(s):' % len(total))
+for n, dep in sorted(total):
+    if n in ALIASES:
+        kind = 'name mismatch -> %s' % ALIASES[n]
+    elif dep:
+        kind = 'deprecated and removed'
+    else:
+        kind = 'UNEXPLAINED: never implemented'
+    print('   %-44s %s' % (n, kind))


### PR DESCRIPTION
Follow-up to #157. Verified the reference against the handlers the plug-in actually registers, and added the cross-links the Word document could not have had.

## Two documented calls did not match the code

**`getAllScenes` had the same signature twice** — once under API 1.21, once under 6.0. The implementation takes the argument as optional:

```cpp
API_HANDLER_BEGIN("getAllScenes");
    CefRefPtr<CefValue> input = CefValue::Create();
    if (args->GetSize())  input = args->GetValue(0);
    else                  input->SetNull();
    ...->SerializeObsScenes(input, result);
```

and `GetVideoComposition()` falls back to `GetObsNativeVideoComposition()` whenever the input is not a dictionary carrying a string `videoCompositionId`. So the 1.21 form takes **no argument**. The neighbouring `getCurrentScene` pair is already written exactly that way, which is what makes the copy-paste unmistakable.

| | before | after |
| --- | --- | --- |
| 1.21 | `getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)` | `getAllScenes(ResultCallback<SceneInfo[]>)` |
| 6.0 | `getAllScenes({ videoCompositionId }, ResultCallback<SceneInfo[]>)` | unchanged |

**`getShowBuiltInMenuItems` was documented as `getShowBuildInMenuItems`.** No such handler exists, and `setShowBuiltInMenuItems` directly above it was already spelled correctly — so anyone copying the getter out of the docs got a call that silently does not resolve.

## Data structures linked from signatures

141 entries across 48 files, reaching 61 of the 70 types. A signature is a code span and a code span cannot contain a link, so the types go on their own line at the end of each entry:

```markdown
## `getAllScenes(ResultCallback<SceneInfo[]>)`

**Available since API version 1.21**

Get all scenes in the scene collection.

**Data structures:** [`SceneInfo`](../types/SceneInfo.md)
```

`tools/docx-to-markdown/link_types.py` is idempotent — it replaces its own generated line rather than stacking another — so it can be re-run after any edit. Word boundaries are enforced, or `VideoCompositionInfo` would match inside `SharedVideoCompositionInfo` and link the wrong page.

The 9 unlinked types are reachable only from an event's `detail` or from inside another type's table, not from a call signature.

## The strict build caught my own mistake

The first anchor I hand-wrote for the corrected `getAllScenes` was wrong — there is no space before `ResultCallback` in that signature, so there is no hyphen in the slug. MkDocs failed the build instead of publishing a dead link:

```
WARNING - Doc file 'README.md' contains a link
  'host/scenes.md#getallscenes-resultcallbacksceneinfo', but the doc
  'host/scenes.md' does not contain an anchor '#getallscenes-resultcallbacksceneinfo'.
```

That is exactly why anchor validation went in with #157.

## Left unresolved, deliberately

The audit found more than it fixed. These are recorded in `tools/docx-to-markdown/README.md` as open questions rather than guessed at — each needs someone who knows the intent:

- **Documented but absent from the code (7):** `dispatchKeyboardEvent`, `dispatchMouseEvent`, `getHostCapabilities`, `reloadAllBrowserSources`, `getContainerForeignPopupWindowsProperties`, `setContainerForeignPopupWindowsProperties`, `setCurrentProfileById` (the code has `setCurrentProfile`). Either stale docs or unimplemented spec — I can't tell which from the code alone.
- **Registered but undocumented (1):** `getCurrentSceneCollectionProperties`.
- **Debug-only, undocumented on purpose (3):** `crashProgram`, `crashProgramFastFail`, `deadlockProgram`.

One methodology note for whoever picks that up: handlers are registered in **two** files. Auditing only `StreamElementsApiMessageHandler.cpp` falsely reports `endDialog`, `endModalDialog` and `endNonModalDialog` as undocumented — they live in `StreamElementsBrowserDialog.cpp`. The recorded command covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)