### PR TITLE
fix(browser): close browsers before the widget tree is torn down (CORE-1060)

### DIFF
--- a/streamelements/StreamElementsBrowserWidgetManager.cpp
+++ b/streamelements/StreamElementsBrowserWidgetManager.cpp
@@ -24,15 +24,33 @@ StreamElementsBrowserWidgetManager::~StreamElementsBrowserWidgetManager()
 	// This runs before the base destructor deletes any dock, so on the OBS
 	// teardown path every entry here may already have been destroyed by Qt
 	// along with its dock. QPointer makes that visible (CORE-786).
+	//
+	// Closing each browser here, rather than leaving it to
+	// ~StreamElementsBrowserWidget, is deliberate and is the whole point of
+	// this loop (CORE-1060).
+	//
+	// QCefWidgetInternal::closeBrowser() runs a nested Qt event loop for up
+	// to a second: with CEF configured for an external message pump it is
+	// only driven by a Qt timer, so waiting for the browser to close means
+	// keeping Qt's loop turning. That loop delivers every other queued event
+	// too. Reached from the widget's destructor -- which is where the base
+	// class ends up, several frames inside ~QWidget and deleteChildren -- it
+	// hands control to unrelated code while our widget tree is half
+	// destroyed. A third-party plugin enumerating docks at that moment
+	// dereferenced a child that was already gone.
+	//
+	// Called here the same loop runs against an intact widget tree, which is
+	// what makes it safe. DestroyBrowser() is idempotent, so the destructor's
+	// own call becomes a no-op.
 	for (auto kv : m_browserWidgets) {
 		if (!kv.second)
 			continue;
 
-		kv.second->RemoveVideoCompositionView();
+		kv.second->DestroyBrowser();
 	}
 
 	if (m_notificationBarBrowserWidget) {
-		m_notificationBarBrowserWidget->RemoveVideoCompositionView();
+		m_notificationBarBrowserWidget->DestroyBrowser();
 	}
 }
 


### PR DESCRIPTION
Moves the browser close out of the widget destructor, so obs-browser's nested event loop no longer runs while our widget tree is half destroyed.

Fixes CORE-1060.

## Why the loop is dangerous *there*, not in itself

`QCefWidgetInternal::closeBrowser()` runs a nested Qt event loop for up to a second, and it has to: obs-browser configures CEF with `external_message_pump = true`, so CEF only advances when `CefDoMessageLoopWork()` runs off a Qt timer. Waiting for a browser to close means keeping Qt's loop turning — and that loop delivers **every** other queued event.

Reached from `~StreamElementsBrowserWidget`, that happens several frames inside `~QWidget` → `deleteChildren`. Unrelated code gets control while our tree is mid-destruction. The Elgato Stream Deck plugin's `JS_QUERY_DOCKS` enumerated docks at exactly that moment and dereferenced a child that was already gone — `EXCEPTION_ACCESS_VIOLATION_READ` at `0x8` in `qt_qFindChildren_helper`, seen as SELIVE-1B and SELIVE-2G: 6 events, 4 users, steady across three betas.

Called from `~StreamElementsBrowserWidgetManager`, the same loop runs against an **intact** widget tree. That is the whole fix. `DestroyBrowser()` is idempotent (it latches `m_isDestroyed`), so the destructor's later call is a no-op.

## What this deliberately does not do

**It does not touch obs-browser, and it does not remove the loop.** I tried removing it: an experimental build that closed the browser asynchronously turned an intermittent shutdown hang into one that reproduced **4 runs out of 4**. The wait is load-bearing, exactly as its author said, even though the stated rationale is loose about why. That experiment is not part of this PR.

The separate obs-browser defect — a dangling `widget` back-pointer when the widget dies before its browser is created — remains open as CORE-1028. A minimal patch for it exists but is not shipped here, since we do not ship `obs-browser.dll`.

## Verification

`ctest` 8/8. **Not reproduced locally** — the crash needs the Stream Deck plugin with a dock query in flight at shutdown, and that did not load on the dev machine when the race harness ran. The fix is argued from ownership of the re-entrancy rather than red-to-green, which deserves a reviewer's eye.

Race-tested alongside CORE-1193 for regressions: 6 clean exits out of 8, no crashes, and the plugin reaches `reference count balance = 0` in every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
