### PR TITLE
fix(scenes): never hand a raw video-composition pointer to a signal callback (CORE-1114)

### DIFF
--- a/streamelements/StreamElementsObsSceneManager.cpp
+++ b/streamelements/StreamElementsObsSceneManager.cpp
@@ -551,14 +551,19 @@ SerializeObsSceneItemCompositionSettings(obs_source_t *source,
 	return d;
 }
 
-static void SerializeSourceAndSceneItem(CefRefPtr<CefValue> &result,
-					obs_scene_t* root_scene,
-					obs_source_t *source,
-					obs_sceneitem_t *sceneitem,
-					const int order = -1,
-					bool serializeDetails = true,
-					bool serializeProperties = false,
-					StreamElementsVideoCompositionBase *videoComposition = nullptr)
+static void SerializeSourceAndSceneItem(
+	CefRefPtr<CefValue> &result, obs_scene_t *root_scene,
+	obs_source_t *source, obs_sceneitem_t *sceneitem, const int order = -1,
+	bool serializeDetails = true, bool serializeProperties = false,
+	// An owning reference, never a raw pointer. A
+	// raw one used to arrive here from an OBS signal
+	// callback on the graphics thread and outlive
+	// what it pointed at (CORE-1114); holding a
+	// shared_ptr means the composition cannot be
+	// destroyed while this call is using it. Null
+	// means "look it up from the scene item".
+	std::shared_ptr<StreamElementsVideoCompositionBase> videoComposition =
+		nullptr)
 {
 	result->SetNull();
 
@@ -575,8 +580,8 @@ static void SerializeSourceAndSceneItem(CefRefPtr<CefValue> &result,
 			return;
 
 		videoComposition = videoCompositionManager
-				->GetVideoCompositionBySceneItemId(sceneItemId,
-								   &root_scene).get();
+					   ->GetVideoCompositionBySceneItemId(
+						   sceneItemId, &root_scene);
 	}
 
 	root->SetString("id", sceneItemId);
@@ -927,14 +932,40 @@ static void dispatch_sceneitem_event(void *my_data, obs_sceneitem_t *sceneitem,
 		obs_source_t *sceneitem_source =
 			obs_sceneitem_get_source(sceneitem);
 
+		// Resolve the composition through the manager rather than
+		// following a back-pointer from the signal handler data. The
+		// handler data only remembers the composition's *id*; the
+		// manager owns the object, so what comes back is either a live
+		// owning reference or null. That is what makes it safe for the
+		// composition to be destroyed while signals are still being
+		// delivered on the graphics thread (CORE-1114).
+		std::shared_ptr<StreamElementsVideoCompositionBase>
+			videoComposition;
+
+		if (my_data &&
+		    StreamElementsGlobalStateManager::IsInstanceAvailable()) {
+			const std::string compositionId =
+				((SESignalHandlerData *)my_data)
+					->GetVideoCompositionId();
+
+			auto videoCompositionManager =
+				StreamElementsGlobalStateManager::GetInstance()
+					->GetVideoCompositionManager();
+
+			if (compositionId.size() &&
+			    videoCompositionManager.get())
+				videoComposition =
+					videoCompositionManager
+						->GetVideoCompositionById(
+							compositionId);
+		}
+
 		// this can deadlock due to full_lock(obs_scene) in obs_sceneitem_get_group
-		SerializeSourceAndSceneItem(
-			item, obs_sceneitem_get_scene(sceneitem),
-			sceneitem_source, sceneitem, -1, serializeDetails,
-			false,
-			my_data ? ((SESignalHandlerData *)my_data)
-					  ->m_videoCompositionBase
-				: nullptr);
+		SerializeSourceAndSceneItem(item,
+					    obs_sceneitem_get_scene(sceneitem),
+					    sceneitem_source, sceneitem, -1,
+					    serializeDetails, false,
+					    videoComposition);
 
 		std::string json =
 			CefWriteJSON(item, JSON_WRITER_DEFAULT).ToString();
@@ -2186,8 +2217,8 @@ void StreamElementsObsSceneManager::DeserializeObsBrowserSource(
 			// Result
 			SerializeSourceAndSceneItem(
 				output, obs_sceneitem_get_scene(sceneitem),
-				source, sceneitem, true, false,
-				videoComposition.get());
+				source, sceneitem, -1, true, false,
+				videoComposition);
 
 			obs_sceneitem_release(SETRACE_DECREF(sceneitem));
 		}
@@ -2290,8 +2321,8 @@ void StreamElementsObsSceneManager::DeserializeObsGameCaptureSource(
 			// Result
 			SerializeSourceAndSceneItem(
 				output, obs_sceneitem_get_scene(sceneitem),
-				source, sceneitem, true, false,
-				videoComposition.get());
+				source, sceneitem, -1, true, false,
+				videoComposition);
 
 			obs_sceneitem_release(SETRACE_DECREF(sceneitem));
 		}
@@ -2458,8 +2489,8 @@ void StreamElementsObsSceneManager::DeserializeObsVideoCaptureSource(
 				SerializeSourceAndSceneItem(
 					output,
 					obs_sceneitem_get_scene(sceneitem),
-					source, sceneitem, true, false,
-					videoComposition.get());
+					source, sceneitem, -1, true, false,
+					videoComposition);
 
 				obs_sceneitem_release(SETRACE_DECREF(sceneitem));
 			}
@@ -2582,8 +2613,8 @@ void StreamElementsObsSceneManager::DeserializeObsNativeSource(
 			// Result
 			SerializeSourceAndSceneItem(
 				output, obs_sceneitem_get_scene(sceneitem),
-				source, sceneitem, true, false,
-				videoComposition.get());
+				source, sceneitem, -1, true, false,
+				videoComposition);
 
 			obs_sceneitem_release(SETRACE_DECREF(sceneitem));
 		}
@@ -2667,7 +2698,7 @@ void StreamElementsObsSceneManager::DeserializeObsSceneItemGroup(
 		SerializeSourceAndSceneItem(
 			output, obs_sceneitem_get_scene(args.sceneitem),
 			obs_sceneitem_get_source(args.sceneitem),
-			args.sceneitem, true, false, videoComposition.get());
+			args.sceneitem, -1, true, false, videoComposition);
 
 		obs_sceneitem_release(SETRACE_DECREF(args.sceneitem));
 	}
@@ -2745,11 +2776,10 @@ void StreamElementsObsSceneManager::SerializeObsSceneItems(
 
 			CefRefPtr<CefValue> item = CefValue::Create();
 
-			SerializeSourceAndSceneItem(
-				item, scene, source, it,
-				context.list->GetSize(), true,
-				serializeProperties,
-				context.videoComposition.get());
+			SerializeSourceAndSceneItem(item, scene, source, it,
+						    context.list->GetSize(),
+						    true, serializeProperties,
+						    context.videoComposition);
 
 			context.list->SetValue(context.list->GetSize(), item);
 		}
@@ -3295,10 +3325,9 @@ void StreamElementsObsSceneManager::SetObsSceneItemPropertiesById(
 	}
 
 	// Result
-	SerializeSourceAndSceneItem(output,
-					obs_sceneitem_get_scene(sceneitem),
-					source, sceneitem, true, false,
-					videoComposition.get());
+	SerializeSourceAndSceneItem(output, obs_sceneitem_get_scene(sceneitem),
+				    source, sceneitem, -1, true, false,
+				    videoComposition);
 }
 
 void StreamElementsObsSceneManager::GetObsSceneItemPropertiesById(
@@ -3334,8 +3363,8 @@ void StreamElementsObsSceneManager::GetObsSceneItemPropertiesById(
 
 	// Result
 	SerializeSourceAndSceneItem(output, obs_sceneitem_get_scene(sceneitem),
-				    source, sceneitem, true, true,
-				    videoComposition.get());
+				    source, sceneitem, -1, true, true,
+				    videoComposition);
 }
 
 void StreamElementsObsSceneManager::SerializeInputSourceClasses(

--- a/streamelements/StreamElementsObsSceneManager.hpp
+++ b/streamelements/StreamElementsObsSceneManager.hpp
@@ -217,12 +217,19 @@ public:
 		: m_obsSceneManager(obsSceneManager),
 		  m_videoCompositionBase(videoCompositionBase)
 	{
+		// Cached now, while the composition is provably alive. Every later
+		// reader wants the id and nothing else, so caching it means the
+		// composition pointer never has to be dereferenced again -- which
+		// is what makes it safe for the composition to die first.
+		m_videoCompositionId = videoCompositionBase
+					       ? videoCompositionBase->GetId()
+					       : std::string();
+
 		m_asyncTaskQueue = std::make_shared<StreamElementsAsyncTaskQueue>(
 			(std::string(
 				 "SESignalHandlerData for video composition ") +
-			 std::string(videoCompositionBase
-					     ? videoCompositionBase->GetId()
-					     : "unknown"))
+			 (m_videoCompositionId.size() ? m_videoCompositionId
+						      : std::string("unknown")))
 				.c_str());
 
 		AddRef();
@@ -274,7 +281,13 @@ private:
 
 		// std::unique_lock lock(m_scenes_mutex);
 
-		m_videoCompositionBase = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(
+				m_videoCompositionMutex);
+
+			m_videoCompositionBase = nullptr;
+		}
+
 		m_obsSceneManager = nullptr;
 
 		for (auto kv : m_scenes) {
@@ -320,9 +333,13 @@ public:
 		}
 		
 		if (shouldDelete) {
+			// The cached id, not m_videoCompositionBase->GetId():
+			// this runs on the teardown path, which is exactly when
+			// the composition is most likely to be gone already.
 			blog(LOG_INFO,
-			     "[obs-streamelements-core]: released SESignalHandlerData for video composition '%s'", m_videoCompositionBase->GetId().c_str());
-			
+			     "[obs-streamelements-core]: released SESignalHandlerData for video composition '%s'",
+			     m_videoCompositionId.c_str());
+
 			delete this;
 		}
 	}
@@ -496,10 +513,49 @@ public:
 	}
 
 public:
+	//
+	// The id of the video composition these signals belong to, or an empty
+	// string once it has been detached.
+	//
+	// Readers want the id, never the object. Handing back the cached string
+	// keeps the composition pointer from escaping to the OBS signal
+	// callbacks that run on the graphics thread -- which is where it used
+	// to be dereferenced after the composition had been destroyed
+	// (CORE-1114).
+	//
+	std::string GetVideoCompositionId()
+	{
+		std::lock_guard<std::mutex> lock(m_videoCompositionMutex);
+
+		return m_videoCompositionBase ? m_videoCompositionId
+					      : std::string();
+	}
+
+	//
+	// Called by the video composition as it is destroyed.
+	//
+	// Release() alone is not enough: it only reaches ~SESignalHandlerData,
+	// and therefore Clear(), when the refcount happens to drop to zero. If
+	// anything else still holds a reference, the back-pointer survives the
+	// composition and the next signal dereferences freed memory.
+	//
+	void DetachVideoComposition()
+	{
+		// Drain queued work first, so nothing is still using the
+		// composition when we let go of it.
+		Wait();
+
+		std::lock_guard<std::mutex> lock(m_videoCompositionMutex);
+
+		m_videoCompositionBase = nullptr;
+	}
+
 	// char m_header[7] = "header"; // TODO: Remvoe debug marker
 	StreamElementsObsSceneManager *m_obsSceneManager = nullptr;
 	StreamElementsVideoCompositionBase *m_videoCompositionBase = nullptr;
 	obs_scene_t* m_scene = nullptr;
+	std::string m_videoCompositionId;
+	std::mutex m_videoCompositionMutex;
 	// char m_footer[7] = "footer"; // TODO: Remvoe debug marker
 
 private:

--- a/streamelements/StreamElementsVideoComposition.cpp
+++ b/streamelements/StreamElementsVideoComposition.cpp
@@ -1469,7 +1469,11 @@ StreamElementsCustomVideoComposition::~StreamElementsCustomVideoComposition()
 		m_currentScene = nullptr;
 	}
 
-	m_signalHandlerData->Wait();
+	// Detach before releasing. Release() only reaches Clear() when the
+	// refcount happens to hit zero here; if anything else still holds a
+	// reference, the back-pointer would outlive this composition and the
+	// next OBS signal would dereference freed memory (CORE-1114).
+	m_signalHandlerData->DetachVideoComposition();
 	m_signalHandlerData->Release();
 	m_signalHandlerData = nullptr;
 }


### PR DESCRIPTION
`EXCEPTION_ACCESS_VIOLATION_READ / 0x6e` on the **libobs graphics thread**, inside an OBS signal callback. Reported by [SELIVE-2H](https://streamelements.sentry.io/issues/SELIVE-2H) on beta `26.8.30.966`.

Fixes CORE-1114.

## What was wrong

A scene-item signal fires on the graphics thread, we serialize the item, and the serializer reads the composition's id:

```
obs_graphics_thread -> signal_handler_signal
  handle_scene_item_source_update_settings   ObsSceneManager.cpp:1150
  SerializeSourceAndSceneItem                ObsSceneManager.cpp:585
  StreamElementsVideoCompositionBase::GetId  VideoComposition.hpp:246  <- read at 0x6e
```

`GetId()` is `return m_id;`, so faulting there means `this` was already gone.

The composition arrived as a **raw pointer** out of `SESignalHandlerData`. That object's own lifetime was handled carefully — refcounted, with a `Wait()` drain — but the composition it pointed at was neither owned nor tracked. The `if (videoComposition)` guard could not help: the pointer wasn't null, it was dangling.

`Clear()` does null it, but `Clear()` is only reachable from the destructor, which only runs once the refcount hits zero — so it never fired in the one window that mattered: **composition destroyed, handler data still referenced**.

## The fix

`SerializeSourceAndSceneItem` now takes a `std::shared_ptr`. The handler data remembers only the composition's **id**; the signal path resolves that through the manager, which owns the object, so what comes back is either a live owning reference or null. The composition cannot be destroyed while a call is using it.

The raw pointer that remains is **never dereferenced** — it survives only as a liveness flag, null-tested under a mutex.

Two supporting changes:

- The composition **detaches explicitly** as it is destroyed, rather than hoping the refcount lands on zero at the right moment.
- The `Release()` log no longer dereferences the pointer either — it prints an id cached at construction. That line runs on the teardown path, which is exactly when the composition is most likely already gone.

## A pre-existing bug this surfaced

Changing the parameter away from a raw pointer exposed something the compiler had been unable to see. Seven call sites passed only seven arguments:

```cpp
SerializeSourceAndSceneItem(output, scene, source, sceneitem, true, false, composition);
//                                                            ^^^^ binds to `order`
```

`true` bound to `order` (giving `1` instead of `-1`), and **the composition pointer implicitly converted to `bool` into `serializeProperties`** — so the composition was never actually passed, and `serializeProperties` was being set from whether one merely existed. A `shared_ptr` doesn't implicitly convert, so the compiler caught it. Those sites now pass the order explicitly.

## Verification

Builds clean; `ctest` 8/8. **Not reproduced locally** — the Sentry report is a single event from one user and the race needs a composition destroyed while a scene-item signal is in flight, which I have not been able to stage deliberately. The fix is argued from the ownership model rather than from a red-to-green repro, which is worth a reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
