### PR TITLE
docs(api): document getCurrentSceneCollectionProperties from the source (CORE-1003)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -193,6 +193,7 @@ Calls marked ⚠️ are documented but **not registered by the plug-in** — dep
 | [`getCurrentProfile(ResultCallback<ProfileInfo>)`](host/profiles.md#getcurrentprofileresultcallbackprofileinfo) | [Profiles](host/profiles.md) |
 | [`getCurrentScene(ResultCallback<SceneInfo>)`](host/scenes.md#getcurrentsceneresultcallbacksceneinfo) | [Scenes](host/scenes.md) |
 | [`getCurrentScene({ videoCompositionId }, ResultCallback<SceneInfo>)`](host/scenes.md#getcurrentscene-videocompositionid-resultcallbacksceneinfo) | [Scenes](host/scenes.md) |
+| [`getCurrentSceneCollectionProperties(ResultCallback<SceneCollectionInfo>)`](host/scene-collections.md#getcurrentscenecollectionpropertiesresultcallbackscenecollectioninfo) | [Scene collections](host/scene-collections.md) |
 | [`getCurrentSceneItemPropertiesById(SceneItemInfo, ResultCallback<success>)`](host/scene-items.md#getcurrentsceneitempropertiesbyidsceneiteminfo-resultcallbacksuccess) | [Scene items](host/scene-items.md) |
 | [`getCurrentSceneItemsAuxiliaryActions(ResultCallback<ActionInfo[]>)`](host/scene-items.md#getcurrentsceneitemsauxiliaryactionsresultcallbackactioninfo) | [Scene items](host/scene-items.md) |
 | [`getEncoderProperties(EncoderInfo, ResultCallback<ObsEncoderInfo \| null>)`](host/encoders.md#getencoderpropertiesencoderinfo-resultcallbackobsencoderinfo-null) | [Encoders](host/encoders.md) |

--- a/docs/api/host/scene-collections.md
+++ b/docs/api/host/scene-collections.md
@@ -8,11 +8,34 @@
 
 Get all scene collections in the “scene collections” menu.
 
-getCurrentSceneCollectionProperties(ResultCallback\<SceneCollectionInfo>)
+**Data structures:** [`SceneCollectionInfo`](../types/SceneCollectionInfo.md)
+
+## `getCurrentSceneCollectionProperties(ResultCallback<SceneCollectionInfo>)`
 
 **Available since API version 1.22**
 
-Get current scene collection properties.
+Get current scene collection properties. Takes no arguments.
+
+Resolved by looking up the collection OBS reports as current
+(`obs_frontend_get_current_scene_collection()`, which returns the *name*)
+against the scene-collection files on disk, so the two fields come from
+different places:
+
+- `id` — the collection’s `.json` filename, without the extension, under
+  `<config>/obs-studio/basic/scenes/`.
+- `name` — the `name` field stored *inside* that file, which is what the
+  Scene Collections menu shows.
+
+Returns **null** rather than an object if no file matches — for instance if
+the current collection’s file carries no `name` field, since a file without
+one is skipped when the list is built.
+
+Either field can be fed back to `setCurrentSceneCollectionById`, which
+takes a plain string and matches it case-insensitively against the `name`
+first and the `id` second — so despite the name, it accepts both.
+
+`referencedFiles` is not populated here; it appears only in results from
+`queryUserEnvironmentBackupReferencedFiles`.
 
 **Data structures:** [`SceneCollectionInfo`](../types/SceneCollectionInfo.md)
 

--- a/tools/docx-to-markdown/README.md
+++ b/tools/docx-to-markdown/README.md
@@ -92,6 +92,13 @@ their own text), a name that does not match the implementation
 (`getHostCapabilities`, `reloadAllBrowserSources` -- neither deprecated nor
 ever built).
 
-`getCurrentSceneCollectionProperties` is registered but undocumented, and is
-still unresolved: writing an entry for it needs someone who knows what it
-returns.
+`getCurrentSceneCollectionProperties` was reported as registered but
+undocumented. It was in fact documented all along -- its heading had lost its
+Heading5 style in Word, so it was body text, absent from the document’s own
+table of contents, and invisible to any structural pass. Promoted to a real
+heading, and its behaviour written up from the source.
+
+Nothing registered is undocumented now except three debug-only handlers
+(`crashProgram`, `crashProgramFastFail`, `deadlockProgram`) and
+`setCurrentProfile`, which is the real name behind the `setCurrentProfileById`
+entry and is marked there.


### PR DESCRIPTION
Closes the last real gap from the docs-vs-implementation audit.

## It was documented all along

The audit reported it as *registered but undocumented*. That was wrong in an interesting way — the entry existed, but its heading had **lost its `Heading5` style in Word**, so it sat in the document as ordinary body text:

```
## `getAllSceneCollections(ResultCallback<SceneCollectionInfo[]>)`
...
getCurrentSceneCollectionProperties(ResultCallback\<SceneCollectionInfo>)   ← body text
```

Verified against the `.docx` itself — the paragraph carries no style, while its neighbour is `Heading5`. That put it outside the document's **own table of contents** and outside anything that navigates by structure, which is also why the conversion didn't treat it as a call: it reproduced the defect faithfully. Promoted to a real heading.

## What it returns, read from the implementation

`SerializeObsCurrentSceneCollection` asks OBS for the current collection — `obs_frontend_get_current_scene_collection()` answers with a **name** — then scans the scene-collection files on disk for the one whose stored name matches. So the two fields come from different places:

| Field | Source |
| --- | --- |
| `id` | the collection's `.json` filename, without extension, under `<config>/obs-studio/basic/scenes/` |
| `name` | the `name` field stored *inside* that file — what the Scene Collections menu shows |

- Takes **no arguments**.
- Returns **null** rather than an object when nothing matches — which happens if the current collection's file carries no `name` field, because `ReadListOfObsSceneCollections` skips a file that has none.
- `referencedFiles` is not populated here; it appears only in `queryUserEnvironmentBackupReferencedFiles` results.

## A claim I corrected before shipping

My first draft said `id` "is what `setCurrentSceneCollectionById` expects". Checking it showed that's too narrow — it takes a plain string and compares case-insensitively against the **name first and the id second**:

```cpp
if (strcasecmp(item.second.c_str(), id.c_str()) == 0)   // name
    actualId = item.second;
else if (strcasecmp(item.first.c_str(), id.c_str()) == 0)  // id
    actualId = item.second;
```

So either field of this result can be fed back to it, despite what its name suggests. That's now documented, since it's the kind of thing a caller would otherwise discover by trial.

## Audit status

Everything the plug-in registers is now documented, except:

- `crashProgram`, `crashProgramFastFail`, `deadlockProgram` — debug-only, undocumented on purpose
- `setCurrentProfile` — the real name behind the `setCurrentProfileById` entry, already marked there

Strict MkDocs build clean; the new heading's anchor matches its index link (validation would have failed otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)