### PR TITLE
docs(api): date the removed API calls from git history (CORE-1003)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -94,6 +94,7 @@ Calls marked ⚠️ are documented but **not registered by the plug-in** — dep
 
 
 
+
 | Call | Group |
 | --- | --- |
 | [`addAudioComposition(AudioCompositionInfo, ResultCallback< AudioCompositionInfo \| null>)`](host/audio-compositions.md#addaudiocompositionaudiocompositioninfo-resultcallback-audiocompositioninfo-null) | [Audio Compositions](host/audio-compositions.md) |

--- a/docs/api/host/browser-sources.md
+++ b/docs/api/host/browser-sources.md
@@ -4,7 +4,7 @@
 
 ## `reloadAllBrowserSources(ResultCallback<success>)`
 
-> ⚠️ **Not implemented.** No handler by this name is registered anywhere in `streamelements/`, so calling it will not resolve. Neither deprecated nor implemented — most likely specified and never built.
+> ⚠️ **Removed.** Implemented once, but taken out in `f206595` (Eject dependency on CEF and obs-browser (#1), 2022-06-17). No handler by this name is registered any more, so calling it will not resolve.
 
 **Removed in API 3.0**
 

--- a/docs/api/host/host-information.md
+++ b/docs/api/host/host-information.md
@@ -12,7 +12,7 @@ Get host platform properties, including platform, architecture, component versio
 
 ## `getHostCapabilities(ResultCallback<HostCapabilities>)`
 
-> ⚠️ **Not implemented.** No handler by this name is registered anywhere in `streamelements/`, so calling it will not resolve. Neither deprecated nor implemented — most likely specified and never built.
+> ⚠️ **Not implemented.** No handler by this name appears anywhere in this repository, in any commit on any branch, and the history goes back to 2014. Documented but never built here.
 
 Available since API version 1.8
 

--- a/docs/api/host/popup-window.md
+++ b/docs/api/host/popup-window.md
@@ -10,7 +10,7 @@ Open pop-up window with specified info.
 
 ## `setContainerForeignPopupWindowsProperties(ForeignPopupWindowsInfo, ResultCallback<success>)`
 
-> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+> ⚠️ **Removed.** Implemented once, but taken out in `f206595` (Eject dependency on CEF and obs-browser (#1), 2022-06-17). No handler by this name is registered any more, so calling it will not resolve.
 
 Deprecated in API 3.0
 
@@ -20,7 +20,7 @@ Set properties for foreign pop-up windows (popup windows opened using standard H
 
 ## `getContainerForeignPopupWindowsProperties(ResultCallback<ForeignPopupWindowsInfo>)`
 
-> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+> ⚠️ **Removed.** Implemented once, but taken out in `f206595` (Eject dependency on CEF and obs-browser (#1), 2022-06-17). No handler by this name is registered any more, so calling it will not resolve.
 
 Deprecated in API 3.0
 

--- a/docs/api/host/profiles.md
+++ b/docs/api/host/profiles.md
@@ -20,7 +20,7 @@ Get current OBS profile.
 
 ## `setCurrentProfileById(ProfileInfo, ResultCallback<success>)`
 
-> ⚠️ **Name does not match the implementation.** The registered handler is `setCurrentProfile`, which does what is described here; no handler named `setCurrentProfileById` exists.
+> ⚠️ **Name does not match the implementation.** The registered handler is `setCurrentProfile`, which does what is described here; no handler named `setCurrentProfileById` has ever existed.
 
 **Available since API version 1.22**
 

--- a/docs/api/host/synthetic-input.md
+++ b/docs/api/host/synthetic-input.md
@@ -4,7 +4,7 @@
 
 ## `dispatchKeyboardEvent(KeyboardEventInfo, ResultCallback<success>)`
 
-> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+> ⚠️ **Removed.** Implemented once, but taken out in `f206595` (Eject dependency on CEF and obs-browser (#1), 2022-06-17). No handler by this name is registered any more, so calling it will not resolve.
 
 Dispatch synthetic keyboard event.
 
@@ -14,7 +14,7 @@ Deprecated in API 3.0
 
 ## `dispatchMouseEvent(MouseEventInfo, ResultCallback<success>)`
 
-> ⚠️ **Removed.** Deprecated as noted below, and no handler by this name is registered anywhere in `streamelements/` any more. Kept for the record; calling it will not resolve.
+> ⚠️ **Removed.** Implemented once, but taken out in `f206595` (Eject dependency on CEF and obs-browser (#1), 2022-06-17). No handler by this name is registered any more, so calling it will not resolve.
 
 Dispatch synthetic mouse event.
 

--- a/tools/docx-to-markdown/README.md
+++ b/tools/docx-to-markdown/README.md
@@ -84,7 +84,9 @@ debug-only handlers that are undocumented on purpose (`crashProgram`,
 `crashProgramFastFail`, `deadlockProgram`). Those are now **marked in the docs themselves** by
 `mark_unimplemented.py`, which derives the list rather than hard-coding it, so
 re-running it after a code change adds and removes markers on its own. It
-distinguishes three cases: deprecated-and-removed (four calls, which say so in
+asks `git log -S` over the full history (back to 2014) so it can tell a call
+that was **removed** from one that was **never built** -- the code alone cannot.
+It distinguishes three cases: deprecated-and-removed (four calls, which say so in
 their own text), a name that does not match the implementation
 (`setCurrentProfileById` -> `setCurrentProfile`), and genuinely unexplained
 (`getHostCapabilities`, `reloadAllBrowserSources` -- neither deprecated nor

--- a/tools/docx-to-markdown/mark_unimplemented.py
+++ b/tools/docx-to-markdown/mark_unimplemented.py
@@ -28,6 +28,7 @@ Idempotent: an existing marker is replaced, never stacked.
 import io
 import os
 import re
+import subprocess
 import sys
 
 REPO = sys.argv[1] if len(sys.argv) > 1 else '.'
@@ -62,29 +63,51 @@ def registered_names():
 REGISTERED = registered_names()
 
 
-def note_for(name, deprecated):
-    """The marker, worded for what is actually known about this call.
+def removal_of(name):
+    """The commit that took this handler out, or None if it never existed.
 
-    Four of the seven absent calls carry "Deprecated in API 3.0" in their own
-    text, so their absence is a removal that already happened rather than a
-    documentation defect, and saying "not implemented" would understate what is
-    known. The remaining ones are genuinely unexplained and should read as such.
+    Asking the code alone cannot tell "removed years ago" from "never built",
+    and those deserve different warnings: the first is a stale document, the
+    second is a specification that outran the implementation. git log -S over
+    the full history separates them with evidence. Five of the six removals
+    turn out to be the same commit -- the 2022 CEF/obs-browser ejection.
     """
+    try:
+        out = subprocess.check_output(
+            ['git', 'log', '-S', name, '--all', '--date=short',
+             '--format=%h\t%ad\t%s', '--', ':!docs', ':!tools'],
+            cwd=REPO, stderr=subprocess.DEVNULL).decode('utf-8', 'replace')
+    except Exception:
+        return None
+
+    lines = [l for l in out.split('\n') if l.strip()]
+    if not lines:
+        return None
+    return lines[0].split('\t')          # newest touch == the removal
+
+
+def note_for(name, deprecated):
+    """The marker, worded for what is actually known about this call."""
     if name in ALIASES:
         return ('> ⚠️ **Name does not match the implementation.** The '
                 'registered handler is `%s`, which does what is described '
-                'here; no handler named `%s` exists.'
+                'here; no handler named `%s` has ever existed.'
                 % (ALIASES[name], name))
 
-    if deprecated:
-        return ('> ⚠️ **Removed.** Deprecated as noted below, and no handler '
-                'by this name is registered anywhere in `streamelements/` any '
-                'more. Kept for the record; calling it will not resolve.')
+    gone = removal_of(name)
 
-    return ('%s No handler by this name is registered anywhere in '
-            '`streamelements/`, so calling it will not resolve. Neither '
-            'deprecated nor implemented — most likely specified and never '
-            'built.' % MARK)
+    if gone:
+        sha, date, subject = gone[0], gone[1], gone[2]
+        return ('> ⚠️ **Removed.** Implemented once, but taken out in `%s` '
+                '(%s, %s)%s. No handler by this name is registered any more, '
+                'so calling it will not resolve.'
+                % (sha, subject, date,
+                   ' — and the entry below does not say so'
+                   if not deprecated else ''))
+
+    return ('%s No handler by this name appears anywhere in this repository, '
+            'in any commit on any branch, and the history goes back to 2014. '
+            'Documented but never built here.' % MARK)
 
 
 def rewrite(path):
@@ -125,7 +148,12 @@ def rewrite(path):
         j = i
         deprecated = False
         while j < len(lines) and not lines[j].startswith('## '):
-            if 'deprecat' in lines[j].lower():
+            low = lines[j].lower()
+            # "Removed in API 3.0" as well as "Deprecated in API 3.0" -- both
+            # forms occur, and matching only the first made the marker tell
+            # reloadAllBrowserSources that its entry "says only that it was
+            # deprecated" when the entry plainly says it was removed.
+            if 'deprecat' in low or 'removed in api' in low:
                 deprecated = True
                 break
             j += 1
@@ -183,8 +211,8 @@ print('marked %d call(s):' % len(total))
 for n, dep in sorted(total):
     if n in ALIASES:
         kind = 'name mismatch -> %s' % ALIASES[n]
-    elif dep:
-        kind = 'deprecated and removed'
     else:
-        kind = 'UNEXPLAINED: never implemented'
+        gone = removal_of(n)
+        kind = ('removed in %s (%s)' % (gone[0], gone[1]) if gone
+                else 'NEVER existed in this repo')
     print('   %-44s %s' % (n, kind))

--- a/tools/docx-to-markdown/mark_unimplemented.py
+++ b/tools/docx-to-markdown/mark_unimplemented.py
@@ -178,6 +178,7 @@ def mark_index(names):
               'one to see which.')
 
     out = []
+    dropped_legend = False
     for line in text.split(nl):
         # Strip any existing marker BEFORE matching. Matching first would look
         # at a line whose name is preceded by the marker, fail, and then drop
@@ -187,8 +188,20 @@ def mark_index(names):
         m = re.match(r'^\| \[`([A-Za-z_][A-Za-z0-9_]*)', line)
         if m and m.group(1) in names:
             line = line.replace('| [`', '| [`⚠️ ', 1)
+
         if line.strip() == legend:
+            dropped_legend = True
             continue
+
+        # Swallow the blank line the legend left behind. Without this the file
+        # gains one blank line per run: the marker count stays identical, so a
+        # test that counts markers reports idempotency while the bytes keep
+        # changing.
+        if dropped_legend and not line.strip():
+            dropped_legend = False
+            continue
+        dropped_legend = False
+
         out.append(line)
 
     text = nl.join(out)


### PR DESCRIPTION
Follow-up to #158, prompted by two corrections from @ilya-se: `getHostCapabilities` exists, and `reloadAllBrowserSources` was worth searching for in code rather than assuming.

**You were right about `reloadAllBrowserSources`.** My marker said "most likely specified and never built". It was built — added 2020-02-20 in `d559162` *"obs-browser: API 1.28: reload all browser sources"* — and removed 2022-06-17 in `f206595` *"Eject dependency on CEF and obs-browser"*, whose diff literally shows `-API_HANDLER_BEGIN("reloadAllBrowserSources")`.

I had only grepped the working tree. The code alone cannot distinguish "removed years ago" from "never existed", and those deserve different warnings, so the marker now asks `git log -S` over the full history and names the commit, subject and date.

## One cause, not six

Five of the six removals are the **same commit** — the 2022 CEF/obs-browser ejection:

| Call | |
| --- | --- |
| `dispatchKeyboardEvent` | removed in `f206595`, 2022-06-17 |
| `dispatchMouseEvent` | removed in `f206595`, 2022-06-17 |
| `getContainerForeignPopupWindowsProperties` | removed in `f206595`, 2022-06-17 |
| `setContainerForeignPopupWindowsProperties` | removed in `f206595`, 2022-06-17 |
| `reloadAllBrowserSources` | removed in `f206595`, 2022-06-17 |

All five were **already declared** deprecated or removed in their own entries, so the document was never wrong about them. The marker adds the commit and date, not a correction. That also means my earlier framing — seven documented-but-missing calls as if all were defects — overstated the problem.

That leaves **two** genuine anomalies, not seven.

## `getHostCapabilities` — I could not find it

You said it exists, and I want to be straight that I could not confirm it. What I checked:

- every commit on every branch in this repo, history back to **2014-08-26** (`git log -S`, excluding my own docs commits) — nothing
- the working tree, case-insensitively, whole repo — nothing
- the sibling **obs-browser** plugin — nothing
- the rest of the **obs-studio plugins tree** — nothing
- the `window.host` props dictionary (`CreateApiPropsDictionaryInternal`), which carries only `hostReady`, `hostContainerHidden`, `apiMajorVersion`, `apiMinorVersion` — not there
- `getHostProperties`, the nearest registered call, returns version strings (`obsVersionString`, `cefVersionString`, …), not capabilities
- the `HostCapabilities` type and its one field `sceneCollections` — the type name never appears in code; `sceneCollections` appears only in backup-related commits

Documented since API 1.8 (2018-11-11). Its marker currently says it was never built **here**, scoped to this repository.

If it lives in the web-side SDK, a wrapper around `window.host`, or another repo, tell me where and I will correct the marker — the ⚠️ is wrong if the call works for callers.

## Also fixed

**The removal-note detector matched only `deprecat`**, so it told `reloadAllBrowserSources` its entry "says only that it was deprecated" when the entry plainly says **"Removed in API 3.0"**. With both forms matched, no entry gets that clause.

**The marker was not idempotent.** Re-running added one blank line to the index each time — the legend was removed but the blank line after it was not, and re-insertion added another. Harmless to render, but it falsified the property the script is meant to have, and my test could not see it: it counted markers, which held steady at 15 while the bytes changed. Now compared by file content, byte-identical over three consecutive runs.

Strict MkDocs build clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)