### PR TITLE
fix(shutdown): release workers waiting on the Qt thread during teardown (CORE-1193)

### DIFF
--- a/streamelements/StreamElementsGlobalStateManager.cpp
+++ b/streamelements/StreamElementsGlobalStateManager.cpp
@@ -704,6 +704,11 @@ void StreamElementsGlobalStateManager::Shutdown()
 		return;
 	}
 
+	// Before anything below blocks. From here the Qt main thread is ours and
+	// will not return to its event loop, so a worker waiting on QtExecSync
+	// must be released rather than left to deadlock us (CORE-1131).
+	SetShuttingDown();
+
 	obs_frontend_remove_event_callback(handle_obs_frontend_event, nullptr);
 
 	PersistState(false);

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <atomic>
+#include <chrono>
 #include <vector>
 #include <regex>
 #include <unordered_map>
@@ -483,9 +484,59 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 			return promise.get_future();
 		}
 
-		std::future<void> result = __QtPostTask_Impl(task, file, line);
+		//
+		// A slot shared with the posted task, so that abandoning the
+		// wait below is safe.
+		//
+		// QtExecSync callers legitimately capture by reference -- the
+		// call is synchronous by contract -- so a task left queued after
+		// this frame unwinds would run against dangling references.
+		// Claiming the slot under its mutex leaves only two cases: the
+		// task has not started, and now never will, or it has already
+		// finished. There is no third.
+		//
+		struct Slot {
+			std::mutex mutex;
+			bool abandoned = false;
+		};
 
-		result.wait();
+		auto slot = std::make_shared<Slot>();
+
+		std::future<void> result = __QtPostTask_Impl(
+			[slot, task]() {
+				std::lock_guard<std::mutex> lock(slot->mutex);
+
+				if (!slot->abandoned)
+					task();
+			},
+			file, line);
+
+		//
+		// Wait in slices rather than in one shot.
+		//
+		// The gate above only covers a caller that arrives after
+		// shutdown has begun. One already parked here when it begins
+		// would go on waiting for a Qt thread that has left its event
+		// loop -- and that is the common case, because the deadlock
+		// exists precisely when the call was already in flight. The
+		// entry check alone moved CORE-1193 five seconds later instead
+		// of removing it: the updater's wait timed out, shutdown
+		// advanced to ~NetworkDialog, and that joined the same worker
+		// still parked right here.
+		//
+		while (result.wait_for(std::chrono::milliseconds(50)) !=
+		       std::future_status::ready) {
+			if (!IsShuttingDown())
+				continue;
+
+			std::lock_guard<std::mutex> lock(slot->mutex);
+
+			slot->abandoned = true;
+
+			std::promise<void> promise;
+			promise.set_value();
+			return promise.get_future();
+		}
 
 		return result;
 	}

--- a/streamelements/StreamElementsUtils.cpp
+++ b/streamelements/StreamElementsUtils.cpp
@@ -440,6 +440,18 @@ std::future<void> __QtPostTask_Impl(std::function<void()> task,
 	return promise->get_future();
 }
 
+static std::atomic<bool> s_shuttingDown(false);
+
+bool IsShuttingDown()
+{
+	return s_shuttingDown.load();
+}
+
+void SetShuttingDown()
+{
+	s_shuttingDown.store(true);
+}
+
 std::future<void> __QtExecSync_Impl(std::function<void()> task,
 				    std::string file, int line)
 {
@@ -456,6 +468,21 @@ std::future<void> __QtExecSync_Impl(std::function<void()> task,
 		promise.set_value();
 		return promise.get_future();
 	} else {
+		// Same contract as the crash gate above, for the same reason:
+		// once the Qt thread has left its event loop the task will never
+		// run, so waiting for it is waiting forever.
+		//
+		// This is not hypothetical. The updater's shutdown blocks the Qt
+		// thread until an in-flight update check finishes, and that check
+		// finishes by calling QtExecSync -- each waiting on the other, a
+		// deadlock caught in a live dump with both halves visible
+		// (CORE-1131).
+		if (IsShuttingDown()) {
+			std::promise<void> promise;
+			promise.set_value();
+			return promise.get_future();
+		}
+
 		std::future<void> result = __QtPostTask_Impl(task, file, line);
 
 		result.wait();

--- a/streamelements/StreamElementsUtils.hpp
+++ b/streamelements/StreamElementsUtils.hpp
@@ -564,6 +564,18 @@ void DispatchJSEventContainer(std::string target, std::string event,
 
 void DispatchJSEventGlobal(std::string event, std::string eventArgsJson);
 
+//
+// True once teardown has begun and the Qt main thread has left its event loop
+// for good.
+//
+// From that moment a cross-thread QtExecSync can never be served: the thread it
+// is waiting for is inside our own shutdown and will not process another
+// posted task. Anything still blocking on one deadlocks the shutdown it is
+// blocking (CORE-1131).
+//
+bool IsShuttingDown();
+void SetShuttingDown();
+
 /* ========================================================= */
 
 bool SecureJoinPaths(std::string base, std::string subpath,

--- a/streamelements/updater/confirmpendingupdatedialog.cpp
+++ b/streamelements/updater/confirmpendingupdatedialog.cpp
@@ -3,6 +3,9 @@
 #include "../StreamElementsUtils.hpp"
 #include <obs-frontend-api.h>
 
+#include <QEvent>
+#include <QTimer>
+
 ConfirmPendingUpdateDialog::ConfirmPendingUpdateDialog(QWidget *parent)
 	: QDialog(parent), ui(new Ui::ConfirmPendingUpdateDialog)
 {
@@ -56,6 +59,47 @@ void ConfirmPendingUpdateDialog::SetReleaseNotes(std::string release_notes)
 				  Q_ARG(QString, qReleaseNotesString));
 }
 
+bool ConfirmPendingUpdateDialog::eventFilter(QObject *watched, QEvent *event)
+{
+	if (event->type() != QEvent::Close || watched != parentWidget() ||
+	    !m_inExecDialog)
+		return QDialog::eventFilter(watched, event);
+
+	//
+	// OBS is being closed while this prompt is up, and the close must not
+	// be delivered from in here.
+	//
+	// exec() below is running a nested event loop, and this event is being
+	// dispatched by it -- so OBS's entire shutdown would run inside that
+	// loop. It cannot finish there: finishing means joining the updater's
+	// worker thread, and that thread is blocked waiting for this exec() to
+	// return. Both halves of that standoff were captured in one live dump
+	// (CORE-1193), with the whole of StreamElementsGlobalStateManager::
+	// Shutdown() sitting on the stack between QDialog::exec and
+	// os_event_wait.
+	//
+	// So answer the prompt on the user's behalf -- as "not now", which is
+	// the safe answer, and without recording a skipped version -- swallow
+	// this close, and ask for it again once the stack has unwound back to
+	// the main event loop. ExecDialog() below does the asking, because the
+	// re-post has to happen after exec() has returned -- see the comment
+	// there. By then the worker has been released and shutdown runs with
+	// nothing left to wait for.
+	//
+	m_closeRequestedDuringExec = true;
+
+	// Only the first close of a burst has a dialog left to answer. Every
+	// one of them still has to be swallowed: exec() does not unwind
+	// instantly, and a later close let through in that gap reaches OBS
+	// from inside this loop, which is the whole problem.
+	if (isVisible())
+		reject();
+
+	event->ignore();
+
+	return true;
+}
+
 int ConfirmPendingUpdateDialog::ExecDialog()
 {
 	int result = 0;
@@ -63,9 +107,44 @@ int ConfirmPendingUpdateDialog::ExecDialog()
 	m_skipVersionClicked = false;
 
 	QtExecSync([&]() {
+		// Installed only for the life of the modal loop. Outside it
+		// there is no nested loop to protect against, and a filter left
+		// on the main window would swallow a close it has no business
+		// touching.
+		QWidget *mainWindow = parentWidget();
+
+		if (mainWindow)
+			mainWindow->installEventFilter(this);
+
+		m_inExecDialog = true;
+
 		setModal(true);
 		result = exec();
 		setModal(false);
+
+		m_inExecDialog = false;
+
+		if (mainWindow)
+			mainWindow->removeEventFilter(this);
+
+		if (m_closeRequestedDuringExec) {
+			m_closeRequestedDuringExec = false;
+
+			// Posted only now, once exec() has returned.
+			//
+			// A timer started from inside the filter is serviced
+			// by exec()'s own event loop, which at that point is
+			// still unwinding -- so the close comes straight back
+			// while this call is on the stack, and with the dialog
+			// now hidden the filter waves it through into the same
+			// deadlock. Measured, not theorised. Posting here puts
+			// it on the main loop instead, which is not reached
+			// until this task has finished and the updater's
+			// worker has been released.
+			QTimer::singleShot(0, mainWindow, [mainWindow]() {
+				mainWindow->close();
+			});
+		}
 	});
 
 	return result;

--- a/streamelements/updater/confirmpendingupdatedialog.hpp
+++ b/streamelements/updater/confirmpendingupdatedialog.hpp
@@ -61,7 +61,16 @@ private slots:
 		reject();
 	}
 
+protected:
+	///
+	// Watches the OBS main window for a close request while this prompt is
+	// up. See the implementation for why it cannot simply be let through.
+	//
+	bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
 	Ui::ConfirmPendingUpdateDialog *ui;
 	bool m_skipVersionClicked = false;
+	bool m_inExecDialog = false;
+	bool m_closeRequestedDuringExec = false;
 };

--- a/streamelements/updater/updater.cpp
+++ b/streamelements/updater/updater.cpp
@@ -1019,10 +1019,29 @@ void streamelements_updater_shutdown(void)
 		streamelements_check_for_updates_signal_id,
 		streamelements_check_for_updates_signal_callback, nullptr);
 
-	os_event_wait(streamelements_check_for_updates_event);
-
-	os_event_destroy(streamelements_check_for_updates_event);
-	streamelements_check_for_updates_event = nullptr;
+	// Bounded, and deliberately so. This waits for an in-flight update check
+	// to release the slot, and that check releases it from a worker that may
+	// itself be waiting on the Qt main thread -- the thread running this
+	// function. The gate in QtExecSync now releases such a worker, so the
+	// wait below should complete promptly; the timeout is the backstop for
+	// anything else that holds the slot.
+	//
+	// A previous build hung here indefinitely on an early shutdown, with the
+	// two halves of the deadlock visible in a live dump.
+	if (os_event_timedwait(streamelements_check_for_updates_event, 5000) ==
+	    0) {
+		os_event_destroy(streamelements_check_for_updates_event);
+		streamelements_check_for_updates_event = nullptr;
+	} else {
+		// Left alive on purpose. Something still holds the slot and will
+		// signal this event when it is done; destroying it here would
+		// have that signal land on freed memory, and nulling the pointer
+		// would have it dereference null. Leaking one event handle as
+		// the process exits is much the lesser defect.
+		blog(LOG_WARNING,
+		     "obs-streamelements-core: updater: an update check was still "
+		     "in flight at shutdown; continuing without waiting for it");
+	}
 
 	s_NetworkDialog = nullptr;
 	s_ConfirmPendingUpdateDialog = nullptr;

--- a/streamelements/updater/updater.cpp
+++ b/streamelements/updater/updater.cpp
@@ -452,7 +452,12 @@ static bool prompt_for_update(const bool allowUseLastResponse,
 			      const uint64_t avail_version_number,
 			      std::string release_notes)
 {
-	if (!streamelements_updater_is_running)
+	// IsShuttingDown() as well as the flag above: the flag is cleared by
+	// streamelements_updater_shutdown(), so a check that passed a moment
+	// earlier is already stale. Neither closes the race on its own -- the
+	// sliced wait in QtExecSync does that -- but between them an update
+	// prompt does not go up on screen while OBS is closing.
+	if (!streamelements_updater_is_running || IsShuttingDown())
 		return false;
 
 	bool result = false;


### PR DESCRIPTION
Closing OBS a few seconds after launch could wedge the process forever at `[obs-streamelements-core]: shutting down` — no crash, no dialog, the user has to kill it.

Fixes CORE-1193. **Three commits, because the first diagnosis was incomplete and the dumps corrected it twice.** Read the third commit as the real fix; the first two are the path to it.

## What actually goes wrong

`streamelements_updater_shutdown()` waits, **from the Qt thread**, for an in-flight update check to finish. That check finishes by calling `QtExecSync`, which posts to the Qt thread and blocks until it runs — the thread already sitting in the wait. Neither side can move.

That is the shape. There turned out to be **three** distinct ways into it, each needing a different fix, each confirmed from a live `cdb` capture with both halves of the standoff on the stack.

### 1. The Qt thread is blocked and a *new* caller arrives

Covered by an entry gate in `__QtExecSync_Impl`, mirroring the `IsCrashReportingInProgress()` gate from CORE-862: once `SetShuttingDown()` is raised a cross-thread `QtExecSync` returns instead of waiting for a thread that will never serve it. Plus `os_event_timedwait(..., 5000)` on the updater's own wait as a backstop, with the event deliberately left alive on timeout — destroying it would have the worker's later signal land on freed memory.

### 2. A caller was *already parked* when shutdown began

The entry gate is checked once, so it does nothing for a caller already in `result.wait()`. And that is the common case — the deadlock exists precisely when the call was already in flight. Fix (1) alone just moved the hang five seconds later:

```
main    Shutdown -> streamelements_updater_shutdown
        os_event_timedwait(5000) times out, shutdown advances
        s_NetworkDialog = nullptr -> ~NetworkDialog
        ~StreamElementsAsyncTaskQueue -> Shutdown -> os_event_wait
worker  ... -> ConfirmPendingUpdateDialog::ExecDialog
        -> __QtExecSync_Impl -> future::wait, still parked
```

`QtExecSync` now waits in 50 ms slices and re-checks. No added latency — `wait_for` still returns the instant the task completes.

**Abandoning that wait has to be made safe.** `QtExecSync` callers legitimately capture by reference, so a task left queued after the frame unwinds would run against dangling references — and a nested event loop really can still run it. The task and the waiter share a mutex-guarded slot; claiming it leaves only two cases: the task has not started and now never will, or it has already finished.

### 3. The posted task *was* running — and it was running `QDialog::exec()`

The one no flag can fix. The update prompt goes up through `QtExecSync`, and its nested event loop then dispatched the main window's close event, so **OBS's entire shutdown ran inside the modal loop of our own dialog**:

```
__QtPostTask_Impl executor
 -> __QtExecSync_Impl slot lambda
 -> ConfirmPendingUpdateDialog::ExecDialog
 -> QDialog::exec()                          <- modal loop
 -> ... processEvents -> QWidget::closeEvent
 -> OBSBasic::closeWindow -> handle_obs_frontend_event
 -> StreamElementsGlobalStateManager::Shutdown
 -> streamelements_updater_shutdown -> ~NetworkDialog
 -> AsyncTaskQueue::Shutdown -> os_event_wait   <- blocked
```

It cannot finish there: finishing means joining the worker that is blocked waiting for that `exec()` to return. The dialog went up *before* shutdown started, so `IsShuttingDown()` is never false at the wrong moment — it is simply too late.

`ConfirmPendingUpdateDialog` now filters the main window for `QEvent::Close` while the prompt is up: answer the prompt as **"not now"**, swallow that close, and re-post it once the stack has unwound to the main event loop. By then `exec()` has returned and the worker has finished, so shutdown runs with nothing left to wait for.

## Measured

Race harness: launch, post `WM_CLOSE` as soon as a main window exists. **Every hang classified from its stack** — no unexplained residue in any run.

| configuration | runs | clean | obs-browser crash | (2) queued | (3) modal exec |
| --- | --- | --- | --- | --- | --- |
| baseline — entry gate only | 16 | 9 | 3 | 1 | 3 |
| + obs-browser patch, + fix (2) | 16 | 11 | 0 | 0 | 5 |
| + fix (3), first attempt | 16 | 15 | 0 | 0 | 1 |
| **+ fix (3) complete** | **24** | **24** | **0** | **0** | **0** |

`reference count balance = 0` in every run, and the median run is **8.6 s against 15 s** before, because nothing reaches the 5 s timeout any more.

Two details in fix (3) are load-bearing, and both were found by measurement rather than by reading — the two intermediate rows are those mistakes:

* The re-post happens **after `exec()` returns**, not from inside the filter. A zero timer started in the filter is serviced by `exec()`'s own loop while it is still unwinding, so the close arrives back with the call still on the stack — same deadlock, different route.
* The guard is **"the modal loop is running"**, not "the dialog is visible". `reject()` hides the dialog immediately but `exec()` does not unwind immediately, and one `processEvents` drains every window-system event queued at that moment. A second close arriving in that gap found `isVisible()` already false and went straight through.

`ctest` 8/8.

> **The obs-browser column is [CORE-1028](https://linear.app/streamelements/issue/CORE-1028), an upstream defect in code we do not ship.** Its patch was deployed locally only, to isolate the columns. On a stock OBS that cause remains, at roughly 3 hangs in 16 — this PR does not and cannot address it.

## Reviewer's eye

* Fix (1) changes a contract: during shutdown a cross-thread `QtExecSync` task **does not run**. That matches what the crash gate already does, and running UI work during teardown is pointless — but it is a behaviour change, not just a timeout.
* Fix (3) answers a prompt on the user's behalf. It picks the safe answer (no update, no version skipped), and it only fires when the main window is being closed with the prompt up — but it is a decision made for the user, and worth agreeing with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
